### PR TITLE
docs: surface DISABLE_REGISTRATION self-hosting flag (#11)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,17 @@
 # instance never emits mail from a domain that isn't yours.
 SELF_HOSTED=true
 
+# Close public self-service registration — for instances where all accounts are
+# provisioned by your team (admin "Add user" / invites). When true, the public
+# signup route is blocked (OAuth auto-signup with it) AND the login page hides
+# its "Create account" button so the UI matches the backend. First-user setup on
+# an empty DB is still allowed so a fresh install can be initialized.
+# DISABLE_REGISTRATION=true
+
+# Redirect "/" to the app (/app) instead of serving the marketing landing page.
+# For internal-only deployments that don't want the public homepage shown.
+# DISABLE_HOMEPAGE=true
+
 # Where new-signup admin notifications are sent. Leave UNSET to disable admin
 # notifications entirely — the user's welcome email is unaffected. Self-hosters
 # who want to be notified of signups set this to their own address.

--- a/README.md
+++ b/README.md
@@ -243,6 +243,13 @@ Restart=always
 Environment=PORT=3001
 Environment=NODE_ENV=production
 Environment=SELF_HOSTED=true
+# Lock down an internal / provisioned-only instance (all accounts created by your
+# team). DISABLE_REGISTRATION closes self-service signup — first-user setup on an
+# empty DB is still allowed, and the login page hides its "Create account" button
+# to match. DISABLE_HOMEPAGE sends `/` straight to the app instead of the
+# marketing landing page.
+# Environment=DISABLE_REGISTRATION=true
+# Environment=DISABLE_HOMEPAGE=true
 # Environment=APP_URL=https://signage.yourcompany.com
 # Environment=STRIPE_SECRET_KEY=sk_live_...
 # Environment=STRIPE_WEBHOOK_SECRET=whsec_...


### PR DESCRIPTION
Surfaces the existing `DISABLE_REGISTRATION` self-hosting flag so it stops being easy to miss (a self-hoster nearly filed a request to build a feature that already exists).

**What already existed (no change):**
- Backend gate — `routes/auth.js` `canRegister()` blocks the public signup route (and OAuth auto-signup) when `DISABLE_REGISTRATION=true`; first-user setup on an empty DB is still allowed.
- UI already matches — `/api/auth/config` returns `registration_enabled:false` under the flag, and `login.js` hides the "Create account" button + trial notice. Verified end-to-end (`registration_enabled` flips to `false`).
- README env-var table already listed the flag.

**The gap (fixed here, docs only):**
- `.env.example` (the file self-hosters copy) didn't mention `DISABLE_REGISTRATION` or `DISABLE_HOMEPAGE` — added both under the Self-hosting section.
- README systemd unit example didn't show them — added commented `Environment=` lines with a note that the login UI hides the signup button to match.

No code change. Closes #11.
