### PR TITLE
fix(ui): sidebar nav unscrollable on short screens

### DIFF
--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -212,6 +212,11 @@ body {
 .nav-links {
   flex: 1;
   padding: 12px 8px;
+  /* Scroll the nav when it's taller than the viewport (short screens, e.g.
+     1366x768) so items below the fold (Settings) stay reachable. min-height:0
+     is required for a flex child to shrink and scroll instead of overflowing. */
+  overflow-y: auto;
+  min-height: 0;
 }
 
 .nav-link {


### PR DESCRIPTION
Reported by @ChrisChrome on 1366x768: "I can't scroll on the sidebar… had to zoom out to get to Settings."

`.nav-links` had `flex:1` but no overflow handling, so when the nav is taller than the viewport the overflow is clipped (body is `overflow:hidden`) and items below the fold are unreachable.

Fix: `overflow-y:auto` + `min-height:0` on `.nav-links` (the `min-height:0` is required for a flex child to shrink and scroll rather than overflow). Header + footer stay fixed; only the nav list scrolls.