### PR TITLE
fix(android): zone image falls back to server URL when not cached (#78)

### DIFF
--- a/android/app/src/main/java/com/remotedisplay/player/player/ZoneManager.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/player/ZoneManager.kt
@@ -252,17 +252,26 @@ class ZoneManager(
                     } else {
                         Log.w(TAG, "Zone ${zone.name}: skipping unloadable image $contentId")
                     }
-                } else if (!remoteUrl.isNullOrEmpty()) {
-                    Thread {
-                        val bitmap = com.remotedisplay.player.util.ImageLoader.decodeUrl(remoteUrl, targetW, targetH)
-                        if (bitmap != null) {
-                            imageView.post {
-                                try { imageView.setImageBitmap(bitmap) } catch (e: Throwable) { Log.e(TAG, "setImageBitmap failed: ${e.message}") }
+                } else {
+                    // #78: not in the local cache yet (first-sync download still in flight, or a
+                    // zone whose content the preloader hasn't fetched). Load straight from the
+                    // server - mirrors how the video branch above falls back to a server URL -
+                    // so the zone isn't blank until a restart populates the cache.
+                    val imgUrl = if (!remoteUrl.isNullOrEmpty()) remoteUrl
+                                 else if (contentId != null) "$renderServerUrl/api/content/$contentId/file"
+                                 else null
+                    if (imgUrl != null) {
+                        Thread {
+                            val bitmap = com.remotedisplay.player.util.ImageLoader.decodeUrl(imgUrl, targetW, targetH)
+                            if (bitmap != null) {
+                                imageView.post {
+                                    try { imageView.setImageBitmap(bitmap) } catch (e: Throwable) { Log.e(TAG, "setImageBitmap failed: ${e.message}") }
+                                }
+                            } else {
+                                Log.w(TAG, "Zone ${zone.name}: unloadable image $contentId via $imgUrl")
                             }
-                        } else {
-                            Log.w(TAG, "Zone ${zone.name}: skipping unloadable remote image")
-                        }
-                    }.start()
+                        }.start()
+                    }
                 }
                 container.addView(imageView); zoneViews[zone.id] = imageView
                 if (multi) scheduleZoneAdvance(zone.id, durationMs, advance)


### PR DESCRIPTION
Fixes #78. A zone rendered its image from the local content cache only; if the content wasn't cached at first render, a static (single, unscheduled) zone stayed blank until restart. Now mirrors the video branch — when `getCachedFile` is null, load the image directly from the server (`remote_url`, else `/api/content/<id>/file`).

**Verified live** on a 2-zone layout (two single-unscheduled items, fresh content): both zones render with **no restart**, confirmed with only one item in the on-device cache — the other displayed via the URL fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)