### PR TITLE
fix(server): last-resort uncaughtException/unhandledRejection safety net (#114)

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -8,6 +8,26 @@ const fs = require('fs');
 const config = require('./config');
 const VERSION = require('./version');
 
+// #114: last-resort crash safety net. better-sqlite3 is SYNCHRONOUS, so a constraint
+// violation (e.g. a FK write) inside a socket.io handler with no local try/catch
+// propagates to uncaughtException; Node's default then prints a bare message and exits
+// with NO stack — which is exactly why #114's "FOREIGN KEY constraint failed" couldn't
+// be root-caused. This handler logs the FULL STACK (the file:line of the offending
+// write) then exits(1) so systemd restarts a fresh process. It is NOT catch-and-
+// continue: after an uncaught throw the process state is undefined, so we never keep
+// serving. Registered before everything else so it's in place during startup too.
+// (Verified: uncaughtException does catch a synchronous socket.io-handler throw.)
+function logFatalAndExit(kind, err) {
+  try {
+    const e = err instanceof Error ? err : new Error('Non-error thrown: ' + require('util').inspect(err));
+    process.stderr.write(`\n[FATAL ${kind}] ${new Date().toISOString()}\n${e.stack || e.message}\n`);
+  } catch (_) { /* the death handler must never throw */ }
+  try { require('./db/database').db.close(); } catch (_) { /* best-effort WAL flush */ }
+  process.exit(1);
+}
+process.on('uncaughtException', (err) => logFatalAndExit('uncaughtException', err));
+process.on('unhandledRejection', (reason) => logFatalAndExit('unhandledRejection', reason));
+
 // Ensure upload directories exist
 [config.contentDir, config.screenshotsDir].forEach(dir => {
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });


### PR DESCRIPTION
Part of #114 (the safety net / investigation tool — **not** the root-cause FK fix, which is separate and blocked on the stack trace this produces).

## What
A single, contained top-of-`server.js` last-resort handler:
- `process.on('uncaughtException')` and `process.on('unhandledRejection')` → **log the full `err.stack`** (file:line of the offending write) + ISO timestamp, best-effort `db.close()` (WAL flush), then **`exit(1)`** so systemd restarts fresh.
- **NOT catch-and-continue** — after an uncaught throw the process state is undefined, so it never keeps serving.

## Why
On 1.9.1-beta2 a `FOREIGN KEY constraint failed` **crashed the whole process** with a bare message and **no stack** — which is exactly why it couldn't be root-caused. better-sqlite3 is synchronous, so a constraint throw inside a socket.io handler with no local try/catch propagates to `uncaughtException`; with no handler, Node exits traceless. This net is both the **fleet-wide-crash safety net** and the **investigation tool** (it captures the file:line the next crash needs).

## Design check — verified, not assumed
A synthetic **synchronous FK throw inside a real socket.io handler** IS caught by `uncaughtException`. Captured trace:
```
[FATAL uncaughtException] 2026-06-15T20:53:12.283Z
SqliteError: FOREIGN KEY constraint failed
    at Socket.<anonymous> (/tmp/netcheck.js:32:60)   <- exact file:line of the write
    at Socket.emit (node:events:524:28)
    ...
EXIT CODE: 1
```

## Non-over-reach — verified
The net is a **last resort**, not a catch-all that masks local handling:
- FK throw in an **Express route** → Express handles it (**500**), net does **not** fire.
- FK throw in a **local try/catch** → caught (**200**), net does **not** fire.
- `global net fired: false`; process stays **alive**.

## Validation summary
- ✅ uncaughtException catches a socket.io-handler sync FK throw → full stack + exit(1)
- ✅ Non-over-reach: Express + local try/catch handled locally, net silent, process alive
- ✅ 149 server tests green
- ✅ Server boots clean (net doesn't trip on startup)

Scope: `server/server.js` only. **No root-cause hunting in this PR.**

## Release boundary
Does not go to prod; rides a future beta with the rest. Merge timing your call.
