### PR TITLE
fix(player-web): render widgets in content zones (black-zone bug)

### DIFF
--- a/server/player/index.html
+++ b/server/player/index.html
@@ -1506,7 +1506,11 @@
       const src = a.remote_url || `${config.serverUrl}/uploads/content/${a.filepath}`;
       const dur = (a.duration_sec || 10) * 1000;
 
-      if (zone.zone_type === 'widget' && a.widget_id) {
+      // Render based on what the ASSIGNMENT is (widget_id), not the zone's type:
+      // a widget can be placed in a 'content' zone, and gating on zone_type==='widget'
+      // left those zones blank (mime_type is null -> no video/image match). Matches the
+      // Android player, which keys off the assignment's widget_type.
+      if (a.widget_id) {
         const iframe = document.createElement('iframe');
         iframe.src = `${config.serverUrl}/api/widgets/${a.widget_id}/render`;
         // Sandbox into a unique origin so widget scripts can't read window.parent


### PR DESCRIPTION
A widget assigned to a `content`-type zone rendered **black** in the web player. `showZoneItem` gated the widget branch on `zone.zone_type === 'widget'`; widgets in `content` zones were skipped and (null mime_type) matched no other branch. Now keys off the assignment's `widget_id` — matching the Android ZoneManager (which is why it worked on the APK but not the web). Found via a real screen capture: left zone (video) rendered, right zone (directory-board widget in a content zone) was black.