### PR TITLE
ui(content): advertise multi-file upload in drop-zone text (#39)

### DIFF
--- a/frontend/js/i18n/en.js
+++ b/frontend/js/i18n/en.js
@@ -134,7 +134,7 @@ export default {
   'content.title': 'Content Library',
   'content.subtitle': 'Upload and manage your media files',
   'content.help_tip': 'Upload videos and images here. Select multiple files for bulk upload. Use Remote URL to stream from external sources. Click a thumbnail to preview.',
-  'content.drop': 'Drop files here or click to upload',
+  'content.drop': 'Drop files here, or click to select one or more',
   'content.upload_hint': 'Supports MP4, WebM, AVI, MKV, JPEG, PNG, GIF, WebP',
   'content.upload_progress': 'Uploading...',
   'content.upload_progress_named': 'Uploading {name}...',


### PR DESCRIPTION
Closes #39. Multi-file upload via the button already works — the `#fileInput` has `multiple` and its change handler shares `handleFiles()` with drag-drop (so shift/ctrl-click in the picker uploads several at once). It just wasn't discoverable; the drop-zone now reads "click to select one or more".