### PR TITLE
fix(widgets): CORP header on the route that actually serves content images

### DIFF
--- a/server/routes/content.js
+++ b/server/routes/content.js
@@ -347,12 +347,6 @@ router.get('/:id/file', (req, res) => {
   // Prevent path traversal
   const safePath = path.resolve(config.contentDir, path.basename(content.filepath));
   if (!safePath.startsWith(path.resolve(config.contentDir))) return res.status(403).json({ error: 'Invalid path' });
-  // Widget boards (logo/background images) render inside the player's sandboxed
-  // (opaque-origin) widget iframe, so these image requests are cross-origin. Without
-  // CORP: cross-origin the helmet default (same-origin) blocks them (NS_ERROR_DOM_CORP_FAILED,
-  // 0 bytes). Matches the /uploads/content static route. Content already serves publicly.
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
   res.sendFile(safePath);
 });
 
@@ -363,9 +357,6 @@ router.get('/:id/thumbnail', (req, res) => {
   if (!content.thumbnail_path) return res.status(404).json({ error: 'Thumbnail not found' });
   const safePath = path.resolve(config.contentDir, path.basename(content.thumbnail_path));
   if (!safePath.startsWith(path.resolve(config.contentDir))) return res.status(403).json({ error: 'Invalid path' });
-  // See /:id/file — cross-origin so sandboxed widget iframes can load it.
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
   res.sendFile(safePath);
 });
 

--- a/server/server.js
+++ b/server/server.js
@@ -469,6 +469,13 @@ app.get('/api/content/:id/file', (req, res) => {
   if (!inPlaylist && !inWidget && !requesterCanAccessContent(req, content)) return res.status(403).json({ error: 'Content not assigned to any playlist or widget' });
   const safePath = path.resolve(config.contentDir, path.basename(content.filepath));
   if (!safePath.startsWith(path.resolve(config.contentDir))) return res.status(403).json({ error: 'Invalid path' });
+  // Widget boards (logo / background images) render inside the player's sandboxed
+  // (opaque-origin) widget iframe, so these image loads are cross-origin. The helmet
+  // default CORP: same-origin blocks them (NS_ERROR_DOM_CORP_FAILED, 0 bytes). Allow
+  // cross-origin — matches the /uploads/content static route; this content is already
+  // served here without auth (playlist/widget-gated above).
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
   res.sendFile(safePath);
 });
 
@@ -488,6 +495,8 @@ async function proxyRemoteThumbnail(url, res) {
     const buf = Buffer.from(await upstream.arrayBuffer());
     res.set('Content-Type', ct);
     res.set('Cache-Control', 'public, max-age=86400');
+    res.set('Access-Control-Allow-Origin', '*');
+    res.set('Cross-Origin-Resource-Policy', 'cross-origin'); // load in sandboxed widget iframes
     return res.send(buf);
   } catch (e) {
     return res.status(502).json({ error: 'Thumbnail fetch failed' });
@@ -513,6 +522,9 @@ app.get('/api/content/:id/thumbnail', (req, res) => {
   if (/^https?:\/\//i.test(content.thumbnail_path)) return proxyRemoteThumbnail(content.thumbnail_path, res);
   const safePath = path.resolve(config.contentDir, path.basename(content.thumbnail_path));
   if (!safePath.startsWith(path.resolve(config.contentDir))) return res.status(403).json({ error: 'Invalid path' });
+  // See /file — cross-origin so sandboxed widget iframes can load it.
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
   res.sendFile(safePath);
 });
 


### PR DESCRIPTION
Follow-up to #195 — the CORP fix there was on the wrong (shadowed) handler.

`server.js` registers a **public** `app.get('/api/content/:id/file')` and `/thumbnail` **before** the auth-gated content router. Those public routes (gated by a playlist/widget reference) are what actually serve widget logo/background images. The `#195` change to `routes/content.js` `/:id/file` was therefore dead — origin kept returning `Cross-Origin-Resource-Policy: same-origin`, so the player's sandboxed (opaque-origin) widget iframe still got `NS_ERROR_DOM_CORP_FAILED` / 0 bytes.

This moves the fix to the real routes: `Access-Control-Allow-Origin: *` + `Cross-Origin-Resource-Policy: cross-origin` on **/file**, **/thumbnail** (local), and the **remote-thumbnail proxy**. Reverts the dead `content.js` edit.

Diagnosed live: origin (bypassing Cloudflare, `cf-cache-status: DYNAMIC`) still served `same-origin` after the #195 deploy → traced to the shadowing public route.

Full suite **486/486**. Will verify on the origin (`curl` → `cross-origin`) after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)