### PR TITLE
fix(security): rate-limit the whole /api/provision pairing surface (#88)

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -283,8 +283,12 @@ app.use('/api/auth/register', rateLimit(60000, 5)); // 5 registrations per minut
 // path prefix first, so this fires before /api/auth catches the request.
 app.use('/api/auth/users', rateLimit(60000, 20));
 app.use('/api/auth', require('./routes/auth'));
-// Rate limit pairing to prevent brute force (5 attempts per minute per IP)
-app.use('/api/provision/pair', rateLimit(60000, 5));
+// Rate limit pairing to prevent brute force (5 attempts per minute per IP).
+// #88: bind this to the whole /api/provision surface, not just /pair - the bare
+// POST /api/provision (routes/provisioning.js) is a second pairing endpoint that
+// was unthrottled, letting an authed user brute-force pairing codes. /api/provision
+// matches both /api/provision and /api/provision/pair.
+app.use('/api/provision', rateLimit(60000, 5));
 // Rate limit expensive operations
 app.use('/api/status/export', rateLimit(60000, 5)); // 5 exports per minute
 app.use('/api/status/import', rateLimit(60000, 3)); // 3 imports per minute


### PR DESCRIPTION
Closes #88. `POST /api/provision` (the `routes/provisioning.js` router endpoint) paired a device by `pairing_code` with **no rate limit** — the throttle at server.js:287 covered only the `/api/provision/pair` override, so the bare endpoint was an unthrottled pairing-code brute-force vector. Bound the rate limit to the `/api/provision` mount (one line) so it covers both pairing paths.

**Verified live:** 6 rapid POSTs to `/api/provision` → 401×5 then **429** (was unlimited); `/api/provision/pair` still 429s on the 6th. Syntax checked.

Note: the bare `/api/provision` endpoint is vestigial (no client calls it — the dashboard uses `/pair`); consolidating to a single pairing endpoint is a reasonable follow-up but not needed to close the hole. Pairing-code strength (6 digits) is tracked separately as a design discussion in #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)