### PR TITLE
feat(seo): integrations internal linking + drop public /api/status link

### DIFF
--- a/frontend/compare/anthias-alternative.html
+++ b/frontend/compare/anthias-alternative.html
@@ -39,6 +39,7 @@
         <a href="/#features">Features</a>
         <a href="/#pricing">Pricing</a>
         <a href="/#compare">Compare</a>
+        <a href="/integrations/">Integrations</a>
         <a href="/app#/login" class="btn btn-outline" style="margin-left:16px">Sign In</a>
         <a href="/app#/login" class="btn btn-primary" style="margin-left:8px">Try Free</a>
       </div>

--- a/frontend/compare/optisigns-alternative.html
+++ b/frontend/compare/optisigns-alternative.html
@@ -39,6 +39,7 @@
         <a href="/#features">Features</a>
         <a href="/#pricing">Pricing</a>
         <a href="/#compare">Compare</a>
+        <a href="/integrations/">Integrations</a>
         <a href="/app#/login" class="btn btn-outline" style="margin-left:16px">Sign In</a>
         <a href="/app#/login" class="btn btn-primary" style="margin-left:8px">Try Free</a>
       </div>

--- a/frontend/compare/screencloud-alternative.html
+++ b/frontend/compare/screencloud-alternative.html
@@ -39,6 +39,7 @@
         <a href="/#features">Features</a>
         <a href="/#pricing">Pricing</a>
         <a href="/#compare">Compare</a>
+        <a href="/integrations/">Integrations</a>
         <a href="/app#/login" class="btn btn-outline" style="margin-left:16px">Sign In</a>
         <a href="/app#/login" class="btn btn-primary" style="margin-left:8px">Try Free</a>
       </div>

--- a/frontend/compare/xibo-alternative.html
+++ b/frontend/compare/xibo-alternative.html
@@ -39,6 +39,7 @@
         <a href="/#features">Features</a>
         <a href="/#pricing">Pricing</a>
         <a href="/#compare">Compare</a>
+        <a href="/integrations/">Integrations</a>
         <a href="/app#/login" class="btn btn-outline" style="margin-left:16px">Sign In</a>
         <a href="/app#/login" class="btn btn-primary" style="margin-left:8px">Try Free</a>
       </div>

--- a/frontend/compare/yodeck-alternative.html
+++ b/frontend/compare/yodeck-alternative.html
@@ -39,6 +39,7 @@
         <a href="/#features">Features</a>
         <a href="/#pricing">Pricing</a>
         <a href="/#compare">Compare</a>
+        <a href="/integrations/">Integrations</a>
         <a href="/app#/login" class="btn btn-outline" style="margin-left:16px">Sign In</a>
         <a href="/app#/login" class="btn btn-primary" style="margin-left:8px">Try Free</a>
       </div>

--- a/frontend/guides/digital-signage-android-tv.html
+++ b/frontend/guides/digital-signage-android-tv.html
@@ -39,6 +39,7 @@
         <a href="/#features">Features</a>
         <a href="/#pricing">Pricing</a>
         <a href="/#compare">Compare</a>
+        <a href="/integrations/">Integrations</a>
         <a href="/app#/login" class="btn btn-outline" style="margin-left:16px">Sign In</a>
         <a href="/app#/login" class="btn btn-primary" style="margin-left:8px">Try Free</a>
       </div>

--- a/frontend/guides/open-source-digital-signage.html
+++ b/frontend/guides/open-source-digital-signage.html
@@ -39,6 +39,7 @@
         <a href="/#features">Features</a>
         <a href="/#pricing">Pricing</a>
         <a href="/#compare">Compare</a>
+        <a href="/integrations/">Integrations</a>
         <a href="/app#/login" class="btn btn-outline" style="margin-left:16px">Sign In</a>
         <a href="/app#/login" class="btn btn-primary" style="margin-left:8px">Try Free</a>
       </div>
@@ -77,7 +78,7 @@
       <li><strong>Multi-screen:</strong> video walls with multi-screen sync, group sync, kiosk mode, and offline-native playback that keeps running when the network drops.</li>
       <li><strong>Management:</strong> live remote control (Android players, with accessibility permission), auto-update/OTA, telemetry, a public API with scoped tokens, an agency portal, and white-label / reseller support.</li>
       <li><strong>Every player is free:</strong> Android TV / Fire TV (native APK), Samsung Tizen (.wgt), LG webOS, Amazon Vega OS, Raspberry Pi (free setup script), and Windows / ChromeOS / any browser via the web player.</li>
