### PR TITLE
feat(config): HIDE_BILLING flag to hide the Subscription/billing UI (#116)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,12 @@
 # instance never emits mail from a domain that isn't yours.
 SELF_HOSTED=true
 
+# Hide the Subscription/billing UI (nav item + pricing cards) and bounce #/billing to
+# the dashboard. Opt-in; default off (billing shown). For instances that bill customers
+# externally and don't sell plans through the app. UI-only — does not change SELF_HOSTED
+# or disable any /api/subscription endpoints.
+HIDE_BILLING=true
+
 # Close public self-service registration — for instances where all accounts are
 # provisioned by your team (admin "Add user" / invites). When true, the public
 # signup route is blocked (OAuth auto-signup with it) AND the login page hides

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Schema migrations run automatically on first boot — no manual migration comman
 | `HTTPS_PORT` | HTTPS port (used when SSL certs are present) | `3443` |
 | `NODE_ENV` | Runtime env (`production` enables Express production optimizations + stricter error handling) | _(none)_ |
 | `SELF_HOSTED` | First user gets all features unlocked | `false` |
+| `HIDE_BILLING` | Hide the Subscription nav item + billing view; `#/billing` redirects to the dashboard (UI-only, opt-in) | `false` |
 | `DISABLE_REGISTRATION` | Block new account creation (including OAuth auto-signup). First-user setup on an empty DB is still allowed. | `false` |
 | `DISABLE_HOMEPAGE` | Redirect `/` to `/app` instead of serving the marketing landing page. For internal-only self-hosted deployments. | `false` |
 | `APP_URL` | Your public URL (used for Stripe callbacks and invite-accept URLs in emailed invites) | _(none)_ |

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -132,7 +132,7 @@
         </svg>
         <span>Settings</span>
       </a></li>
-      <li><a href="#/billing" class="nav-link" data-view="billing">
+      <li id="billingNavItem"><a href="#/billing" class="nav-link" data-view="billing">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
           <rect x="1" y="4" width="22" height="16" rx="2" ry="2"/>
           <line x1="1" y1="10" x2="23" y2="10"/>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -458,8 +458,17 @@ function route() {
     currentView = settings;
     settings.render(app);
   } else if (hash === '#/billing') {
-    currentView = billing;
-    billing.render(app);
+    // #116: when HIDE_BILLING is set, a direct #/billing navigation is bounced to the
+    // dashboard. replaceState (not a hash assignment) so it doesn't add a history entry
+    // — the back button skips over it instead of looping back into the guard.
+    if (getCurrentUser()?.hide_billing) {
+      history.replaceState(null, '', window.location.pathname + '#/');
+      currentView = dashboard;
+      dashboard.render(app);
+    } else {
+      currentView = billing;
+      billing.render(app);
+    }
   } else {
     currentView = dashboard;
     dashboard.render(app);
@@ -473,6 +482,11 @@ function updateSidebarUser() {
   // Show admin nav only for platform admins (legacy 'superadmin' or Phase 1 renamed 'platform_admin')
   const adminNav = document.getElementById('adminNavItem');
   if (adminNav) adminNav.style.display = isPlatformAdmin(user) ? '' : 'none';
+
+  // #116: hide the Subscription nav item when HIDE_BILLING is set (surfaced on /me).
+  // Runs at boot from the cached user (no flash on warm loads) and again after /me.
+  const billingNav = document.getElementById('billingNavItem');
+  if (billingNav) billingNav.style.display = user.hide_billing ? 'none' : '';
 
   let userEl = document.getElementById('sidebarUser');
   if (!userEl) {

--- a/server/config.js
+++ b/server/config.js
@@ -74,6 +74,10 @@ module.exports = {
   graphDevRestrictTo: process.env.GRAPH_DEV_RESTRICT_TO || '',
   // Self-hosted mode: if true, first user gets enterprise plan and no billing
   selfHosted: process.env.SELF_HOSTED === 'true',
+  // #116: opt-in UI gate. When true, hides the Subscription nav item + billing view
+  // and bounces #/billing to the dashboard. Default off, so existing deployments are
+  // unchanged. UI-only — /api/subscription/* stays in place (internal usage reads).
+  hideBilling: process.env.HIDE_BILLING === 'true',
   // Disable public registration (OAuth auto-signup is also blocked when set).
   // First-user setup is still allowed so a fresh install can be initialized.
   disableRegistration: ['true', '1'].includes(String(process.env.DISABLE_REGISTRATION || '').toLowerCase()),

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -522,6 +522,7 @@ router.get('/me', requireAuth, resolveTenancy, (req, res) => {
 
   res.json({
     ...req.user,
+    hide_billing: config.hideBilling, // #116: client hides the Subscription nav + guards #/billing
     current_workspace_id: req.workspaceId,
     current_workspace: req.workspace ? { id: req.workspace.id, name: req.workspace.name, organization_id: req.workspace.organization_id } : null,
     current_organization: currentOrg,


### PR DESCRIPTION
Closes #116.

## What
Opt-in `HIDE_BILLING` env flag. When set, hides the **Subscription** sidebar item + billing view and bounces `#/billing` to the dashboard. **Default off** — billing shown, existing deployments unaffected. **UI-only**: `/api/subscription/*` is intentionally left in place (other code reads subscription/usage internally) — exactly the scope strobe specced.

## Spec assumptions — verified against code before building
1. ✅ The `adminNavItem` toggle pattern is real (`index.html` `<li id="adminNavItem">` + `app.js` `updateSidebarUser`); this mirrors it.
2. ✅ `/me` is fetched at boot (`refreshCurrentUser`) and stored on the user object; `updateSidebarUser` runs **both at boot (cached user) and post-`/me`**, so the **no-flash claim holds on warm loads**. *Nuance:* a one-time flash is possible on the very first load after the flag flips (cache not yet carrying it) — identical to how the admin nav behaves. Minor, noted.
3. ✅ Route dispatch is an `if/else` chain — guard added at the `#/billing` branch using `history.replaceState('#/')` so the **back button doesn't loop** into the guard.
4. ✅ Scope respected — no server-side subscription guard (UI-only), as strobe scoped.
- Nav label is **static** (`<span>Subscription</span>`, no `data-i18n`), so **no i18n change** needed.

## Changes
- `server/config.js` — `config.hideBilling` from `HIDE_BILLING` (mirrors `selfHosted`).
- `server/routes/auth.js` — `hide_billing` on `GET /api/auth/me`.
- `frontend/index.html` — `id="billingNavItem"` on the Subscription `<li>`.
- `frontend/js/app.js` — toggle in `updateSidebarUser`; `#/billing` redirect guard.
- `.env.example` + `README.md` documented.

## Validation (headless Chrome, both states)
| State | Subscription tab | `#/billing` |
|---|---|---|
| **Default (unset)** | **visible** | **renders** (hash stays) — backward-compat ✓ |
| **`HIDE_BILLING=true`** | **hidden** | **redirects to `#/`** ✓ |
- `config.hideBilling` maps `HIDE_BILLING` both ways; live `/me` default → `hide_billing:false`.
- **149 server tests green.**
- **Default-off = zero change** for existing deployments (and prod 1.8.2, which doesn't carry this code at all).

**Known cosmetic (harmless):** after the redirect the billing nav *link* keeps its `active` class, but the nav item is `display:none` so it's never visible.

## Release boundary
Tiny + zero-risk (default-off). Rides the next beta or folds into 1.9.1 stabilization. **No prod** — merge timing your call.
