### PR TITLE
fix(android): stop zero-duration widget self-loop pegging the main thread

### DIFF
--- a/android/app/src/main/java/com/remotedisplay/player/player/PlaylistController.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/player/PlaylistController.kt
@@ -36,7 +36,13 @@ class PlaylistController(
     // nothing has ever played (fresh device). Never used while content is on screen.
     private val onWaitingForContent: (() -> Unit)? = null
 ) {
-    private companion object { const val CONTENT_RECHECK_MS = 3000L }
+    private companion object {
+        const val CONTENT_RECHECK_MS = 3000L
+        // Backstop against a busy-loop: an auto-advance is never scheduled faster than
+        // this, so a bad/zero duration on any path can't peg the main thread (see #widget
+        // zero-duration self-loop — a solo fullscreen widget with duration_sec=0).
+        const val MIN_ADVANCE_MS = 500L
+    }
 
     private val items = mutableListOf<PlaylistItem>()
     private var currentIndex = -1
@@ -325,14 +331,19 @@ class PlaylistController(
         // for the completion callback. Wall followers never auto-advance — the
         // leader's wall:sync index drives every switch.
         if (!wallFollower && (item.mimeType.startsWith("image/") || item.isWidget)) {
-            scheduleAdvance(item.durationSec * 1000L)
+            // slotMs() floors a zero/negative duration to 10s (the max(1, duration||10)
+            // contract shared with the web/Tizen players). A raw durationSec*1000 here let a
+            // solo fullscreen widget with duration_sec=0 schedule a 0ms advance -> self-loop.
+            scheduleAdvance(slotMs(item))
         }
     }
 
     private fun scheduleAdvance(delayMs: Long) {
         cancelAdvance()
+        // Backstop: never busy-loop, even if a future caller passes a tiny/zero delay.
+        val safeDelayMs = maxOf(delayMs, MIN_ADVANCE_MS)
         advanceRunnable = Runnable { next() }
-        handler.postDelayed(advanceRunnable!!, delayMs)
+        handler.postDelayed(advanceRunnable!!, safeDelayMs)
     }
 
     private fun cancelAdvance() {


### PR DESCRIPTION
## Problem
A solo fullscreen widget (or image) with `duration_sec=0` scheduled a **0ms** auto-advance in `PlaylistController.playCurrentItem()` (`scheduleAdvance(item.durationSec * 1000L)`). For a single-item playlist, `next()` re-selects the same item, so it re-played on **every looper tick (~20×/sec)** — black-screening the TV and locking the UI (couldn't even reach home).

Surfaced in the field on 1.9.9: a screen ran fine for hours, then its schedule collapsed to a single always-on duration-0 widget and it black-screened. Remote debug showed `playItem` / `Layout: SINGLE/FULLSCREEN` spamming ~20 lines/sec on the same widget (`647c12a9-…`, "Right- Info").

## Fix
- `playCurrentItem()` now uses `slotMs(item)` — the `max(1, duration||10)` contract already shared with the web/Tizen players — so a zero/negative duration floors to **10s** instead of 0ms.
- `scheduleAdvance()` floors any delay to `MIN_ADVANCE_MS` (**500ms**) as a backstop, so no present or future path can busy-loop the main thread.

## Testing
- `./gradlew :app:compileDebugKotlin` — **BUILD SUCCESSFUL**, no errors, no new warnings from the change.
- Not runtime-tested on device.

## Notes
- **No version bump** (per release discipline — the bump is a separate dedicated commit on main after merge).
- **Immediate field mitigation** without this build: set a non-zero duration on the affected widget assignment; the player patches `durationSec` in place, breaking the live loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)