### PR TITLE
fix(android): Android 14+ MediaProjection / foreground-service crash (#5)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -67,11 +67,21 @@
             android:screenOrientation="landscape"
             android:theme="@style/Theme.RemoteDisplay.Fullscreen" />
 
-        <!-- WebSocket foreground service -->
+        <!-- WebSocket foreground service. #5: declares ONLY mediaPlayback - the
+             always-on service must not claim the mediaProjection FGS type, which
+             Android 14+ rejects unless a projection consent token is held. -->
         <service
             android:name=".service.WebSocketService"
             android:exported="false"
-            android:foregroundServiceType="mediaPlayback|mediaProjection" />
+            android:foregroundServiceType="mediaPlayback" />
+
+        <!-- #5: dedicated MediaProjection foreground service for system screen
+             capture. Started only after the user grants consent, so claiming the
+             mediaProjection FGS type is valid on Android 14+. -->
+        <service
+            android:name=".service.MediaProjectionService"
+            android:exported="false"
+            android:foregroundServiceType="mediaProjection" />
 
         <!-- Accessibility service for power controls -->
         <service

--- a/android/app/src/main/java/com/remotedisplay/player/ScreenCapturePermissionActivity.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/ScreenCapturePermissionActivity.kt
@@ -6,7 +6,7 @@ import android.content.Intent
 import android.media.projection.MediaProjectionManager
 import android.os.Bundle
 import android.util.Log
-import com.remotedisplay.player.service.ScreenCaptureService
+import com.remotedisplay.player.service.MediaProjectionService
 
 /**
  * Transparent activity that requests MediaProjection permission.
@@ -50,8 +50,11 @@ class ScreenCapturePermissionActivity : Activity() {
                 Companion.resultData = data?.clone() as? Intent
                 Companion.hasPermission = true
 
-                // Tell the service to start the projection
-                ScreenCaptureService.startProjection(this, resultCode, data)
+                // #5: hand the consent to the dedicated mediaProjection foreground
+                // service. It must enter the foreground with the mediaProjection FGS
+                // type BEFORE getMediaProjection() on Android 14+ - an Activity can't
+                // do that, so we can't call getMediaProjection() directly here.
+                MediaProjectionService.start(this, resultCode, data)
 
                 getSharedPreferences("remote_display", MODE_PRIVATE)
                     .edit().putBoolean("screen_capture_granted", true).apply()

--- a/android/app/src/main/java/com/remotedisplay/player/service/MediaProjectionService.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/service/MediaProjectionService.kt
@@ -1,0 +1,101 @@
+package com.remotedisplay.player.service
+
+import android.app.Activity
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.remotedisplay.player.RemoteDisplayApp
+
+/**
+ * #5: Foreground service that owns the MediaProjection FGS type for system-wide
+ * screen capture (the `enable_system_capture` command).
+ *
+ * Android 14+ requires an FGS of type `mediaProjection` to be running - started
+ * AFTER the user grants consent - before MediaProjectionManager.getMediaProjection()
+ * may be called. An Activity can't enter that foreground state, so the consent
+ * Activity hands the result here. Kept separate from WebSocketService so the
+ * always-on service never claims the mediaProjection type at boot.
+ */
+class MediaProjectionService : Service() {
+
+    companion object {
+        private const val TAG = "MediaProjectionSvc"
+        private const val NOTIF_ID = 2
+        private const val EXTRA_RESULT_CODE = "result_code"
+        private const val EXTRA_RESULT_DATA = "result_data"
+
+        /** Start the projection FGS with the user's consent result. */
+        fun start(context: Context, resultCode: Int, data: Intent) {
+            val intent = Intent(context, MediaProjectionService::class.java).apply {
+                putExtra(EXTRA_RESULT_CODE, resultCode)
+                putExtra(EXTRA_RESULT_DATA, data)
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, MediaProjectionService::class.java))
+        }
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Enter the foreground with the mediaProjection type FIRST (required on
+        // Android 14+ before getMediaProjection()).
+        startForegroundCompat()
+
+        val resultCode = intent?.getIntExtra(EXTRA_RESULT_CODE, Activity.RESULT_CANCELED)
+            ?: Activity.RESULT_CANCELED
+        @Suppress("DEPRECATION")
+        val data: Intent? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent?.getParcelableExtra(EXTRA_RESULT_DATA, Intent::class.java)
+        } else {
+            intent?.getParcelableExtra(EXTRA_RESULT_DATA)
+        }
+
+        if (resultCode != Activity.RESULT_OK || data == null) {
+            Log.e(TAG, "Missing/invalid projection consent; stopping service")
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
+        return try {
+            ScreenCaptureService.startProjection(this, resultCode, data)
+            START_STICKY
+        } catch (e: Throwable) {
+            Log.e(TAG, "startProjection failed: ${e.message}", e)
+            stopSelf()
+            START_NOT_STICKY
+        }
+    }
+
+    private fun startForegroundCompat() {
+        val notif = NotificationCompat.Builder(this, RemoteDisplayApp.CHANNEL_ID)
+            .setContentTitle("ScreenTinker")
+            .setContentText("Screen capture active")
+            .setSmallIcon(android.R.drawable.ic_menu_camera)
+            .setOngoing(true)
+            .build()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(NOTIF_ID, notif, ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION)
+        } else {
+            startForeground(NOTIF_ID, notif)
+        }
+    }
+
+    override fun onDestroy() {
+        // Release the projection when the service goes away.
+        try { ScreenCaptureService.stop() } catch (_: Throwable) {}
+        super.onDestroy()
+    }
+}