-      <li><strong>Native widgets:</strong> YouTube, RSS, Weather, Clock, Text/HTML, Social, and a Directory-board. A universal <strong>Webpage</strong> widget embeds any framable public URL - published Google Slides, Canva, Power BI publish-to-web, and live dashboards.</li>
+      <li><strong>Native widgets:</strong> <a href="/integrations/youtube-digital-signage.html">YouTube</a>, <a href="/integrations/rss-digital-signage.html">RSS</a>, <a href="/integrations/weather-digital-signage.html">Weather</a>, Clock, Text/HTML, Social, and a Directory-board. A universal <strong>Webpage</strong> widget embeds any framable public URL - published <a href="/integrations/google-slides-digital-signage.html">Google Slides</a>, <a href="/integrations/canva-digital-signage.html">Canva</a>, <a href="/integrations/power-bi-digital-signage.html">Power BI</a>, and live dashboards. See all <a href="/integrations/">integrations</a>.</li>
       <li><strong>Self-host switch:</strong> set <code>SELF_HOSTED=true</code> to unlock the enterprise plan, disable subscription and Stripe checks, and run unlimited devices for free.</li>
     </ul>
 

--- a/frontend/guides/raspberry-pi-digital-signage.html
+++ b/frontend/guides/raspberry-pi-digital-signage.html
@@ -39,6 +39,7 @@
         <a href="/#features">Features</a>
         <a href="/#pricing">Pricing</a>
         <a href="/#compare">Compare</a>
+        <a href="/integrations/">Integrations</a>
         <a href="/app#/login" class="btn btn-outline" style="margin-left:16px">Sign In</a>
         <a href="/app#/login" class="btn btn-primary" style="margin-left:8px">Try Free</a>
       </div>

--- a/frontend/guides/self-hosted-digital-signage.html
+++ b/frontend/guides/self-hosted-digital-signage.html
@@ -39,6 +39,7 @@
         <a href="/#features">Features</a>
         <a href="/#pricing">Pricing</a>
         <a href="/#compare">Compare</a>
+        <a href="/integrations/">Integrations</a>
         <a href="/app#/login" class="btn btn-outline" style="margin-left:16px">Sign In</a>
         <a href="/app#/login" class="btn btn-primary" style="margin-left:8px">Try Free</a>
       </div>

--- a/frontend/guides/what-is-digital-signage.html
+++ b/frontend/guides/what-is-digital-signage.html
@@ -39,6 +39,7 @@
         <a href="/#features">Features</a>
         <a href="/#pricing">Pricing</a>
         <a href="/#compare">Compare</a>
+        <a href="/integrations/">Integrations</a>
         <a href="/app#/login" class="btn btn-outline" style="margin-left:16px">Sign In</a>
         <a href="/app#/login" class="btn btn-primary" style="margin-left:8px">Try Free</a>
       </div>
@@ -73,11 +74,11 @@
     <ul>
       <li><strong>Images</strong> - promotions, posters, wayfinding, safety notices.</li>
       <li><strong>Video</strong> - product clips, brand reels, looping ambient content.</li>
-      <li><strong>YouTube</strong> - embed videos or channels directly with a native widget.</li>
+      <li><strong>YouTube</strong> - <a href="/integrations/youtube-digital-signage.html">embed videos or channels</a> directly with a native widget.</li>
       <li><strong>Playlists</strong> - sequences of items that rotate on a schedule, with dayparting and content expiry.</li>
-      <li><strong>Web pages and dashboards</strong> - a universal Webpage widget embeds any framable public URL: published Google Slides, Canva, Power BI publish-to-web, and live BI dashboards.</li>
-      <li><strong>RSS feeds</strong> - headlines, alerts, or any syndicated feed.</li>
-      <li><strong>Weather and clock</strong> - native widgets for local conditions and time.</li>
+      <li><strong>Web pages and dashboards</strong> - a universal Webpage widget embeds any framable public URL: published <a href="/integrations/google-slides-digital-signage.html">Google Slides</a>, <a href="/integrations/canva-digital-signage.html">Canva</a>, <a href="/integrations/power-bi-digital-signage.html">Power BI publish-to-web</a>, and live BI dashboards.</li>
+      <li><strong>RSS feeds</strong> - <a href="/integrations/rss-digital-signage.html">headlines, alerts, or any syndicated feed</a>.</li>
+      <li><strong>Weather and clock</strong> - native <a href="/integrations/weather-digital-signage.html">weather</a> and clock widgets for local conditions and time.</li>
       <li><strong>Menus and directories</strong> - menu boards for QSR/retail and a directory-board widget for building listings.</li>
     </ul>
 

--- a/frontend/integrations/canva-digital-signage.html
+++ b/frontend/integrations/canva-digital-signage.html
@@ -39,6 +39,7 @@
         <a href="/#features">Features</a>
         <a href="/#pricing">Pricing</a>
         <a href="/#compare">Compare</a>
+        <a href="/integrations/">Integrations</a>
         <a href="/app#/login" class="btn btn-outline" style="margin-left:16px">Sign In</a>
         <a href="/app#/login" class="btn btn-primary" style="margin-left:8px">Try Free</a>
       </div>

--- a/frontend/integrations/google-slides-digital-signage.html
+++ b/frontend/integrations/google-slides-digital-signage.html
@@ -39,6 +39,7 @@
         <a href="/#features">Features</a>
         <a href="/#pricing">Pricing</a>
         <a href="/#compare">Compare</a>
