### PR TITLE
feat: opt-in TOTP MFA with recovery codes (#100)

### DIFF
--- a/server/db/database.js
+++ b/server/db/database.js
@@ -187,6 +187,12 @@ const migrations = [
   "ALTER TABLE ai_settings ADD COLUMN image_provider TEXT",
   // #41: optional separate key for the image endpoint (for local-LLM + cloud-image setups).
   "ALTER TABLE ai_settings ADD COLUMN image_api_key_enc TEXT",
+  // #100: TOTP MFA. Columns default to "off" so every existing account is unaffected.
+  "ALTER TABLE users ADD COLUMN totp_secret_enc TEXT",
+  "ALTER TABLE users ADD COLUMN totp_enabled INTEGER NOT NULL DEFAULT 0",
+  "ALTER TABLE users ADD COLUMN totp_last_step INTEGER NOT NULL DEFAULT 0",
+  "CREATE TABLE IF NOT EXISTS totp_recovery_codes (id TEXT PRIMARY KEY, user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE, code_hash TEXT NOT NULL, created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')), used_at INTEGER)",
+  "CREATE INDEX IF NOT EXISTS idx_totp_recovery_user ON totp_recovery_codes(user_id)",
 ];
 // Apply each ALTER idempotently. A "duplicate column name" / "already exists"
 // error means the column is already present (expected on a migrated DB) - benign.

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -37,9 +37,26 @@ CREATE TABLE IF NOT EXISTS users (
     stripe_subscription_id TEXT,
     subscription_status TEXT DEFAULT 'active',
     subscription_ends  INTEGER,
+    -- #100: TOTP MFA (opt-in, local accounts only). totp_secret_enc is secretbox-
+    -- encrypted (REVERSIBLE - the server recomputes codes). totp_last_step blocks
+    -- intra-window replay (a code from an already-consumed 30s step is rejected).
+    totp_secret_enc TEXT,
+    totp_enabled    INTEGER NOT NULL DEFAULT 0,
+    totp_last_step  INTEGER NOT NULL DEFAULT 0,
     created_at      INTEGER NOT NULL DEFAULT (strftime('%s','now')),
     updated_at      INTEGER NOT NULL DEFAULT (strftime('%s','now'))
 );
+
+-- #100: single-use TOTP recovery codes. SHA-256 hashed (same discipline as
+-- api_tokens.token_hash); plaintext shown once at enrollment. used_at NULL = available.
+CREATE TABLE IF NOT EXISTS totp_recovery_codes (
+    id          TEXT PRIMARY KEY,
+    user_id     TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    code_hash   TEXT NOT NULL,
+    created_at  INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+    used_at     INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_totp_recovery_user ON totp_recovery_codes(user_id);
 
 CREATE TABLE IF NOT EXISTS devices (
     id              TEXT PRIMARY KEY,

--- a/server/lib/totp-lockout.js
+++ b/server/lib/totp-lockout.js
@@ -1,0 +1,30 @@
+'use strict';
+
+// #100 (tightening #2): brute-force lockout for POST /api/auth/totp/verify. A 6-digit
+// code is only 1e6 wide, and an attacker who has the password already holds a valid
+// mfa_pending token - the verify endpoint is the real attack surface. Lock a key
+// (the mfa_pending user id) after MAX_FAILS bad codes, on top of the per-route 10/min
+// rate-limit. Same shape as lib/pair-lockout.js (#87). In-memory; resets on restart.
+
+const MAX_FAILS = 5;                  // consecutive bad codes before lockout
+const LOCKOUT_MS = 15 * 60 * 1000;    // how long the key is then blocked
+
+const failures = new Map(); // key -> { count, lockedUntil }
+
+function isLocked(key, now = Date.now()) {
+  const rec = failures.get(key);
+  return !!(rec && rec.lockedUntil > now);
+}
+
+function recordFailure(key, now = Date.now()) {
+  const rec = failures.get(key) || { count: 0, lockedUntil: 0 };
+  rec.count += 1;
+  if (rec.count >= MAX_FAILS) { rec.lockedUntil = now + LOCKOUT_MS; rec.count = 0; }
+  failures.set(key, rec);
+  return rec;
+}
+
+// A successful verify (or any reason to forgive) clears the key.
+function reset(key) { failures.delete(key); }
+
+module.exports = { isLocked, recordFailure, reset, MAX_FAILS, LOCKOUT_MS };

--- a/server/lib/totp.js
+++ b/server/lib/totp.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// #100: TOTP (RFC 6238) helper. The shared secret is REVERSIBLE (the server must
+// recompute codes), so it's stored via secretbox (AES-256-GCM) - NOT hashed like the
+// API token / recovery codes. Recovery codes ARE hashed (SHA-256, same discipline as
+// api_tokens) - see generateRecoveryCodes / hashRecoveryCode.
+
+const { authenticator } = require('otplib');
+const crypto = require('crypto');
+const secretbox = require('./secretbox');
+const { hashToken } = require('../middleware/apiToken');
+
+const STEP_SEC = 30;
+const ISSUER = 'ScreenTinker';
+authenticator.options = { window: 1 }; // accept ±1 step (±30s) for clock skew
+
+function generateSecret() { return authenticator.generateSecret(); }            // base32 plaintext
+function keyuri(email, secret) { return authenticator.keyuri(email, ISSUER, secret); } // otpauth:// for the QR
+function encryptSecret(secret) { return secretbox.encrypt(secret); }            // for storage
+function decryptSecret(enc) { return secretbox.decrypt(enc); }                  // for verification
+
+function currentStep(now = Date.now()) { return Math.floor(now / 1000 / STEP_SEC); }
+
+// Verify a 6-digit code against the PLAINTEXT secret, blocking intra-window replay
+// via lastStep. Returns the matched step (always > lastStep) on success, else null.
+// The caller persists the returned step as the user's new totp_last_step.
+function verifyCode(token, secret, lastStep = 0, now = Date.now()) {
+  if (!secret || !/^[0-9]{6}$/.test(String(token || '').trim())) return null;
+  const delta = authenticator.checkDelta(String(token).trim(), secret); // -1|0|1 or null
+  if (delta == null) return null;
+  const step = currentStep(now) + delta;
+  if (step <= lastStep) return null; // a code from an already-consumed step (replay)
+  return step;
+}
+
+// 10 single-use recovery codes. Returns plaintext (shown ONCE) + SHA-256 hashes (stored).
+function generateRecoveryCodes(n = 10) {
+  const plain = [], hashes = [];
+  for (let i = 0; i < n; i++) {
+    const code = crypto.randomBytes(5).toString('hex').toUpperCase(); // 10 hex chars
+    plain.push(code);
+    hashes.push(hashToken(code));
+  }
+  return { plain, hashes };
+}
+
+// Normalize user input (strip spaces/hyphens, uppercase) then hash, so a code typed
+// with stray formatting still matches the stored hash.
+function hashRecoveryCode(input) {
+  return hashToken(String(input || '').toUpperCase().replace(/[^0-9A-F]/g, ''));
+}
+
+module.exports = {
+  generateSecret, keyuri, encryptSecret, decryptSecret,
+  verifyCode, currentStep, generateRecoveryCodes, hashRecoveryCode, STEP_SEC,
+};

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -15,6 +15,19 @@ function generateToken(user, currentWorkspaceId) {
   );
 }
 
+// #100: issued after password verification but BEFORE the TOTP step, so the client
+// can complete MFA. It is NOT a session token - it carries mfa_pending:true and is
+// accepted ONLY by POST /api/auth/totp/verify. requireAuth/optionalAuth reject it
+// (see below) - otherwise password-alone would yield a usable token and TOTP would
+// be decorative. Short-lived.
+function generateMfaPendingToken(user) {
+  return jwt.sign(
+    { id: user.id, mfa_pending: true },
+    config.jwtSecret,
+    { algorithm: 'HS256', expiresIn: '5m' }
+  );
+}
+
 function verifyToken(token) {
   return jwt.verify(token, config.jwtSecret, { algorithms: ['HS256'] });
 }
@@ -48,6 +61,11 @@ function requireAuth(req, res, next) {
       req.jwtWorkspaceId = null;
       return next();
     }
+    // #100 (tightening #1): an mfa_pending token has cleared the password but NOT the
+    // TOTP step. It must never authorize a protected route - only /api/auth/totp/verify
+    // accepts it. If this check is removed, password-alone yields a working session and
+    // TOTP is bypassed. (Covered by the mfa_pending bite-test.)
+    if (decoded.mfa_pending) return res.status(401).json({ error: 'mfa_required' });
     const user = db.prepare('SELECT id, email, name, role, auth_provider, avatar_url, plan_id, email_alerts, must_change_password FROM users WHERE id = ?').get(decoded.id);
     if (!user) return res.status(401).json({ error: 'User not found' });
     req.user = user;
@@ -76,6 +94,7 @@ function optionalAuth(req, res, next) {
     try {
       const token = authHeader.split(' ')[1];
       const decoded = verifyToken(token);
+      if (decoded.mfa_pending) return next(); // #100: pre-TOTP token is not a session
       req.user = decoded.recovery
         ? recoveryUser(decoded)
         : db.prepare('SELECT id, email, name, role, auth_provider, avatar_url, plan_id FROM users WHERE id = ?').get(decoded.id);
@@ -144,4 +163,4 @@ function requireSuperAdmin(req, res, next) {
 // Preferred alias for new code.
 const requirePlatformAdmin = requireSuperAdmin;
 
-module.exports = { generateToken, verifyToken, requireAuth, optionalAuth, requireAdmin, requireSuperAdmin, requirePlatformAdmin, isPlatformRole, isPlatformStaff, PLATFORM_ROLES, PLATFORM_STAFF, ELEVATED_ROLES };
+module.exports = { generateToken, generateMfaPendingToken, verifyToken, requireAuth, optionalAuth, requireAdmin, requireSuperAdmin, requirePlatformAdmin, isPlatformRole, isPlatformStaff, PLATFORM_ROLES, PLATFORM_STAFF, ELEVATED_ROLES };

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,6 +19,7 @@
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.3",
         "multer": "^1.4.5-lts.1",
+        "otplib": "^12.0.1",
         "sharp": "^0.33.2",
         "socket.io": "^4.7.2",
         "stripe": "^20.4.1",
@@ -438,6 +439,56 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@otplib/core": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==",
+      "license": "MIT"
+    },
+    "node_modules/@otplib/plugin-crypto": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
+      "integrity": "sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==",
+      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/plugin-thirty-two": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-thirty-two/-/plugin-thirty-two-12.0.1.tgz",
+      "integrity": "sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==",
+      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "thirty-two": "^1.0.2"
+      }
+    },
+    "node_modules/@otplib/preset-default": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
+      "integrity": "sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==",
+      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/preset-v11": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-v11/-/preset-v11-12.0.1.tgz",
+      "integrity": "sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2632,6 +2683,17 @@
         "wrappy": "1"
       }
     },
