### PR TITLE
fix(player): send device_id/token on reconnect before pairing

### DIFF
--- a/server/player/index.html
+++ b/server/player/index.html
@@ -1178,14 +1178,25 @@
 
     function register() {
       const data = {};
-      if (config.deviceId && config.paired) {
+      // #163: always send device identity when we have it, regardless of paired
+      // status. Before this fix, a reconnect before pairing would omit device_id
+      // and device_token, causing the server's fingerprint reclaim guard to fire
+      // device:auth-error ("Authentication failed. Please re-pair this device.")
+      // because the same browser fingerprint looked like a reinstall attack.
+      if (config.deviceId) {
         data.device_id = config.deviceId;
         if (config.deviceToken) data.device_token = config.deviceToken;
-      } else {
-        const code = String(Math.floor(100000 + Math.random() * 900000));
-        config.pairingCode = code;
-        saveConfig(config);
-        data.pairing_code = code;
+      }
+      if (!config.paired) {
+        // Reuse the existing pairing code across reconnects so the operator
+        // doesn't see a new code every time the socket flaps. Only generate a
+        // fresh one on the very first registration when no code exists yet.
+        if (!config.pairingCode) {
+          const code = String(Math.floor(100000 + Math.random() * 900000));
+          config.pairingCode = code;
+          saveConfig(config);
+        }
+        data.pairing_code = config.pairingCode;
       }
       data.device_info = {
         android_version: 'Web/' + navigator.userAgent.split(' ').pop(),


### PR DESCRIPTION
## What

Fixes #163 — web player breaks with "Authentication failed. Please re-pair this device." when the socket reconnects before pairing.

## Root Cause

`server/player/index.html` `register()` only sent `device_id` and `device_token` when `config.paired === true`. On reconnect before pairing, the player sent a fresh `pairing_code` but **no device identity**, making the server treat it as a new anonymous registration. The fingerprint reclaim guard then rejected it because the same browser fingerprint was still "settling" from the first connection.

## Fix

- `device_id` and `device_token` are now sent whenever they exist, regardless of paired status
- The pairing code is reused across reconnects instead of generating a new random code each time
- This keeps the server in the authenticated reconnect path instead of the anonymous registration path

## Why it matters

Self-hosted deployments behind Cloudflare Tunnel (the default for the LXC 180 work-pve-01 setup) experience frequent WebSocket reconnects. Without this fix, the web player is unusable behind a tunnel.

## Verification

- [x] Server-side tests pass (`fingerprint-reclaim.test.js` — 4/4)
- [x] No changes to server logic — purely client-side

## Affected

`server/player/index.html` — `register()` function only