### PR TITLE
fix(widgets): no-store on widget/kiosk render

### DIFF
--- a/server/routes/kiosk.js
+++ b/server/routes/kiosk.js
@@ -183,6 +183,7 @@ router.get('/:id/render', (req, res) => {
   // Embedded by the player in a sandboxed (null-origin) iframe; the global
   // X-Frame-Options: SAMEORIGIN would refuse that and leave it blank.
   res.removeHeader('X-Frame-Options');
+  res.setHeader('Cache-Control', 'no-store');
   res.setHeader('Content-Type', 'text/html');
   res.send(html);
 });

--- a/server/routes/widgets.js
+++ b/server/routes/widgets.js
@@ -189,6 +189,9 @@ router.get('/:id/render', (req, res) => {
   // widgets render blank in the web player. Drop it here; the sandbox - not
   // X-Frame-Options - is what isolates the widget (it can't read the dashboard JWT).
   res.removeHeader('X-Frame-Options');
+  // Never cache the render: widget data (clock/weather/rss/directory) changes, and
+  // a cached copy from before the X-Frame-Options change would keep showing blank.
+  res.setHeader('Cache-Control', 'no-store');
   res.setHeader('Content-Type', 'text/html');
   res.send(renderWidgetHtml(widget.widget_type, config));
 });


### PR DESCRIPTION
Follow-up to #43. The render carried no `Cache-Control`, so a copy cached *before* the X-Frame-Options fix keeps rendering blank in already-open browsers. Mark `/render` `no-store` (correct anyway — widget data is dynamic).