### PR TITLE
fix(widgets): make widget/kiosk render frameable (X-Frame-Options)

### DIFF
--- a/server/routes/kiosk.js
+++ b/server/routes/kiosk.js
@@ -180,6 +180,9 @@ router.get('/:id/render', (req, res) => {
   </script>
 </body></html>`;
 
+  // Embedded by the player in a sandboxed (null-origin) iframe; the global
+  // X-Frame-Options: SAMEORIGIN would refuse that and leave it blank.
+  res.removeHeader('X-Frame-Options');
   res.setHeader('Content-Type', 'text/html');
   res.send(html);
 });

--- a/server/routes/widgets.js
+++ b/server/routes/widgets.js
@@ -183,6 +183,12 @@ router.get('/:id/render', (req, res) => {
   const widget = db.prepare('SELECT * FROM widgets WHERE id = ?').get(req.params.id);
   if (!widget) return res.status(404).send('Widget not found');
   const config = JSON.parse(widget.config || '{}');
+  // This page is DESIGNED to be embedded by the player, which frames it in a
+  // sandboxed (allow-scripts, no allow-same-origin) iframe = a null origin. The
+  // global helmet X-Frame-Options: SAMEORIGIN refuses that (null != same), so
+  // widgets render blank in the web player. Drop it here; the sandbox - not
+  // X-Frame-Options - is what isolates the widget (it can't read the dashboard JWT).
+  res.removeHeader('X-Frame-Options');
   res.setHeader('Content-Type', 'text/html');
   res.send(renderWidgetHtml(widget.widget_type, config));
 });


### PR DESCRIPTION
Web-player widgets render **blank** because the player frames them in a `sandbox="allow-scripts"` (no `allow-same-origin`) iframe — a **null origin** — and the global helmet `X-Frame-Options: SAMEORIGIN` refuses that. Pre-existing (the sandbox predates the last deploy); video worked since it isn't an iframe; Android works since it loads widgets directly in a WebView, not a framed iframe.

**Fix:** drop `X-Frame-Options` on **just** the `/api/widgets/:id/render` and `/api/kiosk/:id/render` endpoints. The **sandbox** (null origin) is what isolates the widget from the dashboard's JWT — not X-Frame-Options — so this is safe; the dashboard keeps its clickjacking protection.

**Verified:** directory board renders in a sandboxed iframe with no refusal; suite 45/45.