### PR TITLE
fix(android): soft keyboard for PIN/URL dialogs over immersive fullscreen

### DIFF
--- a/android/app/src/main/java/com/remotedisplay/player/MainActivity.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/MainActivity.kt
@@ -999,6 +999,26 @@ class MainActivity : AppCompatActivity() {
         handler.postDelayed(backTapRunnable!!, TAP_WINDOW_MS)
     }
 
+    // Show a dialog containing a text field over the IMMERSIVE_STICKY fullscreen so the soft
+    // keyboard actually attaches. A dialog shown over an immersive activity otherwise doesn't gain
+    // window focus -> its EditText gets no cursor/IME, so on a kiosk with no hardware keyboard the
+    // PIN/URL can't be typed. Fix: mark the dialog NOT_FOCUSABLE *before* show() so it doesn't steal
+    // focus and reset the activity's immersive flags; mirror those flags onto the dialog; then clear
+    // NOT_FOCUSABLE *after* show() so the IME can attach to the focused field.
+    @Suppress("DEPRECATION")
+    private fun showImeDialog(dialog: AlertDialog, focus: android.view.View?) {
+        val w = dialog.window
+        w?.setFlags(
+            android.view.WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
+            android.view.WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+        )
+        w?.decorView?.systemUiVisibility = window.decorView.systemUiVisibility
+        dialog.show()
+        w?.clearFlags(android.view.WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)
+        w?.setSoftInputMode(android.view.WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
+        focus?.requestFocus()
+    }
+
     private fun showPinDialog() {
         val input = EditText(this).apply {
             inputType = android.text.InputType.TYPE_CLASS_NUMBER or android.text.InputType.TYPE_NUMBER_VARIATION_PASSWORD
@@ -1011,7 +1031,7 @@ class MainActivity : AppCompatActivity() {
             addView(input)
         }
 
-        AlertDialog.Builder(this)
+        val dialog = AlertDialog.Builder(this)
             .setTitle(getString(R.string.settings_pin_title))
             .setView(container)
             .setPositiveButton(android.R.string.ok) { _, _ ->
@@ -1022,7 +1042,8 @@ class MainActivity : AppCompatActivity() {
                 }
             }
             .setNegativeButton(android.R.string.cancel, null)
-            .show()
+            .create()
+        showImeDialog(dialog, input)
     }
 
     private fun showSettingsDialog() {
@@ -1115,7 +1136,7 @@ class MainActivity : AppCompatActivity() {
             addView(input)
         }
 
-        AlertDialog.Builder(this)
+        val dialog = AlertDialog.Builder(this)
             .setTitle(getString(R.string.settings_change_server))
             .setView(container)
             .setPositiveButton(getString(R.string.settings_save)) { _, _ ->
@@ -1126,7 +1147,8 @@ class MainActivity : AppCompatActivity() {
                 }
             }
             .setNegativeButton(android.R.string.cancel, null)
-            .show()
+            .create()
+        showImeDialog(dialog, input)
     }
 
     private fun showPermissionsDialog() {


### PR DESCRIPTION
## Problem
On kiosk devices you can't type into the hidden-settings **PIN box** (opened via 2× back) — nor the **change-server URL** dialog. Both are plain `AlertDialog`s with an `EditText`, shown over the player's `SYSTEM_UI_FLAG_IMMERSIVE_STICKY` fullscreen activity. A dialog over an immersive-sticky activity **doesn't gain window focus**, so the soft keyboard never attaches and the field gets no cursor. On a panel/Fire TV with no hardware keyboard, the PIN simply can't be entered.

**Pre-existing** — `showPinDialog` hasn't changed since it was added (`c7f1eed`) and the immersive flags date to the initial release; it just surfaces on tier-0 kiosk devices where immersive is active. Not related to any recent change. Reported in the context of #170's device testing.

## Fix
Shared `showImeDialog()` applies the well-established immersive-dialog IME workaround:
1. mark the dialog window `FLAG_NOT_FOCUSABLE` **before** `show()` (so it doesn't steal focus and reset the activity's immersive flags),
2. mirror the activity's immersive `systemUiVisibility` onto the dialog,
3. **clear** `FLAG_NOT_FOCUSABLE` after `show()` so the IME can attach to the focused field,
4. `SOFT_INPUT_STATE_ALWAYS_VISIBLE` + `input.requestFocus()`.

Routed both the PIN and change-server dialogs through it. Additive and low-risk (only changes how those two text dialogs present the keyboard).

## Validation
`:app:compileDebugKotlin` clean. **The IME behavior can't be exercised headless** — needs a smoke test on a real tier-0 panel / Fire TV: 2× back → PIN box → confirm the keyboard appears and the PIN types. Recommend confirming on a repro device before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
