### PR TITLE
feat(dashboard): version loading indicator + immediate first poll

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -576,7 +576,7 @@ export function updateVersionIndicator({ version, latest_version, update_availab
 
 // Show loading state while first poll resolves
 const verLabel = document.getElementById('versionLabel');
-if (verLabel) verLabel.textContent = 'Verificando...';
+if (verLabel) verLabel.textContent = t('common.checking');
 
 async function checkVersion() {
   try {

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -570,10 +570,15 @@ let knownHash = null;
 export function updateVersionIndicator({ version, latest_version, update_available }) {
   const label = document.getElementById('versionLabel');
   const badge = document.getElementById('versionBadge');
-  if (label) label.textContent = version ? 'v' + version : '';
+  if (label) label.textContent = version ? 'v' + version : '-';
   if (badge) badge.hidden = !update_available;
 }
-setInterval(async () => {
+
+// Show loading state while first poll resolves
+const verLabel = document.getElementById('versionLabel');
+if (verLabel) verLabel.textContent = 'Verificando...';
+
+async function checkVersion() {
   try {
     const res = await fetch('/api/version');
     const data = await res.json();
@@ -590,7 +595,9 @@ setInterval(async () => {
     }
     updateVersionIndicator(data);
   } catch {}
-}, 15000);
+}
+checkVersion(); // Fire first poll immediately
+setInterval(checkVersion, 15000);
 
 // Session timeout warning - check JWT expiry every minute
 if (isAuthenticated()) {

--- a/frontend/js/i18n/en.js
+++ b/frontend/js/i18n/en.js
@@ -35,6 +35,7 @@ export default {
   'common.saving': 'Saving...',
   'common.deleting': 'Deleting...',
   'common.loading': 'Loading...',
+  'common.checking': 'Checking...',
   'confirm_delete.type_label': 'Type "{name}" to confirm',
   'confirm_delete.failed': 'Action failed',
   'common.connected': 'Connected',

--- a/frontend/js/i18n/es.js
+++ b/frontend/js/i18n/es.js
@@ -31,6 +31,7 @@ export default {
   'common.edit': 'Editar',
   'common.done': 'Listo',
   'common.loading': 'Cargando...',
+  'common.checking': 'Verificando...',
   'common.connected': 'Conectado',
   'common.disconnected': 'Desconectado',
   'common.never': 'Nunca',


### PR DESCRIPTION
## What

- Shows "Verificando..." in the sidebar version indicator while the first API call resolves
- Fires the first version check immediately on page load instead of waiting 15 seconds
- Falls back to "-" when version is unavailable (instead of blank)

## Why

Currently the version label in the sidebar footer stays empty for up to 15 seconds after page load (the first `setInterval` tick). This is visible on hard refresh (Ctrl+Shift+R). After the change:

1. **Instant**: label shows "Verificando..."  
2. **~200ms later**: label updates to "v1.9.7"

## Files

| File | Change |
|------|--------|
| `frontend/js/app.js` | +10 −3 lines |

## Testing

- Dev instance at http://localhost:3001/app — hard refresh and observe sidebar footer
- No new tests needed (purely visual/UX change)
