### PR TITLE
fix(pi-setup): portable Chromium package name (chromium-browser | chromium)

### DIFF
--- a/scripts/raspberry-pi-setup.sh
+++ b/scripts/raspberry-pi-setup.sh
@@ -229,19 +229,28 @@ fi
 # 5. Kiosk display packages
 # ============================================================
 log "Installing kiosk packages..."
+# Chromium's package name differs by distro: Raspberry Pi OS / Ubuntu ship
+# 'chromium-browser', Debian ships 'chromium'. Try the Pi/Ubuntu name first, then
+# fall back to Debian's, so a bundled apt-get can't hard-fail (set -e) on a
+# Debian-based player. No-op if a chromium is already present.
+install_chromium() {
+    if command -v chromium-browser &>/dev/null || command -v chromium &>/dev/null; then
+        return 0
+    fi
+    apt-get install -y -qq chromium-browser >> "$LOG_FILE" 2>&1 || \
+        apt-get install -y -qq chromium >> "$LOG_FILE" 2>&1
+}
 if [ "$HAS_DESKTOP" = false ]; then
-    # Lite: install X11 + Chromium from scratch
+    # Lite: install X11 + helpers, then Chromium (portable package name)
     apt-get install -y -qq \
         xserver-xorg x11-xserver-utils xinit \
-        chromium-browser \
         unclutter xdotool \
         >> "$LOG_FILE" 2>&1
+    install_chromium
 else
     # Desktop: X already running, just ensure Chromium + helpers
     apt-get install -y -qq unclutter xdotool >> "$LOG_FILE" 2>&1
-    if ! command -v chromium-browser &>/dev/null && ! command -v chromium &>/dev/null; then
-        apt-get install -y -qq chromium-browser >> "$LOG_FILE" 2>&1
-    fi
+    install_chromium
 fi
 
 # Find Chromium binary


### PR DESCRIPTION
`raspberry-pi-setup.sh` bundled `chromium-browser` into the X11 `apt-get install`. That package name only exists on **Raspberry Pi OS / Ubuntu**; on **Debian** it's `chromium`, so the combined install hard-failed and `set -e` aborted the whole installer on any Debian-based player.

**Fix:** split Chromium out of the bundle into an `install_chromium()` helper that tries `chromium-browser` then falls back to `chromium` (no-op if already present). `CHROMIUM_BIN` detection already handled either binary.

**Found by** running the installer end-to-end on a Debian arm64 VM (QEMU) standing in for a Pi — it aborted at `E: Package 'chromium-browser' has no installation candidate`. With this fix the installer completes and configures the full kiosk chain (autologin → `screentinker-kiosk.service` → startx → `chromium --kiosk .../player`).

No behavior change on real Raspberry Pi OS (it has `chromium-browser`, so the first attempt succeeds exactly as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)