### PR TITLE
fix(android): pairing code not visible on some screens (auto-size)

### DIFF
--- a/android/app/src/main/java/com/remotedisplay/player/ProvisioningActivity.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/ProvisioningActivity.kt
@@ -34,6 +34,7 @@ class ProvisioningActivity : AppCompatActivity() {
     private lateinit var statusText: TextView
     private lateinit var progressBar: ProgressBar
     private lateinit var pairingSection: View
+    private lateinit var serverSection: View
 
     private val connection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
@@ -73,6 +74,7 @@ class ProvisioningActivity : AppCompatActivity() {
         statusText = findViewById(R.id.statusText)
         progressBar = findViewById(R.id.progressBar)
         pairingSection = findViewById(R.id.pairingSection)
+        serverSection = findViewById(R.id.serverSection)
 
         // Pre-fill if previously entered
         if (config.serverUrl.isNotEmpty()) {
@@ -135,6 +137,10 @@ class ProvisioningActivity : AppCompatActivity() {
         wsService?.onRegistered = { deviceId ->
             runOnUiThread {
                 progressBar.visibility = View.GONE
+                // Hide the server/connect controls so the pairing code has the
+                // whole screen and stays visible on short/landscape phones.
+                serverSection.visibility = View.GONE
+                connectBtn.visibility = View.GONE
                 pairingSection.visibility = View.VISIBLE
                 pairingCodeText.text = wsService?.getPairingCode() ?: "------"
                 statusText.text = "Enter this code in the dashboard to pair this display"

--- a/android/app/src/main/res/layout/activity_provisioning.xml
+++ b/android/app/src/main/res/layout/activity_provisioning.xml
@@ -1,123 +1,141 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<!-- Scrolls so content is always reachable on short screens; the pairing code
+     auto-sizes to fit any screen width (phones, TVs, HD sticks). -->
+<ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="center"
-    android:orientation="vertical"
-    android:background="#111827"
-    android:padding="48dp"
-    android:keepScreenOn="true">
+    android:fillViewport="true"
+    android:background="#111827">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="RemoteDisplay"
-        android:textColor="#3B82F6"
-        android:textSize="36sp"
-        android:textStyle="bold"
-        android:layout_marginBottom="8dp" />
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Digital Signage Player"
-        android:textColor="#94A3B8"
-        android:textSize="16sp"
-        android:layout_marginBottom="48dp" />
-
-    <!-- Server URL Section -->
     <LinearLayout
-        android:layout_width="400dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:gravity="center"
         android:orientation="vertical"
-        android:layout_marginBottom="24dp">
+        android:padding="32dp"
+        android:keepScreenOn="true">
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Server URL"
-            android:textColor="#94A3B8"
-            android:textSize="14sp"
+            android:text="RemoteDisplay"
+            android:textColor="#3B82F6"
+            android:textSize="36sp"
+            android:textStyle="bold"
             android:layout_marginBottom="8dp" />
 
-        <EditText
-            android:id="@+id/serverUrlInput"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:background="@drawable/input_background"
-            android:hint="http://192.168.1.100:3000"
-            android:textColorHint="#64748B"
-            android:textColor="#F1F5F9"
-            android:textSize="16sp"
-            android:padding="12dp"
-            android:inputType="textUri"
-            android:singleLine="true"
-            android:importantForAutofill="no" />
-    </LinearLayout>
-
-    <Button
-        android:id="@+id/connectBtn"
-        android:layout_width="400dp"
-        android:layout_height="48dp"
-        android:text="Connect"
-        android:textColor="#FFFFFF"
-        android:textSize="16sp"
-        android:textStyle="bold"
-        android:background="@drawable/button_primary"
-        android:layout_marginBottom="32dp" />
-
-    <ProgressBar
-        android:id="@+id/progressBar"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:indeterminate="true"
-        android:visibility="gone" />
-
-    <!-- Pairing Section (shown after connection) -->
-    <LinearLayout
-        android:id="@+id/pairingSection"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:gravity="center"
-        android:visibility="gone">
-
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Pairing Code"
+            android:text="Digital Signage Player"
             android:textColor="#94A3B8"
             android:textSize="16sp"
-            android:layout_marginBottom="12dp" />
+            android:layout_marginBottom="32dp" />
 
-        <TextView
-            android:id="@+id/pairingCodeText"
-            android:layout_width="wrap_content"
+        <!-- Server URL Section (hidden once paired so the code has room) -->
+        <LinearLayout
+            android:id="@+id/serverSection"
+            android:layout_width="400dp"
             android:layout_height="wrap_content"
-            android:text="------"
-            android:textColor="#3B82F6"
-            android:textSize="64sp"
+            android:orientation="vertical"
+            android:layout_marginBottom="24dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Server URL"
+                android:textColor="#94A3B8"
+                android:textSize="14sp"
+                android:layout_marginBottom="8dp" />
+
+            <EditText
+                android:id="@+id/serverUrlInput"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:background="@drawable/input_background"
+                android:hint="http://192.168.1.100:3000"
+                android:textColorHint="#64748B"
+                android:textColor="#F1F5F9"
+                android:textSize="16sp"
+                android:padding="12dp"
+                android:inputType="textUri"
+                android:singleLine="true"
+                android:importantForAutofill="no" />
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/connectBtn"
+            android:layout_width="400dp"
+            android:layout_height="48dp"
+            android:text="Connect"
+            android:textColor="#FFFFFF"
+            android:textSize="16sp"
             android:textStyle="bold"
-            android:fontFamily="monospace"
-            android:letterSpacing="0.3" />
+            android:background="@drawable/button_primary"
+            android:layout_marginBottom="32dp" />
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:indeterminate="true"
+            android:visibility="gone" />
+
+        <!-- Pairing Section (shown after connection) -->
+        <LinearLayout
+            android:id="@+id/pairingSection"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:visibility="gone">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Pairing Code"
+                android:textColor="#94A3B8"
+                android:textSize="16sp"
+                android:layout_marginBottom="12dp" />
+
+            <!-- Auto-sizes between 24sp and 96sp to fill the available width on a
+                 single line, so it's readable and never clipped on any screen. -->
+            <TextView
+                android:id="@+id/pairingCodeText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="------"
+                android:textColor="#3B82F6"
+                android:textStyle="bold"
+                android:fontFamily="monospace"
+                android:letterSpacing="0.3"
+                android:maxLines="1"
+                android:gravity="center"
+                app:autoSizeTextType="uniform"
+                app:autoSizeMinTextSize="24sp"
+                app:autoSizeMaxTextSize="96sp"
+                app:autoSizeStepGranularity="2sp" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Enter this code in the dashboard to pair this display"
+                android:textColor="#64748B"
+                android:textSize="14sp"
+                android:layout_marginTop="16dp"
+                android:gravity="center" />
+        </LinearLayout>
 
         <TextView
+            android:id="@+id/statusText"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Enter this code in the dashboard to pair this display"
-            android:textColor="#64748B"
+            android:textColor="#94A3B8"
             android:textSize="14sp"
-            android:layout_marginTop="16dp"
-            android:gravity="center" />
+            android:gravity="center"
+            android:layout_marginTop="16dp" />
+
     </LinearLayout>
-
-    <TextView
-        android:id="@+id/statusText"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textColor="#94A3B8"
-        android:textSize="14sp"
-        android:layout_marginTop="16dp" />
-
-</LinearLayout>
+</ScrollView>


### PR DESCRIPTION
Reported by @ChrisChrome while testing the patched APK on a Pixel 10: the **pairing code wasn't visible**.

**Cause:** the provisioning screen is a non-scrolling vertical `LinearLayout`. When the pairing section appears (below the server-URL field + Connect button), the fixed **64sp** code is pushed off-screen on a short/landscape phone, and can clip horizontally on narrow widths.

**Fix:**
- Wrap the screen in a `ScrollView` (`fillViewport`) — content is always reachable.
- `pairingCodeText` **auto-sizes** (`autoSizeTextType=uniform`, 24–96sp, single line, `match_parent` width) so it fills the available width and never clips — works on phones, TVs, and HD sticks.
- Hide the server-URL section + Connect button once paired, so the code gets the whole screen.

✅ Compiles + signed APK builds. ❌ Needs an on-device check (Pixel 10 / onn stick) that the code is now visible — combined test APK below.