### PR TITLE
fix(content): render YouTube Shorts in 9:16 instead of a landscape frame (#184)

### DIFF
--- a/android/app/src/main/java/com/remotedisplay/player/util/WebViewSupport.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/util/WebViewSupport.kt
@@ -93,9 +93,18 @@ object WebViewSupport {
     fun youtubeEmbedHtml(url: String, muted: Boolean = true): String? {
         val id = extractYoutubeId(url) ?: return null
         val mute = if (muted) 1 else 0
+        // Vertical (Shorts) content is tagged st_aspect=vertical at ingest.
+        val vertical = url.contains("st_aspect=vertical")
         val src = "$YT_BASE/embed/$id?autoplay=1&mute=$mute&controls=0&rel=0&modestbranding=1&loop=1&playlist=$id&playsinline=1&enablejsapi=1"
+        // Vertical: center a 9:16 iframe so it fills a portrait panel and pillarboxes
+        // cleanly on landscape, instead of a 100%x100% landscape frame.
+        val css = if (vertical)
+            "html,body{margin:0;padding:0;height:100%;background:#000;overflow:hidden;display:flex;align-items:center;justify-content:center}" +
+            "iframe{display:block;height:100%;aspect-ratio:9/16;max-width:100%;border:0}"
+        else
+            "html,body{margin:0;padding:0;height:100%;background:#000;overflow:hidden}iframe{display:block;width:100%;height:100%;border:0}"
         return "<!DOCTYPE html><html><head><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">" +
-            "<style>html,body{margin:0;padding:0;height:100%;background:#000;overflow:hidden}iframe{display:block;width:100%;height:100%;border:0}</style>" +
+            "<style>$css</style>" +
             "</head><body><iframe src=\"$src\" allow=\"autoplay; encrypted-media\" allowfullscreen></iframe></body></html>"
     }
 }

--- a/server/player/index.html
+++ b/server/player/index.html
@@ -1920,11 +1920,26 @@
       // Destroy old player without triggering side effects (callbacks check generation)
       if (activeYtPlayer) { try { activeYtPlayer.destroy(); } catch {} activeYtPlayer = null; }
 
+      // Vertical (Shorts) content is tagged st_aspect=vertical at ingest. Render it
+      // in a centered 9:16 box so it fills a portrait screen and pillarboxes cleanly
+      // on landscape, instead of the standard 100%x100% landscape frame.
+      const isVertical = /st_aspect=vertical/i.test(src || '') || /st_aspect=vertical/i.test((item && item.remote_url) || '');
+
       // Create a div for the YT player to replace
       const playerDiv = document.createElement('div');
       playerDiv.id = 'yt-player-' + Date.now();
       playerDiv.style.cssText = 'width:100%;height:100%;background:#000';
-      container.appendChild(playerDiv);
+      let mountEl = playerDiv;
+      if (isVertical) {
+        const wrap = document.createElement('div');
+        wrap.style.cssText = 'width:100%;height:100%;background:#000;display:flex;align-items:center;justify-content:center';
+        const inner = document.createElement('div');
+        inner.style.cssText = 'height:100%;aspect-ratio:9/16;max-width:100%';
+        inner.appendChild(playerDiv);
+        wrap.appendChild(inner);
+        mountEl = wrap;
+      }
+      container.appendChild(mountEl);
 
       // Add a click-to-unmute overlay on top of the YouTube iframe
       if (!userHasInteracted) {

--- a/server/routes/content.js
+++ b/server/routes/content.js
@@ -144,21 +144,27 @@ router.post('/youtube', async (req, res) => {
     const videoId = extractYoutubeId(url);
     if (!videoId) return res.status(400).json({ error: 'Invalid YouTube URL' });
 
-    // Fetch video title from YouTube oEmbed if no name provided
+    // Fetch title + aspect from YouTube oEmbed, queried with the ORIGINAL url so a
+    // /shorts/ link reports its true vertical dimensions. A Short is detected from
+    // the /shorts/ URL form OR portrait oEmbed dims (height > width). We persist that
+    // as st_aspect=vertical on the embed URL so every player can render it 9:16
+    // without re-querying oEmbed on each loop (remote_url is the only signal players
+    // get; the /shorts/ origin is otherwise lost after ingest). YouTube ignores the
+    // unknown param, and players read the video id — not the full URL — for the embed.
     let filename = name;
-    if (!filename) {
-      try {
-        const oembedRes = await fetch(`https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${videoId}&format=json`);
-        if (oembedRes.ok) {
-          const oembed = await oembedRes.json();
-          filename = oembed.title;
-        }
-      } catch {}
-    }
+    let isVertical = /\/shorts\//i.test(url);
+    try {
+      const oembedRes = await fetch(`https://www.youtube.com/oembed?url=${encodeURIComponent(url)}&format=json`);
+      if (oembedRes.ok) {
+        const oembed = await oembedRes.json();
+        if (!filename) filename = oembed.title;
+        if (oembed.height && oembed.width && Number(oembed.height) > Number(oembed.width)) isVertical = true;
+      }
+    } catch {}
     if (!filename) filename = `YouTube: ${videoId}`;
 
     const id = uuidv4();
-    const embedUrl = `https://www.youtube.com/embed/${videoId}?autoplay=1&mute=1&controls=0&rel=0&modestbranding=1&loop=1&playlist=${videoId}&enablejsapi=1`;
+    const embedUrl = `https://www.youtube.com/embed/${videoId}?autoplay=1&mute=1&controls=0&rel=0&modestbranding=1&loop=1&playlist=${videoId}&enablejsapi=1${isVertical ? '&st_aspect=vertical' : ''}`;
     // thumbnail_path is a REMOTE URL here; the /api/content/:id/thumbnail route proxies
     // remote thumbnails server-side (so this isn't a local-file path). Future option for
     // CDN independence: download the thumbnail at ingest into contentDir + backfill

--- a/server/test/youtube-shorts.test.js
+++ b/server/test/youtube-shorts.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+// #184 — YouTube Shorts aspect. Verifies the ingest side of Option A: a Short is
+// detected (from the /shorts/ URL form OR portrait oEmbed dims) and persisted as
+// st_aspect=vertical on the stored embed URL, which every player reads to render
+// 9:16. A normal landscape video is left untagged.
+
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+process.env.DATA_DIR = path.join(os.tmpdir(), 'st-yt-' + crypto.randomBytes(4).toString('hex'));
+process.env.SELF_HOSTED = 'true';
+process.env.NODE_ENV = 'test';
+
+const { test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const { db } = require('../db/database');
+const contentRouter = require('../routes/content');
+
+db.pragma('foreign_keys = OFF'); // skip user/workspace FK setup for this unit
+
+// Mock oEmbed. Capture the real fetch first so test HTTP calls still hit the server.
+let oembedResponse = { title: 'Vid', height: 270, width: 480 };
+let oembedOk = true;
+const realFetch = globalThis.fetch;
+globalThis.fetch = async () => ({ ok: oembedOk, json: async () => oembedResponse });
+
+const app = express();
+app.use(express.json());
+app.use((req, _res, next) => { req.user = { id: 'u1' }; req.workspaceId = 'ws1'; next(); });
+app.use('/api/content', contentRouter);
+const server = app.listen(0);
+let base;
+before(async () => { await new Promise(r => server.listening ? r() : server.once('listening', r)); base = `http://127.0.0.1:${server.address().port}`; });
+after(() => { server.close(); globalThis.fetch = realFetch; });
+
+const addYoutube = async (url) => {
+  const r = await realFetch(`${base}/api/content/youtube`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ url }),
+  });
+  return { status: r.status, body: await r.json() };
+};
+
+test('/shorts/ URL is tagged st_aspect=vertical', async () => {
+  oembedResponse = { title: 'A Short', height: 200, width: 113 };
+  const { status, body } = await addYoutube('https://www.youtube.com/shorts/3HiJYYIupd4');
+  assert.equal(status, 201);
+  assert.ok(/\/embed\/3HiJYYIupd4\?/.test(body.remote_url), 'embed URL built with the extracted id');
+  assert.ok(/st_aspect=vertical/.test(body.remote_url), 'Short tagged vertical');
+});
+
+test('watch URL with portrait oEmbed dims is tagged vertical', async () => {
+  oembedResponse = { title: 'Vertical watch', height: 1920, width: 1080 };
+  const { body } = await addYoutube('https://www.youtube.com/watch?v=3HiJYYIupd4');
+  assert.ok(/st_aspect=vertical/.test(body.remote_url), 'portrait dims -> vertical');
+});
+
+test('normal landscape watch URL is NOT tagged', async () => {
+  oembedResponse = { title: 'Normal', height: 270, width: 480 };
+  const { body } = await addYoutube('https://www.youtube.com/watch?v=abcdefghijk');
+  assert.ok(!/st_aspect=vertical/.test(body.remote_url), 'landscape stays untagged');
+});
+
+test('/shorts/ URL is tagged even when oEmbed fails', async () => {
+  oembedOk = false;
+  const { body } = await addYoutube('https://www.youtube.com/shorts/zzzzzzzzzzz');
+  assert.ok(/st_aspect=vertical/.test(body.remote_url), 'the /shorts/ form alone is sufficient');
+  oembedOk = true;
+});

--- a/tizen/js/player.js
+++ b/tizen/js/player.js
@@ -451,9 +451,10 @@ PlaylistPlayer.prototype.renderVideo = function (item, single) {
 PlaylistPlayer.prototype.renderYouTube = function (item, single) {
   var id = this.youtubeId(item.remote_url);
   if (!id) { this.skipSoon(); return; }
+  var vertical = /st_aspect=vertical/.test(item.remote_url || '');
   var src = 'https://www.youtube.com/embed/' + id +
     '?autoplay=1&mute=1&controls=0&rel=0&modestbranding=1&loop=1&playlist=' + id + '&playsinline=1';
-  this.renderFrame(src, single ? 0 : this.durationMs(item), 'autoplay; encrypted-media');
+  this.renderFrame(src, single ? 0 : this.durationMs(item), 'autoplay; encrypted-media', vertical);
 };
 
 PlaylistPlayer.prototype.renderWidget = function (item, single) {
@@ -461,11 +462,14 @@ PlaylistPlayer.prototype.renderWidget = function (item, single) {
   this.renderFrame(src, single ? 0 : this.durationMs(item));
 };
 
-PlaylistPlayer.prototype.renderFrame = function (src, advanceMs, allow) {
+PlaylistPlayer.prototype.renderFrame = function (src, advanceMs, allow, vertical) {
   var f = document.createElement('iframe');
   f.setAttribute('frameborder', '0');
   f.setAttribute('allowfullscreen', '');
   if (allow) f.setAttribute('allow', allow);
+  // Vertical (Shorts): center a 9:16 iframe on the black stage instead of the
+  // stylesheet's full-bleed 100%x100% (which pillarboxes vertical video badly).
+  if (vertical) f.style.cssText = 'position:absolute;top:0;bottom:0;left:0;right:0;margin:auto;height:100%;width:auto;aspect-ratio:9/16;max-width:100%;border:0';
   f.src = src;
   this.stage.appendChild(f);
   if (advanceMs > 0) this.schedule(advanceMs);
@@ -645,9 +649,10 @@ ZoneRenderer.prototype.showItem = function (zone, list, index) {
     if (mime === 'video/youtube') {
       var yid = zrYoutubeId(a.remote_url);
       if (!yid) { if (multi) this.scheduleAdvance(zone, 2000, advance); return; }
+      var yvert = /st_aspect=vertical/.test(a.remote_url || '');
       var ysrc = 'https://www.youtube.com/embed/' + yid +
         '?autoplay=1&mute=1&controls=0&rel=0&modestbranding=1&loop=1&playlist=' + yid + '&playsinline=1';
-      zone.el.appendChild(zrFrame(ysrc, 'autoplay; encrypted-media'));
+      zone.el.appendChild(zrFrame(ysrc, 'autoplay; encrypted-media', yvert));
       if (multi) this.scheduleAdvance(zone, dur, advance);
     } else if (a.widget_type || (a.widget_id && !a.content_id)) {
       zone.el.appendChild(zrFrame(this.getBase() + '/api/widgets/' + a.widget_id + '/render'));
@@ -695,11 +700,12 @@ function zrFitClass(fit) {
   if (f === 'fill' || f === 'stretch') return 'fill';
   return 'cover';
 }
-function zrFrame(src, allow) {
+function zrFrame(src, allow, vertical) {
   var f = document.createElement('iframe');
   f.setAttribute('frameborder', '0');
   f.setAttribute('allowfullscreen', '');
   if (allow) f.setAttribute('allow', allow);
+  if (vertical) f.style.cssText = 'position:absolute;top:0;bottom:0;left:0;right:0;margin:auto;height:100%;width:auto;aspect-ratio:9/16;max-width:100%;border:0';
   f.src = src;
   return f;
 }


### PR DESCRIPTION
Closes #184.

## Problem
Vertical YouTube Shorts were played in a player forced to `width:100%;height:100%` on a landscape frame, so they rendered pillarboxed/small instead of filling a portrait screen. (Embeddable Shorts *do* play — this is an aspect-ratio/presentation bug, not "playback broken.")

## Fix — Option A (detect + correct aspect)
The "is a Short" signal is lost after ingest (`remote_url` only holds the `/embed/VIDEO_ID` URL), so detection happens **at ingest and is persisted**, then every player honors it — no per-loop oEmbed round-trip.

- **Ingest (`server/routes/content.js`)** — detect vertical from the `/shorts/` URL form **or** portrait oEmbed dims (oEmbed is now queried with the *original* URL so a Short reports its true dimensions), and persist it as `st_aspect=vertical` on the stored embed URL. YouTube ignores the unknown param; players read the video id — not the full URL — to build the embed.
- **Players read `st_aspect=vertical` and center a 9:16 box** (fills a portrait screen, pillarboxes cleanly on landscape) instead of `100%×100%`:
  - Web — `server/player/index.html` `createYoutubeEmbed`
  - Android — `WebViewSupport.youtubeEmbedHtml`
  - Tizen — `player.js` single-zone (`renderFrame`) + zone (`zrFrame`) paths
- Dashboard library uses a static thumbnail (not a live embed), so it's unaffected.

**Not** Option B (yt-dlp): runtime dep + storage/bandwidth + maintenance churn + YouTube ToS exposure, and embed-disabled Shorts already skip gracefully (`onError 101/150`). Rationale in the #184 review comment.

## Tests
`server/test/youtube-shorts.test.js` (4): `/shorts/` and portrait-dims tag vertical; a normal landscape watch URL stays untagged; `/shorts/` tags even when oEmbed fails. Existing content/widget suites still green. Android `:app:compileDebugKotlin` → exit 0; web-player inline JS + Tizen `player.js` parse clean.

## Notes
- Pre-existing Shorts added before this aren't retagged (their `remote_url` has no marker) — re-add to fix, or a small oEmbed backfill as a follow-up.
- Final visual confirmation is a real-device smoke test with an actual Short (playback rendering can't be fully proven headless without live YouTube).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
