### PR TITLE
fix(preview): replace srcdoc with server-side preview sessions to bypass CSP

### DIFF
--- a/frontend/js/views/widgets.js
+++ b/frontend/js/views/widgets.js
@@ -105,7 +105,7 @@ function openContentPicker({ multiple = false, title } = {}) {
   });
 }
 
-function showPreviewModal(html, widgetType) {
+function showPreviewModal(sessionId, widgetType) {
   const overlay = document.createElement('div');
   overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.85);display:flex;align-items:center;justify-content:center;z-index:10000;padding:16px';
   // #104: webpage widgets pointing at frame-denying sites (X-Frame-Options) can't be
@@ -124,12 +124,7 @@ function showPreviewModal(html, widgetType) {
       ${webpageNote}
     </div>`;
   document.body.appendChild(overlay);
-  // srcdoc resolves relative URLs against about:srcdoc, so inject <base> pointing to our origin
-  const baseTag = `<base href="${window.location.origin}/">`;
-  const withBase = /<head[^>]*>/i.test(html)
-    ? html.replace(/<head([^>]*)>/i, `<head$1>${baseTag}`)
-    : html.replace(/<html([^>]*)>/i, `<html$1><head>${baseTag}</head>`);
-  overlay.querySelector('#pvIframe').srcdoc = withBase;
+  overlay.querySelector('#pvIframe').src = '/api/widgets/preview-session/' + sessionId;
   const close = () => overlay.remove();
   overlay.querySelector('#pvClose').onclick = close;
   overlay.onclick = (e) => { if (e.target === overlay) close(); };
@@ -551,14 +546,14 @@ export async function render(container) {
     if (!type) return;
     const config = getConfigFromForm(type);
     try {
-      const res = await fetch('/api/widgets/preview', {
+      const res = await fetch('/api/widgets/preview-session', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${localStorage.getItem('token')}` },
         body: JSON.stringify({ widget_type: type, config }),
       });
       if (!res.ok) throw new Error(t('widget.toast.preview_failed'));
-      const html = await res.text();
-      showPreviewModal(html, type);
+      const { id } = await res.json();
+      showPreviewModal(id, type);
     } catch (err) { showToast(err.message, 'error'); }
   };
 

--- a/server/routes/widgets.js
+++ b/server/routes/widgets.js
@@ -212,6 +212,42 @@ router.post('/preview', (req, res) => {
   res.send(html);
 });
 