+    "node_modules/otplib": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
+      "integrity": "sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/preset-default": "^12.0.1",
+        "@otplib/preset-v11": "^12.0.1"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -3500,6 +3562,14 @@
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/thirty-two": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/thirty-two/-/thirty-two-1.0.2.tgz",
+      "integrity": "sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==",
+      "engines": {
+        "node": ">=0.2.6"
       }
     },
     "node_modules/toidentifier": {

--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.3",
     "multer": "^1.4.5-lts.1",
+    "otplib": "^12.0.1",
     "sharp": "^0.33.2",
     "socket.io": "^4.7.2",
     "stripe": "^20.4.1",

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -165,7 +165,10 @@ function issueSession(req, res, user, extra = {}) {
   logSuccessfulLogin(user.id, user.email, getClientIp(req));
   const workspaceId = ensureDefaultOrgForUser(user, { allowCreate: config.autoCreateOrgOnSignup });
   const token = generateToken(user, workspaceId);
-  const { password_hash, ...safeUser } = user;
+  // #100: callers pass a SELECT * row. Strip password_hash AND the TOTP internals
+  // (the encrypted secret + the replay counter) so no secret/internal rides in the
+  // response body - "secrets never in responses", same as the API token work.
+  const { password_hash, totp_secret_enc, totp_last_step, ...safeUser } = user;
   res.json({ token, user: safeUser, current_workspace_id: workspaceId, ...extra });
 }
 

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -5,9 +5,11 @@ const https = require('https');
 const { v4: uuidv4 } = require('uuid');
 const { OAuth2Client } = require('google-auth-library');
 const { db } = require('../db/database');
-const { generateToken, requireAuth, requireAdmin, requireSuperAdmin, isPlatformRole, isPlatformStaff, PLATFORM_ROLES } = require('../middleware/auth');
+const { generateToken, generateMfaPendingToken, verifyToken, requireAuth, requireAdmin, requireSuperAdmin, isPlatformRole, isPlatformStaff, PLATFORM_ROLES } = require('../middleware/auth');
 const { resolveTenancy } = require('../lib/tenancy');
 const { logActivity, getClientIp } = require('../services/activity');
+const totp = require('../lib/totp');
+const totpLockout = require('../lib/totp-lockout');
 const { sendSignupEmails } = require('../services/signupEmails');
 const { deleteUserCascade, OrgHasOtherMembersError } = require('../lib/user-deletion');
 const config = require('../config');
@@ -147,11 +149,147 @@ router.post('/login', (req, res) => {
     return res.status(401).json({ error: 'Invalid email or password' });
   }
 
-  logSuccessfulLogin(user.id, email, getClientIp(req));
+  // #100: password OK. If TOTP is enabled, DON'T issue a session yet - return an
+  // mfa_pending token; the client completes via POST /api/auth/totp/verify. This is
+  // the ONLY place TOTP gates (interactive password login). The SSO routes and the
+  // API-token path never reach here, so both bypass TOTP by construction.
+  if (user.totp_enabled) {
+    return res.json({ mfa_required: true, mfa_token: generateMfaPendingToken(user) });
+  }
+  issueSession(req, res, user);
+});
+
+// #100: finish an interactive login - shared by /login (no TOTP) and /totp/verify
+// (after TOTP). Logs the successful login + issues the full session JWT.
+function issueSession(req, res, user, extra = {}) {
+  logSuccessfulLogin(user.id, user.email, getClientIp(req));
   const workspaceId = ensureDefaultOrgForUser(user, { allowCreate: config.autoCreateOrgOnSignup });
   const token = generateToken(user, workspaceId);
   const { password_hash, ...safeUser } = user;
-  res.json({ token, user: safeUser, current_workspace_id: workspaceId });
+  res.json({ token, user: safeUser, current_workspace_id: workspaceId, ...extra });
+}
+
+// ==================== TOTP MFA (#100) ====================
+// Opt-in per-user, LOCAL accounts only (SSO IdPs own MFA). Enrollment is a two-step
+// confirm (setup -> enable) so a mistyped secret can't lock anyone out. Recovery
+// codes are shown ONCE at enable, stored SHA-256-hashed, single-use.
+
+const RECOVERY_CODE_COUNT = 10;
+
+function recoveryCodesRemaining(userId) {
+  return db.prepare('SELECT COUNT(*) AS n FROM totp_recovery_codes WHERE user_id = ? AND used_at IS NULL').get(userId).n;
+}
+
+// Atomically replace a user's recovery codes - no window where old + new both verify
+// (tightening #3). Returns the plaintext set (shown ONCE).
+function resetRecoveryCodes(userId) {
+  const { plain, hashes } = totp.generateRecoveryCodes(RECOVERY_CODE_COUNT);
+  db.transaction(() => {
+    db.prepare('DELETE FROM totp_recovery_codes WHERE user_id = ?').run(userId);
+    const ins = db.prepare('INSERT INTO totp_recovery_codes (id, user_id, code_hash) VALUES (?, ?, ?)');
+    for (const h of hashes) ins.run(uuidv4(), userId, h);
+  })();
+  return plain;
+}
+
+// Consume one single-use recovery code (mark used). True if a fresh code matched.
+function consumeRecoveryCode(userId, input) {
+  if (!input) return false;
+  const row = db.prepare('SELECT id FROM totp_recovery_codes WHERE user_id = ? AND code_hash = ? AND used_at IS NULL')
+    .get(userId, totp.hashRecoveryCode(input));
+  if (!row) return false;
+  db.prepare("UPDATE totp_recovery_codes SET used_at = strftime('%s','now') WHERE id = ?").run(row.id);
+  return true;
+}
+
+router.get('/totp/status', requireAuth, (req, res) => {
+  const u = db.prepare('SELECT totp_enabled, auth_provider FROM users WHERE id = ?').get(req.user.id);
+  res.json({
+    enabled: !!u.totp_enabled,
+    eligible: u.auth_provider === 'local',
+    recovery_codes_remaining: u.totp_enabled ? recoveryCodesRemaining(req.user.id) : 0,
+  });
+});
+
+// Step 1: mint a pending secret + return the otpauth:// URI (frontend renders the QR).
+router.post('/totp/setup', requireAuth, (req, res) => {
+  const u = db.prepare('SELECT auth_provider, totp_enabled, email FROM users WHERE id = ?').get(req.user.id);
+  if (u.auth_provider !== 'local') return res.status(400).json({ error: 'TOTP is only for password accounts; your identity provider manages MFA.' });
+  if (u.totp_enabled) return res.status(409).json({ error: 'TOTP already enabled. Disable it first to re-enroll.' });
+  const secret = totp.generateSecret();
+  db.prepare("UPDATE users SET totp_secret_enc = ?, totp_enabled = 0, updated_at = strftime('%s','now') WHERE id = ?")
+    .run(totp.encryptSecret(secret), req.user.id);
+  res.json({ otpauth_uri: totp.keyuri(u.email, secret), secret });
+});
+
+// Step 2: confirm a code from the user's app, THEN enable + issue recovery codes (once).
+router.post('/totp/enable', requireAuth, (req, res) => {
+  const u = db.prepare('SELECT totp_secret_enc, totp_enabled, totp_last_step, auth_provider FROM users WHERE id = ?').get(req.user.id);
+  if (u.auth_provider !== 'local') return res.status(400).json({ error: 'TOTP unavailable for SSO accounts.' });
+  if (u.totp_enabled) return res.status(409).json({ error: 'TOTP already enabled.' });
+  if (!u.totp_secret_enc) return res.status(400).json({ error: 'Start with POST /api/auth/totp/setup.' });
+  const step = totp.verifyCode(req.body.code, totp.decryptSecret(u.totp_secret_enc), u.totp_last_step);
+  if (!step) return res.status(400).json({ error: 'Invalid code' });
+  db.prepare("UPDATE users SET totp_enabled = 1, totp_last_step = ?, updated_at = strftime('%s','now') WHERE id = ?")
+    .run(step, req.user.id);
+  res.json({ enabled: true, recovery_codes: resetRecoveryCodes(req.user.id) }); // shown ONCE
+});
+
+// Disable: re-auth with a current code (or a recovery code) so a hijacked session
+// can't silently strip MFA. Clears the secret + all recovery codes.
+router.post('/totp/disable', requireAuth, (req, res) => {
+  const u = db.prepare('SELECT totp_secret_enc, totp_enabled, totp_last_step FROM users WHERE id = ?').get(req.user.id);
+  if (!u.totp_enabled) return res.status(400).json({ error: 'TOTP is not enabled.' });
+  const ok = !!totp.verifyCode(req.body.code, totp.decryptSecret(u.totp_secret_enc), u.totp_last_step)
+    || consumeRecoveryCode(req.user.id, req.body.code);
+  if (!ok) return res.status(400).json({ error: 'Invalid code' });
+  db.transaction(() => {
+    db.prepare("UPDATE users SET totp_enabled = 0, totp_secret_enc = NULL, totp_last_step = 0, updated_at = strftime('%s','now') WHERE id = ?").run(req.user.id);
+    db.prepare('DELETE FROM totp_recovery_codes WHERE user_id = ?').run(req.user.id);
+  })();
+  res.json({ enabled: false });
+});
+
+// Regenerate recovery codes: re-auth (current code) + ATOMIC replace (tightening #3).
+router.post('/totp/recovery-codes/regenerate', requireAuth, (req, res) => {
+  const u = db.prepare('SELECT totp_secret_enc, totp_enabled, totp_last_step FROM users WHERE id = ?').get(req.user.id);
+  if (!u.totp_enabled) return res.status(400).json({ error: 'TOTP is not enabled.' });
+  const step = totp.verifyCode(req.body.code, totp.decryptSecret(u.totp_secret_enc), u.totp_last_step);
+  if (!step) return res.status(400).json({ error: 'Invalid code' });
+  db.prepare('UPDATE users SET totp_last_step = ? WHERE id = ?').run(step, req.user.id);
+  res.json({ recovery_codes: resetRecoveryCodes(req.user.id) });
+});
+
+// Second login step: exchange an mfa_pending token + a code (TOTP or recovery) for a
+// full session. Per-route 10/min rate-limit (server.js) + per-user lockout (#87 model).
+router.post('/totp/verify', (req, res) => {
+  const { mfa_token, code } = req.body;
+  if (!mfa_token || !code) return res.status(400).json({ error: 'mfa_token and code required' });
+  let decoded;
+  try { decoded = verifyToken(mfa_token); } catch { return res.status(401).json({ error: 'mfa session expired' }); }
+  if (!decoded.mfa_pending || !decoded.id) return res.status(401).json({ error: 'invalid mfa token' });
+  if (totpLockout.isLocked(decoded.id)) return res.status(429).json({ error: 'Too many invalid codes. Try again later.' });
+
+  const user = db.prepare('SELECT * FROM users WHERE id = ?').get(decoded.id);
+  if (!user || !user.totp_enabled) return res.status(401).json({ error: 'invalid mfa token' });
+
+  // TOTP first (with intra-window replay block via totp_last_step), then a recovery code.
+  const step = totp.verifyCode(code, totp.decryptSecret(user.totp_secret_enc), user.totp_last_step);
+  let viaRecovery = false;
+  if (step) {
+    db.prepare('UPDATE users SET totp_last_step = ? WHERE id = ?').run(step, user.id);
+  } else if (consumeRecoveryCode(user.id, code)) {
+    viaRecovery = true;
+  } else {
+    totpLockout.recordFailure(decoded.id);
+    logFailedLogin(user.email, getClientIp(req), 'Bad TOTP/recovery code');
+    return res.status(401).json({ error: 'Invalid code' });
+  }
+  totpLockout.reset(decoded.id);
+  issueSession(req, res, user, {
+    via_recovery: viaRecovery,
+    recovery_codes_remaining: recoveryCodesRemaining(user.id),
+  });
 });
 
 // ==================== Google OAuth ====================

