### PR TITLE
fix(android): OTA APK signature verification (Critical) + pairing-code visibility

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
 
     <application
         android:name=".RemoteDisplayApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@android:drawable/ic_media_play"
         android:label="RemoteDisplay"
         android:largeHeap="true"

--- a/android/app/src/main/java/com/remotedisplay/player/ProvisioningActivity.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/ProvisioningActivity.kt
@@ -143,7 +143,9 @@ class ProvisioningActivity : AppCompatActivity() {
                 connectBtn.visibility = View.GONE
                 pairingSection.visibility = View.VISIBLE
                 pairingCodeText.text = wsService?.getPairingCode() ?: "------"
-                statusText.text = "Enter this code in the dashboard to pair this display"
+                // The instruction is shown once, inside the pairing section; don't
+                // duplicate it in statusText.
+                statusText.text = ""
                 connectBtn.isEnabled = false
             }
         }

--- a/android/app/src/main/java/com/remotedisplay/player/ProvisioningActivity.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/ProvisioningActivity.kt
@@ -34,6 +34,7 @@ class ProvisioningActivity : AppCompatActivity() {
     private lateinit var statusText: TextView
     private lateinit var progressBar: ProgressBar
     private lateinit var pairingSection: View
+    private lateinit var serverSection: View
 
     private val connection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
@@ -73,6 +74,7 @@ class ProvisioningActivity : AppCompatActivity() {
         statusText = findViewById(R.id.statusText)
         progressBar = findViewById(R.id.progressBar)
         pairingSection = findViewById(R.id.pairingSection)
+        serverSection = findViewById(R.id.serverSection)
 
         // Pre-fill if previously entered
         if (config.serverUrl.isNotEmpty()) {
@@ -135,6 +137,10 @@ class ProvisioningActivity : AppCompatActivity() {
         wsService?.onRegistered = { deviceId ->
             runOnUiThread {
                 progressBar.visibility = View.GONE
+                // Hide the server/connect controls so the pairing code has the
+                // whole screen and stays visible on short/landscape phones.
+                serverSection.visibility = View.GONE
+                connectBtn.visibility = View.GONE
                 pairingSection.visibility = View.VISIBLE
                 pairingCodeText.text = wsService?.getPairingCode() ?: "------"
                 statusText.text = "Enter this code in the dashboard to pair this display"

--- a/android/app/src/main/java/com/remotedisplay/player/service/UpdateChecker.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/service/UpdateChecker.kt
@@ -5,6 +5,9 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.content.pm.Signature
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
@@ -17,6 +20,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONObject
 import java.io.File
+import java.security.MessageDigest
 import java.util.concurrent.TimeUnit
 
 class UpdateChecker(private val context: Context) {
@@ -107,6 +111,20 @@ class UpdateChecker(private val context: Context) {
 
             Log.i(TAG, "APK downloaded: ${apkFile.absolutePath} (${apkFile.length()} bytes)")
 
+            // SECURITY (#5 review): never install an APK we didn't sign. The update
+            // is fetched from a server-supplied URL, often over cleartext with no
+            // pinning - a MITM or compromised server could otherwise return a
+            // malicious APK and get it silently installed (REQUEST_INSTALL_PACKAGES).
+            // Verify the downloaded APK is our package AND signed by the same key as
+            // the currently-installed app before installing. An attacker can't forge
+            // our signature, so this holds even over an untrusted transport.
+            if (!verifyApkSignature(apkFile)) {
+                Log.e(TAG, "Refusing update: APK signature/package verification failed (tampered or MITM'd APK)")
+                apkFile.delete()
+                return
+            }
+            Log.i(TAG, "APK signature verified against installed app - proceeding to install")
+
             // Install the APK
             handler.post {
                 installApk(apkFile)
@@ -176,6 +194,56 @@ class UpdateChecker(private val context: Context) {
             }
         } catch (e: Exception) {
             Log.e(TAG, "Package installer failed: ${e.message}")
+        }
+    }
+
+    // True only if the downloaded APK is this same package and shares a signing
+    // certificate with the installed app. Fail-closed on any error.
+    private fun verifyApkSignature(apkFile: File): Boolean {
+        return try {
+            val pm = context.packageManager
+            val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
+                PackageManager.GET_SIGNING_CERTIFICATES else @Suppress("DEPRECATION") PackageManager.GET_SIGNATURES
+            val downloaded = pm.getPackageArchiveInfo(apkFile.absolutePath, flags)
+            if (downloaded == null) {
+                Log.e(TAG, "Could not parse downloaded APK")
+                return false
+            }
+            if (downloaded.packageName != context.packageName) {
+                Log.e(TAG, "APK package mismatch: ${downloaded.packageName} != ${context.packageName}")
+                return false
+            }
+            val installed = pm.getPackageInfo(context.packageName, flags)
+            val downloadedSigs = signingCertHashes(downloaded)
+            val installedSigs = signingCertHashes(installed)
+            if (downloadedSigs.isEmpty() || installedSigs.isEmpty()) {
+                Log.e(TAG, "Missing signing certificates (downloaded=${downloadedSigs.size}, installed=${installedSigs.size})")
+                return false
+            }
+            // Share at least one current signing certificate.
+            val match = downloadedSigs.any { it in installedSigs }
+            if (!match) Log.e(TAG, "APK signing certificate does not match installed app")
+            match
+        } catch (e: Exception) {
+            Log.e(TAG, "Signature verification error: ${e.message}", e)
+            false
+        }
+    }
+
+    private fun signingCertHashes(info: PackageInfo): Set<String> {
+        val sigs: Array<Signature>? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            info.signingInfo?.apkContentsSigners
+        } else {
+            @Suppress("DEPRECATION") info.signatures
+        }
+        return sigs?.mapNotNull { sha256(it.toByteArray()) }?.toSet() ?: emptySet()
+    }
+
+    private fun sha256(bytes: ByteArray): String? {
+        return try {
+            MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+        } catch (e: Exception) {
+            null
         }
     }
 

--- a/android/app/src/main/res/layout/activity_provisioning.xml
+++ b/android/app/src/main/res/layout/activity_provisioning.xml
@@ -12,9 +12,11 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="center"
+        android:gravity="center_horizontal|top"
         android:orientation="vertical"
-        android:padding="32dp"
+        android:paddingHorizontal="32dp"
+        android:paddingTop="24dp"
+        android:paddingBottom="24dp"
         android:keepScreenOn="true">
 
         <TextView
@@ -22,17 +24,17 @@
             android:layout_height="wrap_content"
             android:text="RemoteDisplay"
             android:textColor="#3B82F6"
-            android:textSize="36sp"
+            android:textSize="22sp"
             android:textStyle="bold"
-            android:layout_marginBottom="8dp" />
+            android:layout_marginBottom="4dp" />
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Digital Signage Player"
             android:textColor="#94A3B8"
-            android:textSize="16sp"
-            android:layout_marginBottom="32dp" />
+            android:textSize="14sp"
+            android:layout_marginBottom="20dp" />
 
         <!-- Server URL Section (hidden once paired so the code has room) -->
         <LinearLayout
@@ -100,8 +102,9 @@
                 android:textSize="16sp"
                 android:layout_marginBottom="12dp" />
 
-            <!-- Auto-sizes between 24sp and 96sp to fill the available width on a
-                 single line, so it's readable and never clipped on any screen. -->
+            <!-- Auto-sizes between 24sp and 56sp to fit the width on a single line.
+                 Capped at 56sp (not 96sp) + vertical padding so tall digits are
+                 never clipped, and the whole block stays on screen on short phones. -->
             <TextView
                 android:id="@+id/pairingCodeText"
                 android:layout_width="match_parent"
@@ -113,9 +116,12 @@
                 android:letterSpacing="0.3"
                 android:maxLines="1"
                 android:gravity="center"
+                android:paddingTop="4dp"
+                android:paddingBottom="8dp"
+                android:includeFontPadding="true"
                 app:autoSizeTextType="uniform"
                 app:autoSizeMinTextSize="24sp"
-                app:autoSizeMaxTextSize="96sp"
+                app:autoSizeMaxTextSize="56sp"
                 app:autoSizeStepGranularity="2sp" />
 
             <TextView

--- a/android/app/src/main/res/layout/activity_provisioning.xml
+++ b/android/app/src/main/res/layout/activity_provisioning.xml
@@ -1,123 +1,141 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<!-- Scrolls so content is always reachable on short screens; the pairing code
+     auto-sizes to fit any screen width (phones, TVs, HD sticks). -->
+<ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="center"
-    android:orientation="vertical"
-    android:background="#111827"
-    android:padding="48dp"
-    android:keepScreenOn="true">
+    android:fillViewport="true"
+    android:background="#111827">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="RemoteDisplay"
-        android:textColor="#3B82F6"
-        android:textSize="36sp"
-        android:textStyle="bold"
-        android:layout_marginBottom="8dp" />
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Digital Signage Player"
-        android:textColor="#94A3B8"
-        android:textSize="16sp"
-        android:layout_marginBottom="48dp" />
-
-    <!-- Server URL Section -->
     <LinearLayout
-        android:layout_width="400dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:gravity="center"
         android:orientation="vertical"
-        android:layout_marginBottom="24dp">
+        android:padding="32dp"
+        android:keepScreenOn="true">
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Server URL"
-            android:textColor="#94A3B8"
-            android:textSize="14sp"
+            android:text="RemoteDisplay"
+            android:textColor="#3B82F6"
+            android:textSize="36sp"
+            android:textStyle="bold"
             android:layout_marginBottom="8dp" />
 
-        <EditText
-            android:id="@+id/serverUrlInput"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:background="@drawable/input_background"
-            android:hint="http://192.168.1.100:3000"
-            android:textColorHint="#64748B"
-            android:textColor="#F1F5F9"
-            android:textSize="16sp"
-            android:padding="12dp"
-            android:inputType="textUri"
-            android:singleLine="true"
-            android:importantForAutofill="no" />
-    </LinearLayout>
-
-    <Button
-        android:id="@+id/connectBtn"
-        android:layout_width="400dp"
-        android:layout_height="48dp"
-        android:text="Connect"
-        android:textColor="#FFFFFF"
-        android:textSize="16sp"
-        android:textStyle="bold"
-        android:background="@drawable/button_primary"
-        android:layout_marginBottom="32dp" />
-
-    <ProgressBar
-        android:id="@+id/progressBar"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:indeterminate="true"
-        android:visibility="gone" />
-
-    <!-- Pairing Section (shown after connection) -->
-    <LinearLayout
-        android:id="@+id/pairingSection"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:gravity="center"
-        android:visibility="gone">
-
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Pairing Code"
+            android:text="Digital Signage Player"
             android:textColor="#94A3B8"
             android:textSize="16sp"
-            android:layout_marginBottom="12dp" />
+            android:layout_marginBottom="32dp" />
 
-        <TextView
-            android:id="@+id/pairingCodeText"
-            android:layout_width="wrap_content"
+        <!-- Server URL Section (hidden once paired so the code has room) -->
+        <LinearLayout
+            android:id="@+id/serverSection"
+            android:layout_width="400dp"
             android:layout_height="wrap_content"
-            android:text="------"
-            android:textColor="#3B82F6"
-            android:textSize="64sp"
+            android:orientation="vertical"
+            android:layout_marginBottom="24dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Server URL"
+                android:textColor="#94A3B8"
+                android:textSize="14sp"
+                android:layout_marginBottom="8dp" />
+
+            <EditText
+                android:id="@+id/serverUrlInput"
+                android:layout_width="match_parent"
+                android:layout_height="48dp"
+                android:background="@drawable/input_background"
+                android:hint="http://192.168.1.100:3000"
+                android:textColorHint="#64748B"
+                android:textColor="#F1F5F9"
+                android:textSize="16sp"
+                android:padding="12dp"
+                android:inputType="textUri"
+                android:singleLine="true"
+                android:importantForAutofill="no" />
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/connectBtn"
+            android:layout_width="400dp"
+            android:layout_height="48dp"
+            android:text="Connect"
+            android:textColor="#FFFFFF"
+            android:textSize="16sp"
             android:textStyle="bold"
-            android:fontFamily="monospace"
-            android:letterSpacing="0.3" />
+            android:background="@drawable/button_primary"
+            android:layout_marginBottom="32dp" />
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:indeterminate="true"
+            android:visibility="gone" />
+
+        <!-- Pairing Section (shown after connection) -->
+        <LinearLayout
+            android:id="@+id/pairingSection"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:visibility="gone">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Pairing Code"
+                android:textColor="#94A3B8"
+                android:textSize="16sp"
+                android:layout_marginBottom="12dp" />
+
+            <!-- Auto-sizes between 24sp and 96sp to fill the available width on a
+                 single line, so it's readable and never clipped on any screen. -->
+            <TextView
+                android:id="@+id/pairingCodeText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="------"
+                android:textColor="#3B82F6"
+                android:textStyle="bold"
+                android:fontFamily="monospace"
+                android:letterSpacing="0.3"
+                android:maxLines="1"
+                android:gravity="center"
+                app:autoSizeTextType="uniform"
+                app:autoSizeMinTextSize="24sp"
+                app:autoSizeMaxTextSize="96sp"
+                app:autoSizeStepGranularity="2sp" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Enter this code in the dashboard to pair this display"
+                android:textColor="#64748B"
+                android:textSize="14sp"
+                android:layout_marginTop="16dp"
+                android:gravity="center" />
+        </LinearLayout>
 
         <TextView
+            android:id="@+id/statusText"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Enter this code in the dashboard to pair this display"
-            android:textColor="#64748B"
+            android:textColor="#94A3B8"
             android:textSize="14sp"
-            android:layout_marginTop="16dp"
-            android:gravity="center" />
+            android:gravity="center"
+            android:layout_marginTop="16dp" />
+
     </LinearLayout>
-
-    <TextView
-        android:id="@+id/statusText"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textColor="#94A3B8"
-        android:textSize="14sp"
-        android:layout_marginTop="16dp" />
-
-</LinearLayout>
+</ScrollView>

--- a/android/app/src/main/res/layout/activity_provisioning.xml
+++ b/android/app/src/main/res/layout/activity_provisioning.xml
@@ -102,13 +102,14 @@
                 android:textSize="16sp"
                 android:layout_marginBottom="12dp" />
 
-            <!-- Auto-sizes between 24sp and 56sp to fit the width on a single line.
-                 Capped at 56sp (not 96sp) + vertical padding so tall digits are
-                 never clipped, and the whole block stays on screen on short phones. -->
+            <!-- FIXED-height box: autosize fits the text inside the bounded box and
+                 gravity center vertically centers it, so the digits are never
+                 clipped (the earlier wrap_content height clipped the glyph bottoms).
+                 24-64sp fills the width on phones/TVs/sticks. -->
             <TextView
                 android:id="@+id/pairingCodeText"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="96dp"
                 android:text="------"
                 android:textColor="#3B82F6"
                 android:textStyle="bold"
@@ -116,12 +117,9 @@
                 android:letterSpacing="0.3"
                 android:maxLines="1"
                 android:gravity="center"
-                android:paddingTop="4dp"
-                android:paddingBottom="8dp"
-                android:includeFontPadding="true"
                 app:autoSizeTextType="uniform"
                 app:autoSizeMinTextSize="24sp"
-                app:autoSizeMaxTextSize="56sp"
+                app:autoSizeMaxTextSize="64sp"
                 app:autoSizeStepGranularity="2sp" />
 
             <TextView


### PR DESCRIPTION
Combines the two Android device fixes (was #29 + #31) — they're tested together on the same hardware.

## 1. 🔴 Critical — verify OTA APK signature before install
`UpdateChecker` fetched `download_url` from the server and installed via `PackageInstaller` with **no verification**, over cleartext (no pinning). A MITM or compromised server could return a malicious APK → silent install on an unattended device (`REQUEST_INSTALL_PACKAGES`) → full RCE.

**Fix:** before install, verify the downloaded APK (a) is our own `packageName` and (b) shares a current signing certificate with the installed app (`GET_SIGNING_CERTIFICATES` on API 28+, `GET_SIGNATURES` below). An attacker can't forge our key, so a substituted APK is rejected even over untrusted transport. Fail-closed; file deleted on mismatch; gates both session + intent install paths. Also `android:allowBackup="false"` (no `adb backup` token exfil).

## 2. Pairing code not visible on some screens (Pixel 10)
The provisioning screen was a non-scrolling vertical stack; when the pairing section appeared below the server-URL + Connect controls, the fixed **64sp** code was pushed off-screen on a short landscape phone.

**Fix:** wrap in a `ScrollView`; the code **auto-sizes** (`autoSizeTextType=uniform`, 24–96sp, single line, full width) so it fits phones/TVs/sticks; hide the server-URL + Connect controls once paired.

## Verification
- ✅ Both compile (`:app:compileDebugKotlin`) and a signed debug APK builds.
- ❌ **On-device** — needs @ChrisChrome to confirm on a Pixel 10 / onn stick: pairing code is now visible, pairing works, a same-key update still installs, and a differently-signed APK is rejected (logcat: "signature ... does not match").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