+        <a href="/integrations/">Integrations</a>
         <a href="/app#/login" class="btn btn-outline" style="margin-left:16px">Sign In</a>
         <a href="/app#/login" class="btn btn-primary" style="margin-left:8px">Try Free</a>
       </div>

--- a/frontend/integrations/index.html
+++ b/frontend/integrations/index.html
@@ -39,6 +39,7 @@
         <a href="/#features">Features</a>
         <a href="/#pricing">Pricing</a>
         <a href="/#compare">Compare</a>
+        <a href="/integrations/">Integrations</a>
         <a href="/app#/login" class="btn btn-outline" style="margin-left:16px">Sign In</a>
         <a href="/app#/login" class="btn btn-primary" style="margin-left:8px">Try Free</a>
       </div>

--- a/frontend/integrations/power-bi-digital-signage.html
+++ b/frontend/integrations/power-bi-digital-signage.html
@@ -39,6 +39,7 @@
         <a href="/#features">Features</a>
         <a href="/#pricing">Pricing</a>
         <a href="/#compare">Compare</a>
+        <a href="/integrations/">Integrations</a>
         <a href="/app#/login" class="btn btn-outline" style="margin-left:16px">Sign In</a>
         <a href="/app#/login" class="btn btn-primary" style="margin-left:8px">Try Free</a>
       </div>

--- a/frontend/integrations/rss-digital-signage.html
+++ b/frontend/integrations/rss-digital-signage.html
@@ -39,6 +39,7 @@
         <a href="/#features">Features</a>
         <a href="/#pricing">Pricing</a>
         <a href="/#compare">Compare</a>
+        <a href="/integrations/">Integrations</a>
         <a href="/app#/login" class="btn btn-outline" style="margin-left:16px">Sign In</a>
         <a href="/app#/login" class="btn btn-primary" style="margin-left:8px">Try Free</a>
       </div>

--- a/frontend/integrations/weather-digital-signage.html
+++ b/frontend/integrations/weather-digital-signage.html
@@ -39,6 +39,7 @@
         <a href="/#features">Features</a>
         <a href="/#pricing">Pricing</a>
         <a href="/#compare">Compare</a>
+        <a href="/integrations/">Integrations</a>
         <a href="/app#/login" class="btn btn-outline" style="margin-left:16px">Sign In</a>
         <a href="/app#/login" class="btn btn-primary" style="margin-left:8px">Try Free</a>
       </div>

--- a/frontend/integrations/youtube-digital-signage.html
+++ b/frontend/integrations/youtube-digital-signage.html
@@ -39,6 +39,7 @@
         <a href="/#features">Features</a>
         <a href="/#pricing">Pricing</a>
         <a href="/#compare">Compare</a>
+        <a href="/integrations/">Integrations</a>
         <a href="/app#/login" class="btn btn-outline" style="margin-left:16px">Sign In</a>
         <a href="/app#/login" class="btn btn-primary" style="margin-left:8px">Try Free</a>
       </div>

--- a/frontend/landing.html
+++ b/frontend/landing.html
@@ -186,6 +186,7 @@
         <a href="#platforms">Platforms</a>
         <a href="#pricing">Pricing</a>
         <a href="#compare">Compare</a>
+        <a href="/integrations/">Integrations</a>
         <a href="https://github.com/screentinker/screentinker" target="_blank" rel="noopener" aria-label="ScreenTinker on GitHub" class="nav-github" style="margin-left:16px;display:inline-flex;align-items:center;color:var(--muted)">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2c-3.3.7-4-1.6-4-1.6-.6-1.4-1.4-1.8-1.4-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.9 1.3 1.9 1.3 1.1 1.9 2.9 1.4 3.6 1 .1-.8.4-1.4.8-1.7-2.7-.3-5.5-1.3-5.5-6 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2a11 11 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.7 1.7.3 2.9.1 3.2.8.8 1.2 1.9 1.2 3.2 0 4.6-2.8 5.6-5.5 5.9.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 .3"/></svg>
         </a>
@@ -450,7 +451,6 @@
           <a href="https://github.com/screentinker/screentinker" target="_blank" rel="noopener" style="color:var(--muted)">GitHub</a>
           <a href="https://discord.gg/utTdsrqq4Z" target="_blank" rel="noopener" style="color:var(--muted)">Discord</a>
           <a href="https://www.youtube.com/@ScreenTinker" target="_blank" rel="noopener" style="color:var(--muted)">YouTube</a>
-          <a href="/api/status" target="_blank" style="color:var(--muted)">Status</a>
           <a href="/app#/login" style="color:var(--muted)">Sign in</a>
         </div>
       </div>


### PR DESCRIPTION
Strengthens internal linking for the integration pages and stops advertising the status endpoint.

- **Integrations** added to the top nav (landing + all 17 SEO pages)
- 6 integration spokes cross-linked contextually from the what-is and open-source guides (each spoke: 1 inbound link → 5)
- Public **Status** footer link to `/api/status` removed from landing.html (endpoint stays for the admin panel + Docker healthcheck)

Validated locally + already soaking on alpha (screentinker:main-20260713b). Folding into 1.9.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)