--- a/android/app/src/main/java/com/remotedisplay/player/service/ScreenCaptureService.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/service/ScreenCaptureService.kt
@@ -54,19 +54,22 @@ object ScreenCaptureService {
 
         imageReader = ImageReader.newInstance(captureWidth, captureHeight, PixelFormat.RGBA_8888, 4)
 
-        virtualDisplay = projection.createVirtualDisplay(
-            "ScreenTinker",
-            captureWidth, captureHeight, density,
-            DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR,
-            imageReader!!.surface, null, null
-        )
-
+        // #5: Android 14+ requires a Callback registered BEFORE createVirtualDisplay,
+        // otherwise createVirtualDisplay throws IllegalStateException. (Was registered
+        // after, which broke system capture on Android 14+.)
         projection.registerCallback(object : MediaProjection.Callback() {
             override fun onStop() {
                 Log.i(TAG, "MediaProjection stopped by system")
                 cleanup()
             }
         }, null)
+
+        virtualDisplay = projection.createVirtualDisplay(
+            "ScreenTinker",
+            captureWidth, captureHeight, density,
+            DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR,
+            imageReader!!.surface, null, null
+        )
 
         Log.i(TAG, "MediaProjection started: ${captureWidth}x${captureHeight}")
     }

--- a/android/app/src/main/java/com/remotedisplay/player/service/WebSocketService.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/service/WebSocketService.kt
@@ -53,7 +53,16 @@ class WebSocketService : Service() {
         super.onCreate()
         config = ServerConfig(this)
         deviceInfo = DeviceInfo(this)
-        startForeground(1, createNotification())
+        // #5: claim ONLY the mediaPlayback FGS type. The 2-arg startForeground
+        // claims every manifest-declared type, and on Android 14+ claiming
+        // mediaProjection without a consent token throws and kills the service at
+        // boot (the "app won't run on newer Android" symptom). Screen capture has
+        // its own mediaProjection-typed service (MediaProjectionService).
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+            startForeground(1, createNotification(), android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
+        } else {
+            startForeground(1, createNotification())
+        }
 
         // Keep CPU alive so the WebSocket connection stays alive in background
         val pm = getSystemService(POWER_SERVICE) as android.os.PowerManager


### PR DESCRIPTION
Addresses #5 — app fails to run on newer Android (Pixel 10, onn HD stick).

> **Not closing the issue automatically** — this compiles and builds a signed APK, but I can't run it on the affected devices. It needs on-device verification before we call it fixed (see "Testing" below). @ChrisChrome — would love a logcat from before/after if you can.

## Root cause
The always-on `WebSocketService` calls the **2-arg `startForeground()`**, which claims **every** foreground-service type declared in the manifest — and the manifest declared `mediaPlayback|mediaProjection`. On **Android 14+ (targetSdk 34)** you cannot start an FGS of type `mediaProjection` **without a MediaProjection consent token**, so the core service threw on launch → the player never came up → "app unusable on newer Android." It's the screen-recording policy, as suspected — but via the **foreground-service type**, not the capture trigger itself.

## Fix
- **`WebSocketService`** claims **only `mediaPlayback`** now (explicit `startForeground(..., FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)`, API≥29-guarded; 2-arg on older). Manifest type narrowed to `mediaPlayback`.
- **New `MediaProjectionService`** (manifest type `mediaProjection`), started **only after** the user grants consent. It enters the foreground with the `mediaProjection` type **before** `getMediaProjection()` (required on 14+), then drives `ScreenCaptureService`. The consent Activity now hands the result to this service instead of calling `getMediaProjection()` directly.
- **`ScreenCaptureService`**: register the `MediaProjection.Callback` **before** `createVirtualDisplay()` (Android 14 throws `IllegalStateException` otherwise) — this also broke `enable_system_capture` on 14+.

## Verified
- ✅ Kotlin compiles (`:app:compileDebugKotlin`)
- ✅ Manifest merges: `WebSocketService=mediaPlayback`, `MediaProjectionService=mediaProjection`
- ✅ Signed debug APK builds (`:app:assembleDebug`)
- ❌ **On-device run** — not done (no Pixel 10 / onn stick here)

## Testing (to confirm before merge/close)
1. Sideload the debug APK on a Pixel 10 and an onn HD stick; confirm the app launches and the player connects (the prior failure was at boot).
2. From the dashboard, send `enable_system_capture`; grant the consent dialog; confirm a system screenshot comes through and no `IllegalStateException`/`SecurityException` in logcat.
3. Reboot the device; confirm the player auto-starts cleanly (WebSocketService no longer trips the mediaProjection FGS check).
