### PR TITLE
fix(android): YouTube error 152 — embed under a third-party domain (#4)

### DIFF
--- a/android/app/src/main/java/com/remotedisplay/player/player/MediaPlayerManager.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/player/MediaPlayerManager.kt
@@ -59,7 +59,7 @@ class MediaPlayerManager(
             setBackgroundColor(android.graphics.Color.BLACK)
             // Load via an embed wrapper with a valid youtube.com origin (Error 153 fix).
             val html = com.remotedisplay.player.util.WebViewSupport.youtubeEmbedHtml(embedUrl)
-            if (html != null) loadDataWithBaseURL(com.remotedisplay.player.util.WebViewSupport.YT_BASE, html, "text/html", "UTF-8", null)
+            if (html != null) loadDataWithBaseURL(com.remotedisplay.player.util.WebViewSupport.EMBED_BASE, html, "text/html", "UTF-8", null)
             else loadUrl(embedUrl)
         }
     }

--- a/android/app/src/main/java/com/remotedisplay/player/player/ZoneManager.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/player/ZoneManager.kt
@@ -159,7 +159,7 @@ class ZoneManager(
             mimeType == "video/youtube" && !remoteUrl.isNullOrEmpty() -> {
                 val webView = createWebView()
                 val html = com.remotedisplay.player.util.WebViewSupport.youtubeEmbedHtml(remoteUrl)
-                if (html != null) webView.loadDataWithBaseURL(com.remotedisplay.player.util.WebViewSupport.YT_BASE, html, "text/html", "UTF-8", null)
+                if (html != null) webView.loadDataWithBaseURL(com.remotedisplay.player.util.WebViewSupport.EMBED_BASE, html, "text/html", "UTF-8", null)
                 else webView.loadUrl(remoteUrl)
                 webView.layoutParams = params
                 container.addView(webView); zoneViews[zone.id] = webView

--- a/android/app/src/main/java/com/remotedisplay/player/util/WebViewSupport.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/util/WebViewSupport.kt
@@ -23,6 +23,12 @@ import android.webkit.WebViewClient
 object WebViewSupport {
 
     const val YT_BASE = "https://www.youtube.com"
+    // Base URL the embed page is loaded under (its referrer to YouTube). It must be
+    // a normal embedding site, NOT youtube.com itself — a page claiming to be
+    // youtube.com embedding a youtube.com iframe is rejected as an invalid embed
+    // context ("This video is unavailable / Error 152"). A real third-party domain
+    // is what legitimate embeds use.
+    const val EMBED_BASE = "https://screentinker.com"
 
     fun configure(webView: WebView, tag: String) {
         webView.settings.apply {


### PR DESCRIPTION
**Reproduced on a Pixel 10 / Android 16 emulator:** every YouTube video showed *'This video is unavailable — Error code: 152 - 4'* (universal, not video-specific).

**Cause:** the player loaded the embed via `loadDataWithBaseURL("https://www.youtube.com", …)`, so the embedding page claimed to *be* youtube.com hosting a youtube.com iframe — YouTube rejects that as an invalid embed context → 152.

**Fix:** load the embed under a real third-party domain (`EMBED_BASE`), so the referrer is a legitimate embedding site; the iframe still targets youtube.com/embed. **Verified: video plays.** (Supersedes the earlier base=youtube.com 153-fix; a normal-domain referrer fixes 153 too.)