+// Preview sessions — ephemeral store so the preview iframe loads via src (not srcdoc)
+// and bypasses the dashboard CSP that would block the widget's inline scripts.
+const previewStore = new Map();
+const PREVIEW_TTL = 5 * 60 * 1000;
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of previewStore) {
+    if (now - entry.created > PREVIEW_TTL) previewStore.delete(key);
+  }
+}, 60 * 1000).unref();
+
+router.post('/preview-session', (req, res) => {
+  const { widget_type, config } = req.body || {};
+  if (!widget_type || typeof widget_type !== 'string') return res.status(400).json({ error: 'widget_type required' });
+  if (!KNOWN_WIDGET_TYPES.has(widget_type)) return res.status(400).json({ error: 'Unknown widget_type' });
+  const id = uuidv4();
+  const html = renderWidgetHtml(widget_type, config || {});
+  previewStore.set(id, { html, widget_type, created: Date.now() });
+  res.json({ id, url: `/api/widgets/preview-session/${id}` });
+});
+
+router.get('/preview-session/:id', (req, res) => {
+  const entry = previewStore.get(req.params.id);
+  if (!entry) return res.status(410).send('Preview expired');
+  if (Date.now() - entry.created > PREVIEW_TTL) {
+    previewStore.delete(req.params.id);
+    return res.status(410).send('Preview expired');
+  }
+  let html = entry.html;
+  if (req.workspaceId) html = inlineUserContent(html, req.workspaceId);
+  res.removeHeader('X-Frame-Options');
+  res.setHeader('Cache-Control', 'no-store');
+  res.setHeader('Content-Type', 'text/html');
+  res.send(html);
+});
+
 function renderClock(c) {
   return `<!DOCTYPE html><html><head><style>
   * { margin:0; padding:0; box-sizing:border-box; }

--- a/server/server.js
+++ b/server/server.js
@@ -125,6 +125,7 @@ app.use((req, res, next) => {
   if (req.path.startsWith('/player')) return next();
   if (req.path === '/docs') return next(); // Redoc API reference needs a relaxed CSP
   if (req.path.startsWith('/api/widgets/') && req.path.endsWith('/render')) return next();
+  if (req.path.startsWith('/api/widgets/preview-session/')) return next();
   if (req.path.startsWith('/api/kiosk/') && req.path.endsWith('/render')) return next();
   return dashboardCsp(req, res, next);
 });
@@ -532,6 +533,7 @@ const { PUBLIC_ROUTERS, JWT_ONLY_ROUTERS, AGENCY_ROUTERS } = require('./config/a
 // Public device-render endpoints + the memory-heavy preview limiter must be registered
 // BEFORE their parent router mount so the _skipAuth bypass / the limiter fire first.
 app.get('/api/widgets/:id/render', (req, res, next) => { req._skipAuth = true; next(); });
+app.get('/api/widgets/preview-session/:id', (req, res, next) => { req._skipAuth = true; next(); });
 app.use('/api/widgets/preview', rateLimit(60000, 30)); // base64 inline = memory-intensive
 app.get('/api/kiosk/:id/render', (req, res, next) => { req._skipAuth = true; next(); });
 

--- a/server/server.js
+++ b/server/server.js
@@ -535,6 +535,7 @@ const { PUBLIC_ROUTERS, JWT_ONLY_ROUTERS, AGENCY_ROUTERS } = require('./config/a
 app.get('/api/widgets/:id/render', (req, res, next) => { req._skipAuth = true; next(); });
 app.get('/api/widgets/preview-session/:id', (req, res, next) => { req._skipAuth = true; next(); });
 app.use('/api/widgets/preview', rateLimit(60000, 30)); // base64 inline = memory-intensive
+app.use('/api/widgets/preview-session', rateLimit(60000, 30)); // preview session creation retains rendered HTML in memory for 5min
 app.get('/api/kiosk/:id/render', (req, res, next) => { req._skipAuth = true; next(); });
 
 for (const r of PUBLIC_ROUTERS) {


### PR DESCRIPTION
## Problem

Widget previews (clock, weather, RSS, etc.) in the dashboard editor appear blank or with static content. The clock preview shows the background color but no running time; the weather preview shows the city name but no fetched weather data.

## Root Cause

The preview modal renders widget HTML via `iframe.srcdoc`, which inherits the parent document's Content-Security-Policy. The dashboard CSP has `script-src 'self'` which blocks inline `<script>` tags. All widgets rely on inline scripts to function (clock uses `setInterval`, weather uses `fetch` to wttr.in, etc.), so they render blank.

The device player works fine because it loads widgets via `src="/api/widgets/:id/render"` which bypasses the CSP middleware.

## Fix

Replace `srcdoc` with **server-side preview sessions** that load via `iframe.src`, following the same CSP-bypass pattern as the existing device render endpoint:

- `POST /api/widgets/preview-session` — stores the rendered HTML in an in-memory store (Map, 5-minute TTL) and returns a session ID
- `GET /api/widgets/preview-session/:id` — serves the HTML with no CSP (bypassed in middleware), no X-Frame-Options, and no auth requirement (via `req._skipAuth`)
- Frontend `showPreviewModal` now takes a `sessionId` and sets `iframe.src` instead of `iframe.srcdoc`

The old `POST /api/widgets/preview` endpoint is unchanged for backward compatibility.

## Files changed

| File | Lines |
|---|---|
| `server/server.js` | +2 (CSP bypass + auth bypass for preview-session route) |
| `server/routes/widgets.js` | +36 (preview session store with TTL cleanup, POST + GET routes) |
| `frontend/js/views/widgets.js` | +5 / -10 (session-based preview instead of srcdoc) |

## Verified

- [x] All 7 widget types preview correctly (POST → session ID → GET render = 200)
- [x] Expired sessions return HTTP 410
- [x] Auth required for session creation (401 without token)
- [x] Original `/api/widgets/preview` endpoint unchanged (200)
- [x] Server boots cleanly, no regressions in startup