--- a/server/server.js
+++ b/server/server.js
@@ -271,7 +271,12 @@ app.use('/socket.io-client', express.static(
 const rateLimits = new Map();
 function rateLimit(windowMs, maxRequests) {
   return (req, res, next) => {
-    const key = getClientIp(req) + req.path;
+    // #100: key on the FULL path, not req.path. These limiters are mounted via
+    // app.use('/api/auth/login', ...) etc., and Express strips the mount path, so
+    // req.path was '/' for ALL of them - i.e. /login, /register, /totp/verify shared
+    // ONE per-IP counter (coupled limits; the /totp/verify brute-force limit wasn't
+    // actually independent). originalUrl keeps each endpoint's limit separate.
+    const key = getClientIp(req) + (req.originalUrl || req.url || req.path).split('?')[0];
     const now = Date.now();
     const windowStart = now - windowMs;
     let hits = rateLimits.get(key) || [];
@@ -292,6 +297,10 @@ function rateLimit(windowMs, maxRequests) {
 // Auth routes (public, rate limited)
 app.use('/api/auth/login', rateLimit(60000, 10)); // 10 attempts per minute
 app.use('/api/auth/register', rateLimit(60000, 5)); // 5 registrations per minute
+// #100 (tightening #2): the TOTP verify endpoint is the brute-force surface for a
+// 6-digit code. Cap attempts/min here; the per-user lockout (lib/totp-lockout) sits
+// on top in the handler.
+app.use('/api/auth/totp/verify', rateLimit(60000, 10));
 // Admin password-reset endpoint: even if an admin's session is compromised,
 // cap the blast radius to 20 resets/min/IP. Express matches the longest
 // path prefix first, so this fires before /api/auth catches the request.

--- a/server/test/totp-keyrotation.test.js
+++ b/server/test/totp-keyrotation.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+// #100 key-rotation robustness: secretbox derives its key from JWT_SECRET, so an enrolled
+// user's totp_secret_enc is bound to it. If the key changes (redeploy with a different
+// JWT_SECRET, or a non-persisted .jwt_secret regenerated on a fresh Docker boot), the
+// stored TOTP secret becomes undecryptable. Requirement: the user must NOT be hard-locked
+// out - recovery codes (hashed, key-independent) must still work, and a TOTP attempt must
+// fail CLEANLY (401), never 500. Boots under key A (enroll), reboots under key B (verify).
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+const os = require('node:os');
+const fs = require('node:fs');
+const crypto = require('node:crypto');
+const { authenticator } = require('otplib');
+
+const PORT = 3980;
+const BASE = `http://127.0.0.1:${PORT}`;
+const DATA_DIR = path.join(os.tmpdir(), 'st-totp-rot-' + crypto.randomBytes(4).toString('hex'));
+
+function bootServer(jwtSecret) {
+  const logFd = fs.openSync(path.join(os.tmpdir(), 'st-rot-' + crypto.randomBytes(3).toString('hex') + '.log'), 'w');
+  return spawn('node', ['server.js'], {
+    cwd: path.join(__dirname, '..'),
+    env: { ...process.env, DATA_DIR, SELF_HOSTED: 'true', PORT: String(PORT), NODE_ENV: 'test', JWT_SECRET: jwtSecret },
+    stdio: ['ignore', logFd, logFd],
+  });
+}
+async function waitUp() {
+  for (let i = 0; i < 80; i++) {
+    try { const r = await fetch(BASE + '/api/status'); if (r.ok) return; } catch { /* not yet */ }
+    await new Promise(r => setTimeout(r, 250));
+  }
+  throw new Error('server did not boot');
+}
+async function jfetch(p, opts = {}) {
+  const res = await fetch(BASE + p, opts);
+  let body = null; try { body = await res.json(); } catch { /* non-JSON */ }
+  return { status: res.status, body };
+}
+const post = (o) => ({ method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(o || {}) });
+const postAuth = (tok, o) => ({ method: 'POST', headers: { Authorization: 'Bearer ' + tok, 'Content-Type': 'application/json' }, body: JSON.stringify(o || {}) });
+
+test('#100 key rotation does NOT brick TOTP: recovery survives; TOTP fails cleanly (no 500)', async () => {
+  let proc = bootServer('keyA-' + crypto.randomBytes(8).toString('hex'));
+  try {
+    await waitUp();
+    const email = 'rot' + crypto.randomBytes(4).toString('hex') + '@x.local';
+    const tok = (await jfetch('/api/auth/register', post({ email, password: 'Passw0rd123' }))).body.token;
+    const secret = (await jfetch('/api/auth/totp/setup', postAuth(tok, {}))).body.secret;
+    const recovery = (await jfetch('/api/auth/totp/enable', postAuth(tok, { code: authenticator.generate(secret) }))).body.recovery_codes;
+    assert.equal(recovery.length, 10, 'enrolled under key A');
+
+    proc.kill('SIGKILL'); await new Promise(r => setTimeout(r, 600));
+
+    // Reboot with a DIFFERENT key (same DATA_DIR) -> totp_secret_enc is now undecryptable.
+    proc = bootServer('keyB-' + crypto.randomBytes(8).toString('hex'));
+    await waitUp();
+
+    // password login still issues an MFA challenge
+    const l1 = await jfetch('/api/auth/login', post({ email, password: 'Passw0rd123' }));
+    assert.equal(l1.body.mfa_required, true, 'still challenged after the key change');
+
+    // a TOTP code can't be verified (secret undecryptable) -> CLEAN 401, NEVER 500
+    const totpTry = await jfetch('/api/auth/totp/verify', post({ mfa_token: l1.body.mfa_token, code: authenticator.generate(secret) }));
+    assert.equal(totpTry.status, 401, 'TOTP fails cleanly when the secret cannot be decrypted (not 500)');
+
+    // a RECOVERY code STILL works (hashed, key-independent) -> the user is not bricked
+    const l2 = await jfetch('/api/auth/login', post({ email, password: 'Passw0rd123' }));
+    const rec = await jfetch('/api/auth/totp/verify', post({ mfa_token: l2.body.mfa_token, code: recovery[0] }));
+    assert.ok(rec.body.token, 'recovery code survives the key change -> NOT hard-locked-out');
+  } finally {
+    try { proc.kill('SIGKILL'); } catch { /* ignore */ }
+  }
+});

--- a/server/test/totp-unit.test.js
+++ b/server/test/totp-unit.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+// #100 unit tests: the security-critical assertions that don't need a full server.
+// The bite-test (#1) injects an in-memory db with a real user row so that REMOVING the
+// mfa_pending rejection in requireAuth makes it go red (the pending token would then
+// find the user and call next()).
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const Database = require('better-sqlite3');
+const { authenticator } = require('otplib');
+
+// Inject the db BEFORE requiring middleware/auth so requireAuth queries this one.
+const mem = new Database(':memory:');
+mem.exec(`CREATE TABLE users (id TEXT PRIMARY KEY, email TEXT, name TEXT, role TEXT,
+  auth_provider TEXT, avatar_url TEXT, plan_id TEXT, email_alerts INTEGER,
+  must_change_password INTEGER NOT NULL DEFAULT 0)`);
+mem.prepare("INSERT INTO users (id,email,name,role,auth_provider) VALUES ('u1','u1@x','U1','user','local')").run();
+require.cache[require.resolve('../db/database')] = {
+  id: require.resolve('../db/database'), loaded: true, exports: { db: mem },
+};
+
+const { requireAuth, generateMfaPendingToken, generateToken } = require('../middleware/auth');
+const totp = require('../lib/totp');
+const totpLockout = require('../lib/totp-lockout');
+
+function runRequireAuth(token) {
+  const req = { headers: { authorization: 'Bearer ' + token }, originalUrl: '/api/devices' };
+  let status = 200, nexted = false;
+  const res = { status(s) { status = s; return this; }, json() { return this; } };
+  requireAuth(req, res, () => { nexted = true; });
+  return { status, nexted, req };
+}
+
+test('#100 BITE: requireAuth rejects an mfa_pending token (no password-only session)', () => {
+  const pending = runRequireAuth(generateMfaPendingToken({ id: 'u1' }));
+  assert.equal(pending.status, 401, 'mfa_pending token must be 401');
+  assert.equal(pending.nexted, false, 'must NOT call next() for an mfa_pending token');
+  // Contrast: a FULL token for the SAME user passes - so the user EXISTS in the db,
+  // which means removing the mfa_pending check would let the pending token through too
+  // (next() called). That's what makes this a real bite-test, not a vacuous 401.
+  const full = runRequireAuth(generateToken({ id: 'u1', email: 'u1@x', role: 'user' }, null));
+  assert.equal(full.nexted, true, 'a full token for the same user must pass requireAuth');
+  assert.equal(full.req.user.id, 'u1');
+});
+
+test('#100 lockout: locks after MAX_FAILS, lifts after the window, reset clears', () => {
+  const k = 'user-' + crypto.randomUUID();
+  for (let i = 0; i < totpLockout.MAX_FAILS - 1; i++) totpLockout.recordFailure(k, 1000);
+  assert.equal(totpLockout.isLocked(k, 1000), false);
+  totpLockout.recordFailure(k, 1000);
+  assert.equal(totpLockout.isLocked(k, 1000), true, 'locked at MAX_FAILS');
+  assert.equal(totpLockout.isLocked(k, 1000 + totpLockout.LOCKOUT_MS + 1), false, 'lifts after window');
+  totpLockout.reset(k);
+  assert.equal(totpLockout.isLocked(k, 1000), false, 'reset clears');
+});
+
+test('#100 replay: a TOTP code from an already-consumed step is rejected', () => {
+  const secret = totp.generateSecret();
+  const code = authenticator.generate(secret);
+  const step = totp.currentStep();
+  assert.equal(totp.verifyCode(code, secret, step - 1), step, 'fresh code accepted, returns the step');
+  assert.equal(totp.verifyCode(code, secret, step), null, 'same code at the consumed step is blocked');
+});
+
+test('#100 key-mismatch is graceful: decrypt failure -> null (no throw); verifyCode tolerates null', () => {
+  // If the secretbox key changes (rotated JWT_SECRET, non-persisted .jwt_secret), the
+  // stored TOTP secret becomes undecryptable. That must degrade, not 500.
+  assert.equal(totp.decryptSecret('!!!not-decryptable'), null, 'undecryptable -> null, not a throw');
+  assert.doesNotThrow(() => totp.verifyCode('123456', null, 0), 'null secret must not throw on the login path');
+  assert.equal(totp.verifyCode('123456', null, 0), null, 'null secret -> null (recovery path then handles it)');
+});
+
+test('#100 recovery codes: stored hashed, never plaintext; input normalized', () => {
+  const { plain, hashes } = totp.generateRecoveryCodes(10);
+  assert.equal(plain.length, 10);
+  assert.equal(hashes.length, 10);
+  assert.match(plain[0], /^[0-9A-F]{10}$/, 'plaintext is 10 hex chars (shown once)');
+  assert.match(hashes[0], /^[0-9a-f]{64}$/, 'stored value is a SHA-256 hash');
+  assert.notEqual(plain[0], hashes[0], 'the stored value is not the plaintext');
+  // typed with stray spaces/hyphens/lowercase still matches the stored hash
+  const messy = ' ' + plain[0].toLowerCase().slice(0, 5) + '-' + plain[0].toLowerCase().slice(5) + ' ';
+  assert.equal(totp.hashRecoveryCode(messy), hashes[0], 'normalized input matches');
+});

--- a/server/test/totp.test.js
+++ b/server/test/totp.test.js
@@ -81,6 +81,10 @@ test('/totp/verify completes login via recovery code; single-use; surfaces remai
   assert.ok(v1.body.token, 'recovery code yields a full session token');
   assert.equal(v1.body.via_recovery, true);
   assert.equal(v1.body.recovery_codes_remaining, 9, 'one code consumed');
+  // "secrets never in responses": the encrypted TOTP secret + replay counter must not leak
+  assert.ok(!JSON.stringify(v1.body).includes('totp_secret_enc'), 'no encrypted TOTP secret in the response body');
+  assert.equal(v1.body.user.totp_secret_enc, undefined, 'user object carries no totp_secret_enc');
+  assert.equal(v1.body.user.totp_last_step, undefined, 'user object carries no totp_last_step');
   assert.equal((await jfetch('/api/auth/me', auth(v1.body.token))).status, 200, 'full token works');
   // reuse the SAME recovery code -> rejected (single-use)
   const l2 = await jfetch('/api/auth/login', post(null, { email: u.email, password: PW }));

--- a/server/test/totp.test.js
+++ b/server/test/totp.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+// #100 integration: boots the real server and drives the TOTP route flow end to end.
+// /totp/verify completions use RECOVERY codes (deterministic) - the TOTP-code path +
+// replay are covered in totp-unit.test.js (time-based codes are awkward over HTTP).
+
+const { test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+const os = require('node:os');
+const fs = require('node:fs');
+const crypto = require('node:crypto');
+const { authenticator } = require('otplib');
+
+const PORT = 3979;
+const BASE = `http://127.0.0.1:${PORT}`;
+const DATA_DIR = path.join(os.tmpdir(), 'st-totp-test-' + crypto.randomBytes(4).toString('hex'));
+const LOG = path.join(os.tmpdir(), 'st-totp-' + crypto.randomBytes(4).toString('hex') + '.log');
+let proc;
+
+async function jfetch(p, opts = {}) {
+  const res = await fetch(BASE + p, opts);
+  let body = null; try { body = await res.json(); } catch { /* non-JSON */ }
+  return { status: res.status, body };
+}
+const auth = (tok, extra = {}) => ({ headers: { Authorization: 'Bearer ' + tok, 'Content-Type': 'application/json', ...extra } });
+const post = (tok, obj, extra) => ({ method: 'POST', ...auth(tok, extra), body: JSON.stringify(obj || {}) });
+
+before(async () => {
+  const logFd = fs.openSync(LOG, 'w');
+  proc = spawn('node', ['server.js'], {
+    cwd: path.join(__dirname, '..'),
+    env: { ...process.env, DATA_DIR, SELF_HOSTED: 'true', PORT: String(PORT), NODE_ENV: 'test' },
+    stdio: ['ignore', logFd, logFd],
+  });
+  let up = false;
+  for (let i = 0; i < 80; i++) {
+    try { const r = await fetch(BASE + '/api/status'); if (r.ok) { up = true; break; } } catch { /* not yet */ }
+    await new Promise(r => setTimeout(r, 250));
+  }
+  if (!up) throw new Error('server did not boot:\n' + fs.readFileSync(LOG, 'utf8').slice(-2000));
+});
+after(() => { try { proc.kill('SIGKILL'); } catch { /* ignore */ } });
+
+const PW = 'Passw0rd123';
+async function newUser() {
+  const email = 'u' + crypto.randomBytes(5).toString('hex') + '@x.local';
+  const r = await jfetch('/api/auth/register', post(null, { email, password: PW }));
+  return { email, token: r.body.token };
+}
+async function enroll(token) {
+  const s = await jfetch('/api/auth/totp/setup', post(token, {}));
+  const e = await jfetch('/api/auth/totp/enable', post(token, { code: authenticator.generate(s.body.secret) }));
+  return { secret: s.body.secret, recovery: e.body.recovery_codes };
+}
+
+test('enrollment: setup -> enable issues 10 recovery codes; status reflects it', async () => {
+  const u = await newUser();
+  const { recovery } = await enroll(u.token);
+  assert.equal(recovery.length, 10);
+  const st = await jfetch('/api/auth/totp/status', auth(u.token));
+  assert.equal(st.body.enabled, true);
+  assert.equal(st.body.recovery_codes_remaining, 10);
+});
+
+test('login with TOTP -> mfa_required (no full token); route-level bite: mfa_token 401s a protected route', async () => {
+  const u = await newUser(); await enroll(u.token);
+  const login = await jfetch('/api/auth/login', post(null, { email: u.email, password: PW }));
+  assert.equal(login.body.mfa_required, true);
+  assert.ok(login.body.mfa_token, 'got an mfa_token');
+  assert.equal(login.body.token, undefined, 'NO full session token before the TOTP step');
+  const me = await jfetch('/api/auth/me', auth(login.body.mfa_token));
+  assert.equal(me.status, 401, 'mfa_pending token must 401 a protected route');
+});
+
+test('/totp/verify completes login via recovery code; single-use; surfaces remaining', async () => {
+  const u = await newUser(); const { recovery } = await enroll(u.token);
+  const l1 = await jfetch('/api/auth/login', post(null, { email: u.email, password: PW }));
+  const v1 = await jfetch('/api/auth/totp/verify', post(null, { mfa_token: l1.body.mfa_token, code: recovery[0] }));
+  assert.ok(v1.body.token, 'recovery code yields a full session token');
+  assert.equal(v1.body.via_recovery, true);
+  assert.equal(v1.body.recovery_codes_remaining, 9, 'one code consumed');
+  assert.equal((await jfetch('/api/auth/me', auth(v1.body.token))).status, 200, 'full token works');
+  // reuse the SAME recovery code -> rejected (single-use)
+  const l2 = await jfetch('/api/auth/login', post(null, { email: u.email, password: PW }));
+  const v2 = await jfetch('/api/auth/totp/verify', post(null, { mfa_token: l2.body.mfa_token, code: recovery[0] }));
+  assert.equal(v2.status, 401, 'used recovery code is rejected');
+});
+
+test('API token BYPASSES TOTP: an st_ token works while the owner has TOTP enabled', async () => {
+  const u = await newUser();
+  await enroll(u.token);
+  // the pre-existing session token (issued at register, before enroll) still works -
+  // enabling TOTP does NOT invalidate it - so it can mint an API token:
+  const t = await jfetch('/api/tokens', post(u.token, { name: 'ci', scope: 'read' }));
+  const secret = Object.values(t.body || {}).find(v => typeof v === 'string' && v.startsWith('st_'));
+  assert.ok(secret, 'got an st_ token (existing JWT still valid post-enroll)');
+  const r = await jfetch('/api/devices', auth(secret));
+  assert.equal(r.status, 200, 'st_ token reaches a protected route despite TOTP being on');
+});
+
+test('verify lockout: repeated bad codes -> 429 (per-user, atop the route rate-limit)', async () => {
+  const u = await newUser(); await enroll(u.token);
+  const mfa = (await jfetch('/api/auth/login', post(null, { email: u.email, password: PW }))).body.mfa_token;
+  let last;
+  for (let i = 0; i < 6; i++) {
+    last = await jfetch('/api/auth/totp/verify', post(null, { mfa_token: mfa, code: '000000' }));
+  }
+  assert.equal(last.status, 429, 'locked out after repeated bad codes');
+});


### PR DESCRIPTION
Closes #100 (TOTP scope; passkeys #101 + generic OIDC #102 are tracked separately). Opt-in per-user TOTP for **local** accounts, with single-use recovery codes.

## Design
- **Two-token login**: `/login` returns an `mfa_pending` token when TOTP is on; `/totp/verify` exchanges it (+ a TOTP or recovery code) for a full session.
- **Secret** stored via `secretbox` (AES-256-GCM, reversible — must recompute codes); **recovery codes** SHA-256-hashed (api_tokens discipline), single-use, shown once.
- **API tokens bypass TOTP** and **SSO bypasses** — by construction (the `st_` path never hits `/login`; `/login` filters `auth_provider='local'`). Enabling TOTP doesn't invalidate existing tokens.

## The three tightenings — proven, not deferred
1. **mfa_pending rejection bites** — `requireAuth` 401s any `mfa_pending` JWT; a db-injected bite-test goes **red if the check is removed** (verified by neutralize→red→restore).
2. **/totp/verify rate-limited** — per-route 10/min **+** per-user lockout (5→15min); **replay** blocked via `totp_last_step`.
3. **Recovery codes** — `recovery_codes_remaining` surfaced; regenerate requires re-auth **and** replaces the set atomically.

## Robustness (both verified by tests)
- **Lockfile**: `otplib` pinned `^12.0.1`; lockfile resolves exactly `12.0.1` (v13 is a breaking plugin-rewrite). `npm ci` is deterministic.
- **Key-rotation graceful**: if `JWT_SECRET`/secretbox key changes (redeploy, non-persisted `.jwt_secret`), the TOTP secret becomes undecryptable — `decrypt`→null (no 500), and **recovery codes still work** (key-independent). A key-rotation integration test boots under key A, reboots under key B, and proves recovery survives + TOTP fails cleanly.

## Pre-existing bug fixed
Mounted rate-limiters keyed on `req.path` (stripped to `'/'`) → `/login`+`/register`+`/totp/verify` **shared one per-IP counter**. Fixed to key on `originalUrl` (per-endpoint); the new /totp/verify limit is now actually independent. All 125 existing tests still pass.

**Tests: 136/136** (was 125 + 11 new). 5 commits (schema/deps · primitives · rate-limit fix · login flow+endpoints · tests). For review — not for merge. Doesn't touch the device path; the 1.9.1-beta1/#96 gate is unaffected.