### PR TITLE
fix(dashboard): remove dead IntersectionObserver from hydrateAuthImages

### DIFF
--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -71,11 +71,10 @@ export function isPlatformAdmin(user) {
   return !!(user && (user.role === 'superadmin' || user.role === 'platform_admin'));
 }
 
-// Lazy-load authenticated images. A plain <img> can't send the Bearer token,
+// Eager-load authenticated images. A plain <img> can't send the Bearer token,
 // and thumbnail/file endpoints require auth — a just-uploaded item's thumbnail
 // 403's without it. We fetch with the token and swap in an object URL.
-// IntersectionObserver keeps it lazy; the object URL is revoked after load.
-let _authImgObserver = null;
+// All matching images load immediately; the object URL is revoked after load.
 export function loadAuthImage(img) {
   const url = img.dataset.authSrc;
   if (!url) return;
@@ -89,24 +88,11 @@ export function loadAuthImage(img) {
     })
     .catch(() => { img.style.opacity = '0.25'; });
 }
+// Load every img[data-auth-src] inside root immediately. loadAuthImage is
+// idempotent (deletes data-auth-src on first call), so re-hydrating a
+// container after dynamic content is safe. Callers adding content
+// asynchronously should re-invoke after DOM insertion.
 export function hydrateAuthImages(root) {
   const imgs = root.querySelectorAll('img[data-auth-src]');
-  if (!imgs.length) return;
-
-  // Load all images immediately; IntersectionObserver is used below
-  // only for images that are off-screen (lazy loading).
-  if (typeof IntersectionObserver === 'undefined') {
-    imgs.forEach(loadAuthImage);
-    return;
-  }
-
-  if (!_authImgObserver) {
-    _authImgObserver = new IntersectionObserver((entries, obs) => {
-      for (const e of entries) if (e.isIntersecting) { obs.unobserve(e.target); loadAuthImage(e.target); }
-    }, { rootMargin: '300px' });
-  }
-
-  // Load every image now — the observer will also fire for them but
-  // loadAuthImage is idempotent (deletes data-auth-src on first call).
-  imgs.forEach(img => { loadAuthImage(img); _authImgObserver.observe(img); });
+  imgs.forEach(loadAuthImage);
 }


### PR DESCRIPTION
Follow-up to #182 — addresses [the owner's review comment](https://github.com/screentinker/screentinker/pull/182#issuecomment-4972343244).

## What

Removes the vestigial `IntersectionObserver` and `_authImgObserver` module state from `hydrateAuthImages`. The function was already eager (loads all images immediately), but the observer was dead code — `loadAuthImage` deletes `data-auth-src` on first call, so the observer's callback never found the attribute.

## Changes

- Removed `_authImgObserver` module variable (line 78)
- Removed IntersectionObserver creation and observation (lines 103-111)
- Simplified `hydrateAuthImages` to `imgs.forEach(loadAuthImage)`
- Fixed comments: "Lazy-load" → "Eager-load", removed incorrect "IntersectionObserver keeps it lazy" claim
- Net: -21 lines, +7 lines

## No behavioral change

All 7 call sites (content-library, playlists, device-detail, widgets) already expected eager loading since that's what the code actually did. The observer was never firing usefully.