### PR TITLE
chore(tizen): dev-signing setup + support email

### DIFF
--- a/tizen/README.md
+++ b/tizen/README.md
@@ -42,20 +42,27 @@ No package needed. Host this folder on any web server (e.g. the ScreenTinker
 server itself) and point the display's **URL Launcher** at `…/index.html`.
 The TV runs it as a web app on boot. Best for Samsung B2B signage displays.
 
-### B) Signed `.wgt` (retail TVs / installed app)
-Retail Tizen TVs require a Samsung-signed package:
-1. Install **Tizen Studio** + the TV extension.
-2. **Certificate Manager** → create a Samsung author + distributor certificate
-   (needs a free Samsung account; distributor cert must include the TV's **DUID**).
-3. Create a signing **profile**, then:
-   ```bash
-   ./build-wgt.sh <profileName>     # uses `tizen package -t wgt -s <profileName>`
-   ```
-4. Put the TV in **Developer Mode** (Apps → 12345 → enter host IP), then install:
-   ```bash
-   sdb connect <tv-ip>
-   tizen install -n ScreenTinker.wgt -t <tv-device>
-   ```
+### B) Signed `.wgt` (installed app)
+A signing profile is already set up on the build box (Tizen Studio CLI 6.1):
+- **Profile `ScreenTinker`** = a self-signed **author** cert
+  (`~/tizen-studio-data/keystore/author/st_author.p12`) + the default Tizen
+  **distributor** cert. `./build-wgt.sh` auto-detects the CLI and signs with it,
+  producing a `.wgt` with `author-signature.xml` + `signature1.xml`.
+- This installs on **developer-mode** Samsung TVs and the **Tizen emulator** —
+  the right path for a **self-hosted fleet you control** (enable Developer Mode
+  on each TV once: Apps → enter `12345` → set the host IP).
+
+Install onto a dev-mode TV:
+```bash
+sdb connect <tv-ip>
+tizen install -n ScreenTinker.wgt -t <tv-device>
+```
+
+**Production / retail (no developer mode):** re-sign with a Samsung **Partner**
+or **Public** distributor certificate from the Tizen **Certificate Manager**
+(free Samsung account; distributor cert tied to each TV's **DUID**), then
+`./build-wgt.sh <thatProfile>`. The self-signed author cert is not committed (it
+lives in `~/tizen-studio-data`, password `screentinker`).
 
 ## Validated (2026-06-09)
 - **Protocol**: headless test against the live server passed end-to-end —

--- a/tizen/build-wgt.sh
+++ b/tizen/build-wgt.sh
@@ -1,22 +1,29 @@
 #!/bin/bash
 # Build the ScreenTinker Tizen .wgt.
-#  - If the Tizen CLI is on PATH, sign with a security profile (arg 1, default
-#    "ScreenTinker"): produces a TV-installable signed .wgt.
-#  - Otherwise, produce an UNSIGNED .wgt (plain zip) — fine for inspection / the
-#    URL-Launcher path, but retail Samsung TVs need a signed package.
+#  - If the Tizen CLI is available, sign with a security profile (arg 1, default
+#    "ScreenTinker") and emit a signed, TV-installable .wgt.
+#  - Otherwise, emit an UNSIGNED .wgt (plain zip) — fine for inspection / the
+#    URL-Launcher path, but TVs need a signed package.
+# Only the app files are packaged (README/build script/.gitignore are excluded).
 set -e
 cd "$(dirname "$0")"
 OUT="ScreenTinker.wgt"
 FILES="config.xml index.html icon.png css js"
+
+# Make the Tizen CLI discoverable if installed in the default location.
+[ -d "$HOME/tizen-studio/tools/ide/bin" ] && export PATH="$HOME/tizen-studio/tools/ide/bin:$PATH"
 rm -f "$OUT"
 
 if command -v tizen >/dev/null 2>&1; then
   PROFILE="${1:-ScreenTinker}"
   echo "Tizen CLI found — signing with profile '$PROFILE'…"
-  tizen package -t wgt -s "$PROFILE" -- . -o .
-  echo "Signed $OUT ready."
+  STAGE="$(mktemp -d)"
+  cp -r $FILES "$STAGE"/
+  tizen package -t wgt -s "$PROFILE" -- "$STAGE" -o "$PWD" >/dev/null
+  rm -rf "$STAGE"
+  echo "Signed $OUT ready ($(du -h "$OUT" | cut -f1))."
 else
   echo "Tizen CLI not found — building UNSIGNED $OUT."
   zip -r -X "$OUT" $FILES -x '*.DS_Store' '_*' >/dev/null
-  echo "Built $OUT ($(du -h "$OUT" | cut -f1), UNSIGNED — sign before installing on a retail TV)."
+  echo "Built $OUT ($(du -h "$OUT" | cut -f1), UNSIGNED — sign before installing on a TV)."
 fi

--- a/tizen/config.xml
+++ b/tizen/config.xml
@@ -4,7 +4,7 @@
     <tizen:application id="ScrnTinkr1.ScreenTinker" package="ScrnTinkr1" required_version="2.4"/>
     <tizen:profile name="tv"/>
     <name>ScreenTinker</name>
-    <author email="dw5304@gmail.com">ScreenTinker</author>
+    <author email="support@screentinker.net">ScreenTinker</author>
     <description>ScreenTinker digital signage player</description>
     <icon src="icon.png"/>
     <content src="index.html"/>


### PR DESCRIPTION
Follow-up to the Tizen player (#69):
- Author email → **support@screentinker.net** (cert + config.xml).
- `build-wgt.sh` stages app files only before signing + finds the Tizen CLI automatically.
- README documents the configured **ScreenTinker** signing profile (self-signed author + default Tizen distributor) → installs on **dev-mode TVs / emulator**; production retail needs a Samsung distributor cert.

The signed `.wgt` and the author cert are not committed.