### PR TITLE
feat(directory-board): compositor panel-ring scroll + in-place refresh + per-device frame diagnostic

### DIFF
--- a/android/app/src/main/java/com/remotedisplay/player/MainActivity.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/MainActivity.kt
@@ -545,13 +545,13 @@ class MainActivity : AppCompatActivity() {
                         playerView.visibility = View.GONE
                         imageView.visibility = View.GONE
                         zoneManager?.setupZones(layoutZones, layoutId)
-                        zoneManager?.renderAssignments(assignments, config.serverUrl, contentCache)
+                        zoneManager?.renderAssignments(assignments, config.serverUrl, contentCache, config.deviceId)
                         zoneManager?.lastAssignmentSig = assignmentSig
                     }
                 } else if (changed) {
                     Log.i("MainActivity", "Multi-zone assignments changed, re-rendering")
                     handler.post {
-                        zoneManager?.renderAssignments(assignments, config.serverUrl, contentCache)
+                        zoneManager?.renderAssignments(assignments, config.serverUrl, contentCache, config.deviceId)
                         zoneManager?.lastAssignmentSig = assignmentSig
                     }
                 } else {
@@ -832,7 +832,8 @@ class MainActivity : AppCompatActivity() {
         // layouts; multi-zone widgets go through ZoneManager). Previously unhandled,
         // so widgets were blank/broken in default-fullscreen and the fullscreen template.
         if (item.isWidget) {
-            val url = "${config.serverUrl}/api/widgets/${item.widgetId}/render"
+            val url = "${config.serverUrl}/api/widgets/${item.widgetId}/render" +
+                (if (config.deviceId.isNotEmpty()) "?device=" + android.net.Uri.encode(config.deviceId) else "")
             Log.i("MainActivity", "Playing widget fullscreen: $url")
             mediaPlayer.showWidget(url)
             wsService?.sendPlaybackState(item.contentId.ifEmpty { item.widgetId ?: "" }, 0f)

--- a/android/app/src/main/java/com/remotedisplay/player/player/ZoneManager.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/player/ZoneManager.kt
@@ -45,6 +45,7 @@ class ZoneManager(
     private var zones = listOf<Zone>()
     // Render context kept for rotation re-renders.
     private var renderServerUrl = ""
+    private var renderDeviceId = "" // appended to widget render URLs so widgets can report per-device
     private var renderCache: com.remotedisplay.player.data.ContentCache? = null
 
     var currentLayoutId: String? = null
@@ -77,7 +78,7 @@ class ZoneManager(
         Log.i(TAG, "Setup ${zones.size} zones")
     }
 
-    fun renderAssignments(assignments: JSONArray, serverUrl: String, contentCache: com.remotedisplay.player.data.ContentCache) {
+    fun renderAssignments(assignments: JSONArray, serverUrl: String, contentCache: com.remotedisplay.player.data.ContentCache, deviceId: String = "") {
         // Clear ONLY our own zone views/timers. `container` is the activity root and
         // also holds the static playerView/imageView/youtubeWebView/statusOverlay -
         // removeAllViews() here would detach those and black the screen on switch-back.
@@ -86,13 +87,14 @@ class ZoneManager(
         zoneViews.clear()
         releaseExoPlayers()
         renderServerUrl = serverUrl
+        renderDeviceId = deviceId
         renderCache = contentCache
 
         val containerWidth = container.width
         val containerHeight = container.height
         if (containerWidth == 0 || containerHeight == 0) {
             // Container not laid out yet, retry after layout.
-            container.post { renderAssignments(assignments, serverUrl, contentCache) }
+            container.post { renderAssignments(assignments, serverUrl, contentCache, deviceId) }
             return
         }
 
@@ -205,7 +207,9 @@ class ZoneManager(
             widgetType != null -> {
                 val widgetId = a.optString("widget_id", "")
                 val webView = createWebView()
-                webView.loadUrl("$renderServerUrl/api/widgets/$widgetId/render")
+                val wUrl = "$renderServerUrl/api/widgets/$widgetId/render" +
+                    (if (renderDeviceId.isNotEmpty()) "?device=" + android.net.Uri.encode(renderDeviceId) else "")
+                webView.loadUrl(wUrl)
                 webView.layoutParams = params
                 container.addView(webView); zoneViews[zone.id] = webView
                 if (multi) scheduleZoneAdvance(zone.id, durationMs, advance)

--- a/frontend/js/views/device-detail.js
+++ b/frontend/js/views/device-detail.js
@@ -11,6 +11,7 @@ let screenshotHandler = null;
 let playbackHandler = null;
 let logHandler = null;
 let shellHandler = null;
+let diagPollTimer = null; // polls a diag-smoothness widget's reported frame stats while the page is open
 let screenshotInterval = null;
 let remoteActive = false;
 
@@ -172,6 +173,7 @@ async function loadDevice(deviceId, activeTab = null) {
     const device = await api.getDevice(deviceId);
     currentDevice = device;
     const latestTelemetry = device.telemetry?.[0] || {};
+    const diagWidget = (device.assignments || []).find(a => a && a.widget_type === 'diag-smoothness');
 
     contentEl.innerHTML = `
       <div class="device-header">
@@ -290,6 +292,7 @@ async function loadDevice(deviceId, activeTab = null) {
 
       <!-- Info Tab -->
       <div class="tab-content" id="tab-info">
+        ${diagWidget ? renderDiagPanel(diagWidget) : ''}
         <div class="info-grid">
           <div class="info-card">
             <div class="info-card-label">${t('device.info.status')}</div>
@@ -614,6 +617,8 @@ async function loadDevice(deviceId, activeTab = null) {
         <div style="font-size:10px;color:var(--text-muted);margin-top:4px">${t('device.terminal.push_apk_hint')}</div>
       </div>` : ''}
     `;
+    // If this device is assigned the smoothness-diagnostic widget, poll THIS device's reported stats.
+    if (diagWidget) startDiagPoll(diagWidget.widget_id, deviceId);
     // Hydrate authenticated thumbnail images in the playlist tab
     const pc = document.getElementById('playlistContainer');
     if (pc) hydrateAuthImages(pc);
@@ -1870,7 +1875,69 @@ function updateTelemetryDisplay(telemetry) {
   if (telemetry.cpu_usage != null) update('telCpu', telemetry.cpu_usage.toFixed(1) + '%');
 }
 
+// ----- diag-smoothness widget: show the frame stats it reports from the panel -----
+function renderDiagPanel(w) {
+  return `
+    <div class="info-card" id="diagCard" style="grid-column:1/-1;margin-bottom:16px">
+      <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:12px">
+        <div class="info-card-label">Frame-rate diagnostic${w.widget_name ? ' · ' + esc(w.widget_name) : ''}</div>
+        <span id="diagVerdict" style="font-weight:700;font-size:15px;color:var(--text-muted)">waiting for panel…</span>
+      </div>
+      <div class="info-grid" style="grid-template-columns:repeat(4,minmax(0,1fr));gap:10px">
+        <div class="info-card"><div class="info-card-label">FPS</div><div class="info-card-value" id="diagFps">--</div></div>
+        <div class="info-card"><div class="info-card-label">Refresh</div><div class="info-card-value" id="diagHz">--</div></div>
+        <div class="info-card"><div class="info-card-label">Long frames</div><div class="info-card-value" id="diagLong">--</div></div>
+        <div class="info-card"><div class="info-card-label">Worst stall</div><div class="info-card-value" id="diagWorst">--</div></div>
+      </div>
+      <div style="margin-top:10px;font-size:12px;color:var(--text-muted)" id="diagMeta">The panel running this widget reports its frame timing here every few seconds.</div>
+      <div style="margin-top:6px;font-size:12px;color:var(--danger);font-family:ui-monospace,Menlo,monospace" id="diagStalls"></div>
+    </div>`;
+}
+
+function startDiagPoll(widgetId, deviceId) {
+  if (diagPollTimer) clearInterval(diagPollTimer);
+  const url = `/api/widgets/${encodeURIComponent(widgetId)}/telemetry?device=${encodeURIComponent(deviceId)}`;
+  const tick = async () => {
+    try {
+      const res = await fetch(url, { cache: 'no-store' });
+      updateDiagPanel(res.ok ? await res.json() : null);
+    } catch (e) { /* transient — keep last shown */ }
+  };
+  tick();
+  diagPollTimer = setInterval(tick, 2500);
+}
+
+function updateDiagPanel(d) {
+  const v = document.getElementById('diagVerdict');
+  if (!v) { if (diagPollTimer) { clearInterval(diagPollTimer); diagPollTimer = null; } return; } // navigated away
+  const set = (id, val, color) => { const el = document.getElementById(id); if (el) { el.textContent = val; if (color) el.style.color = color; } };
+  if (!d) {
+    v.textContent = 'no report yet'; v.style.color = 'var(--text-muted)';
+    set('diagMeta', 'No data received yet — make sure the panel is showing this widget, then give it a few seconds.');
+    return;
+  }
+  const age = d.receivedAt ? Math.max(0, Math.round((Date.now() - d.receivedAt) / 1000)) : null;
+  const stale = age != null && age > 15;
+  const verdict = d.verdict || 'measuring';
+  const vcolor = verdict === 'SMOOTH' ? 'var(--success)' : (verdict === 'STALLING' ? 'var(--danger)' : 'var(--text-muted)');
+  // If we haven't heard from THIS panel recently, say so plainly rather than showing stale numbers as live.
+  if (stale) { v.textContent = 'no live report'; v.style.color = 'var(--text-muted)'; }
+  else { v.textContent = verdict; v.style.color = vcolor; }
+  set('diagFps', d.fps != null ? String(d.fps) : '--');
+  set('diagHz', d.refreshHz != null ? d.refreshHz + ' Hz' : '--');
+  set('diagLong', d.longFrames != null ? String(d.longFrames) : '--', d.longFrames > 0 ? 'var(--danger)' : 'var(--success)');
+  set('diagWorst', d.worstStallMs != null ? d.worstStallMs + ' ms' : '--', d.worstStallMs > 50 ? 'var(--danger)' : 'var(--text)');
+  const meta = [];
+  if (d.vp) meta.push('viewport ' + d.vp);
+  if (d.dpr) meta.push('dpr ' + d.dpr);
+  if (d.elapsedS != null) meta.push('running ' + d.elapsedS + 's');
+  if (age != null) meta.push('last report ' + age + 's ago');
+  set('diagMeta', meta.join(' · '));
+  set('diagStalls', Array.isArray(d.recent) && d.recent.length ? ('recent stalls: ' + d.recent.join('   ')) : '');
+}
+
 export function cleanup() {
+  if (diagPollTimer) { clearInterval(diagPollTimer); diagPollTimer = null; }
   if (statusHandler) off('device-status', statusHandler);
   if (screenshotHandler) off('screenshot-ready', screenshotHandler);
   if (playbackHandler) off('playback-state', playbackHandler);

--- a/server/player/index.html
+++ b/server/player/index.html
@@ -2137,6 +2137,19 @@
       pendingWidgetSwap = { iframe, timer: setTimeout(discardPendingSwap, WIDGET_SWAP_TIMEOUT_MS) };
     }
 
+    // A held widget/board is left mounted (it self-refreshes its own data in place — no iframe
+    // reload, so its scroll is never reset). This just re-checks the schedule on the slow cadence:
+    // if it's still the sole active item, leave the live iframe alone and re-arm; if its daypart
+    // closed or a sibling opened, hand off to nextItem (idle or a genuine buffered transition —
+    // schedule-awareness / Fix A preserved).
+    function reevaluateHeldWidget() {
+      if (nextActiveIndex(currentIndex) === currentIndex) {
+        advanceTimer = setTimeout(reevaluateHeldWidget, WIDGET_SOLO_REFRESH_MS);
+        return;
+      }
+      nextItem();
+    }
+
     function renderContent(item) {
       // Cancel any pending advance/refresh timer up front so a prior item's timer (incl. a
       // self-rescheduling widget refresh) can't fire against the new content.
@@ -2150,14 +2163,15 @@
         renderWidgetBuffered(item);
         // Group members run no local timer (their schedule tick drives the index).
         if (!groupSync) {
-          // Advance via nextItem in BOTH cases so the schedule is re-evaluated every cycle
-          // (a closed daypart / newly-active sibling is honored) — never a bespoke loop that
-          // re-renders blind to the schedule. A solo/held board (nextActiveIndex === current)
-          // just does it on a slow cadence: nextItem re-selects this same item and re-renders
-          // it through the buffered swap (data refresh, no flash). A rotating playlist advances
-          // on the item's duration.
+          // A solo/held widget (e.g. a directory board) self-refreshes its own data IN PLACE,
+          // so we must NOT reload its iframe on a timer — that would reset its scroll. Instead,
+          // on the slow cadence just re-check the SCHEDULE and only transition if the active
+          // selection changed (daypart opened/closed). A rotating playlist advances normally on
+          // its duration; the first mount + every genuine transition still go through the
+          // buffered swap.
           const held = nextActiveIndex(currentIndex) === currentIndex;
-          advanceTimer = setTimeout(nextItem, held ? WIDGET_SOLO_REFRESH_MS : (item.duration_sec || 30) * 1000);
+          if (held) advanceTimer = setTimeout(reevaluateHeldWidget, WIDGET_SOLO_REFRESH_MS);
+          else advanceTimer = setTimeout(nextItem, (item.duration_sec || 30) * 1000);
         }
         return;
       }

--- a/server/player/index.html
+++ b/server/player/index.html
@@ -2111,7 +2111,7 @@
       discardPendingSwap();
 
       const iframe = document.createElement('iframe');
-      iframe.src = `${config.serverUrl}/api/widgets/${item.widget_id}/render`;
+      iframe.src = `${config.serverUrl}/api/widgets/${item.widget_id}/render?device=${encodeURIComponent(config.deviceId||'')}`;
       // Positioned + sized by the `#playerContainer > iframe` CSS rule. Hidden while it
       // loads so its black background never shows over the outgoing content.
       iframe.style.background = '#000';
@@ -2313,7 +2313,7 @@
           if (!isFollower) advanceTimer = setTimeout(nextItem, (item.duration_sec || 10) * 1000);
         } else if (item.widget_id) {
           const iframe = document.createElement('iframe');
-          iframe.src = `${serverUrl}/api/widgets/${item.widget_id}/render`;
+          iframe.src = `${serverUrl}/api/widgets/${item.widget_id}/render?device=${encodeURIComponent(config.deviceId||'')}`;
           iframe.style.cssText = 'width:100%;height:100%;border:none;background:#000';
           iframe.allow = 'autoplay; fullscreen';
           // Sandbox into a unique origin so widget scripts can't read window.parent
@@ -2427,7 +2427,7 @@
       // Android player, which keys off the assignment's widget_type.
       if (a.widget_id) {
         const iframe = document.createElement('iframe');
-        iframe.src = `${config.serverUrl}/api/widgets/${a.widget_id}/render`;
+        iframe.src = `${config.serverUrl}/api/widgets/${a.widget_id}/render?device=${encodeURIComponent(config.deviceId||'')}`;
         // Sandbox into a unique origin so widget scripts can't read window.parent
         // state (localStorage / JWT). allow-scripts keeps inline widget code running.
         iframe.setAttribute('sandbox', 'allow-scripts');

--- a/server/routes/widgets.js
+++ b/server/routes/widgets.js
@@ -497,7 +497,6 @@ function renderDirectoryBoard(c) {
     <div class="bg-layer" id="bgLayer"></div>
     <header class="header" id="header"></header>
     <div class="scroller" id="scroller">
-      <div class="track" id="track"></div>
     </div>
     <footer class="footer" id="footer"></footer>
   </div>
@@ -610,118 +609,97 @@ function renderDirectoryBoard(c) {
     return catEl;
   }
 
-  var track = document.getElementById('track');
+  var stage = scroller; // the clip window between header & footer
+  var N = 4;            // panels in the ring (2 tile the screen, 1 dwells below, 1 above)
+  var baseStyle = document.createElement('style');
+  baseStyle.textContent =
+    '.panel{ position:absolute; left:0; right:0; top:0; overflow:hidden; contain:paint; will-change:transform; backface-visibility:hidden; }' +
+    '.pcontent{ position:absolute; left:0; right:0; top:0; padding:0 48px; }';
+  document.head.appendChild(baseStyle);
+  var scrollStyle = document.createElement('style');
+  scrollStyle.id = 'dir-scroll-kf';
+  document.head.appendChild(scrollStyle);
 
-  // ----- WINDOWED (virtualized) marquee -----
-  // Each category is pre-built ONCE onto its own small compositor layer; the scroll only shows the
-  // ones intersecting the viewport (+ a small buffer) and moves them with a transform. Nothing is
-  // built, parsed, or laid out per frame. That keeps every composited layer ~1 screen tall no
-  // matter how long the directory is, so the GPU never re-rasterizes an oversized layer — which was
-  // the tile-boundary stall (~1 dropped frame every 512px-tile / speed ≈ 11s) that hitched the old
-  // CSS marquee once the track grew past a few thousand px.
-  var vstyle = document.createElement('style');
-  vstyle.textContent =
-    '.track{will-change:auto;animation:none;}' +
-    '.vcat{position:absolute;left:48px;right:48px;top:0;will-change:transform;}' +
-    '.vmeasure{position:absolute;left:0;right:0;top:0;visibility:hidden;padding:0 48px;pointer-events:none;}';
-  document.head.appendChild(vstyle);
-
-  var vlayout = [];   // [{top,h}] per category, in virtual (content) coordinates
-  var insts = [];     // pre-built display instances: [{top,h,k,el,shown}] (one el per category × wrap-copy)
-  var loopH = 0;      // full scroll period = total content height + one GAP_PX (the end→repeat gap)
-  var viewH = 0;      // cached scroller height, so the frame loop never forces a layout read
+  // ----- scroll: a ring of compositor-animated, viewport-tall panels -----
+  // Animating one tall track fails on Firefox (it won't composite a transform bigger than ~1.1x the
+  // viewport / 4096px and falls back to a stuttering main-thread animation) and churns GPU tiles even
+  // on Chromium. Instead we run N panels, each exactly one stage-height tall (overflow:hidden +
+  // contain:paint clamp each compositor layer to that box). Each panel is a static window onto a full
+  // copy of the directory (positioned by a static inner translateY = -slice); the PANEL is slid
+  // rigidly upward by ONE CSS @keyframes animation, and the panels are phase-locked by negative
+  // animation-delay so two always tile the screen while one dwells off-screen below and one above.
+  // There is NO per-frame JS — "scrolling" is the compositor sliding pre-rasterized viewport-sized
+  // textures, so nothing on the main thread (GC, extensions, the host player) can stutter it. On each
+  // off-screen wrap a panel jumps its slice N screens ahead (content already built — nothing to load
+  // when it reappears) and, if a data refresh is pending, rebuilds its content THEN, safely off-screen.
+  var panels = [];       // [{el, content, version, slice}]
+  var Sh = 0;            // panel / stage height
+  var C = 0;             // looped directory height (one full copy)
   var speedPxSec = 0;
-  var pos = 0;        // virtual scroll offset; advances downward, wraps at loopH
-  var rafId = null, lastTs = 0;
+  var contentVersion = 0;
+  var pending = null;    // a queued data refresh, picked up per-panel while off-screen
 
-  function clearInsts() {
-    for (var n = 0; n < insts.length; n++) { var e = insts[n].el; if (e.parentNode) e.parentNode.removeChild(e); }
-    insts = [];
-  }
-
-  // Measure each category once at the true render width, then PRE-BUILD every instance that can ever
-  // be on screen (each category × the -1/0/+1 wrap-copies at the loop seam). Runs ONLY on first paint,
-  // resize, and real data changes — never during scroll — so the frame loop only moves finished
-  // elements; it never parses HTML or forces layout. (That per-recycle rebuild was the irregular hitch.)
-  function measureLayout() {
-    viewH = scroller.getBoundingClientRect().height || window.innerHeight;
+  function fillContent(el) { // full directory + a clone of the top (>= one screen) for the within-panel wrap
     var arr = Array.isArray(cfg.categories) ? cfg.categories : [];
-    var meas = document.createElement('div');
-    meas.className = 'vmeasure';
-    track.appendChild(meas);
-    vlayout = [];
-    var top = 0;
-    arr.forEach(function(cat){
-      var el = buildCategoryEl(cat);
-      meas.appendChild(el);
-      var h = el.getBoundingClientRect().height;
-      vlayout.push({ top: top, h: h });
-      top += h;
-    });
-    track.removeChild(meas);
-    loopH = top + GAP_PX;
-    speedPxSec = (top <= viewH) ? MIN_SCROLL_PX_SEC : (SPEEDS[cfg.scroll_speed] || SPEEDS.medium);
-    clearInsts();
-    for (var i = 0; i < arr.length; i++) {
-      for (var k = -1; k <= 1; k++) {
-        var cel = buildCategoryEl(arr[i]);
-        cel.className = 'category vcat';
-        cel.style.display = 'none';
-        track.appendChild(cel);
-        insts.push({ top: vlayout[i].top, h: vlayout[i].h, k: k, el: cel, shown: false });
-      }
+    arr.forEach(function(c){ el.appendChild(buildCategoryEl(c)); });
+    var full = el.scrollHeight; // == C (one full directory)
+    var i = 0, guard = arr.length * 4 + 1;
+    while ((el.scrollHeight - full) < Sh + 4 && arr.length && i < guard) {
+      el.appendChild(buildCategoryEl(arr[i % arr.length])); i++;
     }
+    return full;
   }
 
-  // Per-frame: reposition the pre-built instances. Pure number math + compositor-only transform
-  // writes, zero allocations — nothing here can trigger GC or a layout, so the scroll stays smooth.
-  function renderWindow() {
-    if (loopH <= 0) return;
-    var buffer = 140;
-    for (var n = 0; n < insts.length; n++) {
-      var it = insts[n];
-      var y = it.top - pos + it.k * loopH;
-      if (y + it.h >= -buffer && y <= viewH + buffer) {
-        it.el.style.transform = 'translate3d(0,' + y + 'px,0)';
-        if (!it.shown) { it.el.style.display = ''; it.shown = true; }
-      } else if (it.shown) {
-        it.el.style.display = 'none'; it.shown = false;
-      }
+  function globalScroll() { return speedPxSec * ((document.timeline.currentTime || 0) / 1000); }
+  function mod(a, n) { return n > 0 ? ((a % n) + n) % n : 0; }
+  function setSlice(p, off) { p.slice = off; p.content.style.transform = 'translate3d(0,' + (-off) + 'px,0)'; }
+
+  function seedSlices() { // four consecutive screens, matching the lanes' physical phase (delays 0..-3T)
+    var base = globalScroll();
+    var laneStart = [2 * Sh, 1 * Sh, 0, -1 * Sh];
+    panels.forEach(function(p, i){ setSlice(p, mod(base + laneStart[i % 4], C)); });
+  }
+
+  function onWrap(p) { // fires as a panel wraps to the bottom (off-screen); rebuild + advance N screens
+    if (pending && p.version !== pending.version) {
+      p.content.replaceChildren();
+      C = fillContent(p.content); // all panels share the same data => same C
+      p.version = pending.version;
     }
+    setSlice(p, mod(p.slice + N * Sh, C));
   }
 
-  function frame(ts) {
-    var dt = lastTs ? (ts - lastTs) / 1000 : 0;
-    lastTs = ts;
-    if (dt < 0 || dt > 0.25) dt = 0; // ignore tab-switch / long-frame jumps (no scroll leap)
-    pos += speedPxSec * dt;
-    if (loopH > 0) { pos %= loopH; if (pos < 0) pos += loopH; }
-    renderWindow();
-    rafId = requestAnimationFrame(frame);
-  }
-
-  function remeasure(preservePhase) { // re-measure + rebuild instances, resuming at the same fraction
-    var frac = (preservePhase && loopH > 0) ? (pos / loopH) : 0;
-    measureLayout();
-    pos = frac * loopH;
-    renderWindow();
-  }
-
-  function firstPaint() {
+  function setup() {
     layoutScroller();
-    measureLayout();
-    pos = 0;
-    if (rafId) cancelAnimationFrame(rafId);
-    lastTs = 0;
-    rafId = requestAnimationFrame(frame);
+    Sh = stage.getBoundingClientRect().height || window.innerHeight;
+    stage.replaceChildren();
+    panels = [];
+    for (var i = 0; i < N; i++) {
+      var el = document.createElement('div'); el.className = 'panel'; el.setAttribute('data-lane', i);
+      el.style.height = Sh + 'px';
+      var content = document.createElement('div'); content.className = 'pcontent';
+      el.appendChild(content);
+      stage.appendChild(el);
+      panels.push({ el: el, content: content, version: contentVersion, slice: 0 });
+    }
+    C = fillContent(panels[0].content);
+    for (var j = 1; j < N; j++) fillContent(panels[j].content);
+    speedPxSec = (C <= Sh) ? MIN_SCROLL_PX_SEC : (SPEEDS[cfg.scroll_speed] || SPEEDS.medium);
+    var T = Sh / speedPxSec, dur = N * T;
+    var kf = '@keyframes dir-pan { from { transform: translate3d(0,' + (2 * Sh) + 'px,0); } to { transform: translate3d(0,' + (-2 * Sh) + 'px,0); } }';
+    kf += '.panel{ animation: dir-pan ' + dur + 's linear infinite; }';
+    for (var k = 0; k < N; k++) kf += '.panel[data-lane="' + k + '"]{ animation-delay: ' + (-k * T).toFixed(4) + 's; }';
+    scrollStyle.textContent = kf;
+    seedSlices();
+    panels.forEach(function(p){ p.el.addEventListener('animationiteration', function(){ onWrap(p); }); });
   }
 
-  // wait for images (logo + bgs) to load before the FIRST measure, so heights are correct
+  // wait for images (logo + bgs) to load before the first layout, so heights are correct
   var pendingImgs = Array.from(document.images).filter(function(i){ return !i.complete; });
   if (pendingImgs.length === 0) {
-    firstPaint();
+    setup();
   } else {
-    var built = false, build = function(){ if (!built) { built = true; firstPaint(); } };
+    var built = false, build = function(){ if (!built) { built = true; setup(); } };
     pendingImgs.forEach(function(i){
       i.addEventListener('load', build, { once:true });
       i.addEventListener('error', build, { once:true });
@@ -729,11 +707,11 @@ function renderDirectoryBoard(c) {
     setTimeout(build, 5000); // hard timeout so we never hang
   }
 
-  // re-layout on resize (debounced) — re-measure at the new width, resume at the same fraction
+  // re-layout on resize (debounced) — rebuild the ring; globalScroll() keeps the same content position
   var rT;
   window.addEventListener('resize', function(){
     clearTimeout(rT);
-    rT = setTimeout(function(){ layoutScroller(); remeasure(true); }, 250);
+    rT = setTimeout(setup, 250);
   });
 
   // ----- live data refresh: poll data.json; re-render ONLY when the entries changed -----
@@ -751,7 +729,8 @@ function renderDirectoryBoard(c) {
         if (sig === lastSig) return;      // unchanged -> leave the scroll running untouched
         lastSig = sig;
         cfg.categories = cats;
-        remeasure(true);                  // rebuild instances in place; scroll resumes at the same fraction
+        contentVersion++;                 // queue it; each panel adopts it on its next off-screen wrap
+        pending = { version: contentVersion };
       })
       .catch(function(){ /* transient error -> keep last-good board */ });
   }, REFRESH_MS);

--- a/server/routes/widgets.js
+++ b/server/routes/widgets.js
@@ -168,7 +168,7 @@ router.delete('/:id', (req, res) => {
   res.json({ success: true });
 });
 
-const KNOWN_WIDGET_TYPES = new Set(['clock','weather','rss','text','webpage','social','directory-board','directory-search']);
+const KNOWN_WIDGET_TYPES = new Set(['clock','weather','rss','text','webpage','social','directory-board','directory-search','diag-smoothness']);
 function renderWidgetHtml(type, config) {
   config = config || {};
   switch (type) {
@@ -180,6 +180,7 @@ function renderWidgetHtml(type, config) {
     case 'social': return renderSocial(config);
     case 'directory-board': return renderDirectoryBoard(config);
     case 'directory-search': return renderDirectorySearch(config);
+    case 'diag-smoothness': return renderDiagSmoothness(config);
     default: return '<html><body style="color:white;background:black;display:flex;align-items:center;justify-content:center;height:100vh;margin:0"><h1>Unknown widget</h1></body></html>';
   }
 }
@@ -219,6 +220,35 @@ router.get('/:id/data.json', (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Cache-Control', 'no-store');
   res.json({ categories });
+});
+
+// Latest frame-rate telemetry per widget, reported by the diag-smoothness widget running on a device.
+// In-memory (diagnostic, not persisted) — a device page reads the snapshot for the widget it plays.
+const widgetTelemetry = new Map();
+// Public POST from the widget: it runs in a null-origin sandboxed iframe, so this must be no-auth +
+// CORS-open. The widget sends text/plain (a "simple" request → no CORS preflight); we JSON.parse it.
+router.post('/:id/telemetry', express.text({ type: '*/*', limit: '16kb' }), (req, res) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  let t = {};
+  try { t = typeof req.body === 'string' ? JSON.parse(req.body || '{}') : (req.body || {}); } catch (e) { t = {}; }
+  t.receivedAt = Date.now();
+  // Key by the reporting device (player passes ?device=<id>) so multiple panels don't collide;
+  // fall back to a widget-scoped key for players that don't pass a device id yet.
+  const key = (t.device && String(t.device).slice(0, 64)) || ('w:' + req.params.id);
+  widgetTelemetry.set(key, t);
+  res.json({ ok: true });
+});
+// Public GET so the dashboard device page can display the snapshot. ?device=<id> reads that panel's
+// report; without it (or if that panel hasn't reported) falls back to the widget-scoped snapshot.
+router.get('/:id/telemetry', (req, res) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Cache-Control', 'no-store');
+  const dev = req.query.device ? String(req.query.device) : null;
+  // Device-scoped request returns ONLY that device's report — NO widget-wide fallback, or one
+  // reporting panel's data would show on every other device's page (incl. offline ones). A request
+  // with no device id gets the widget-scoped snapshot (raw/debug view only).
+  const rec = dev ? (widgetTelemetry.get(dev) || null) : (widgetTelemetry.get('w:' + req.params.id) || null);
+  res.json(rec);
 });
 
 // Preview unsaved widget from config (used by editor Preview button)
@@ -1031,6 +1061,117 @@ function renderDirectorySearch(c) {
 })();
 </script>
 </body></html>`;
+}
+
+// diag-smoothness: a self-contained frame-cadence tester for the ACTUAL panel. Two GPU-composited
+// animations (a vertical scroll like the board + a fast sweep) plus a big on-screen HUD (FPS, refresh
+// estimate, long-frame count, worst stall, SMOOTH/STALLING verdict) — so a stutter can be read off the
+// panel screen with no console. If this stalls on real signage hardware, the hardware is the cause.
+function renderDiagSmoothness(config) {
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Smoothness Diagnostic</title><style>
+  *{box-sizing:border-box;margin:0;padding:0}
+  html,body{height:100%}
+  body{background:#0a0d13;color:#cbd4e4;font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;overflow:hidden;height:100vh}
+  .bar{position:absolute;top:0;left:0;right:0;padding:1.4vh 2vw;border-bottom:1px solid #20293a;background:#0f1420;z-index:5}
+  .bar h1{font-size:2.2vh;font-weight:700;letter-spacing:.02em}
+  .bar p{font-size:1.7vh;color:#6d7789;margin-top:.4vh}
+  .bar b{color:#54a6ff}
+  .stage{position:absolute;top:0;left:0;right:0;bottom:0}
+  .col{position:absolute;top:0;left:0;width:52%;height:100%;overflow:hidden;border-right:1px solid #20293a}
+  .roll{position:absolute;left:0;right:0;top:0;will-change:transform;animation:roll 30s linear infinite}
+  @keyframes roll{from{transform:translate3d(0,0,0)}to{transform:translate3d(0,-50%,0)}}
+  .row{display:flex;align-items:center;gap:1.4vw;padding:1.5vh 2vw;border-bottom:1px solid #20293a;font-family:ui-monospace,Menlo,Consolas,monospace;font-size:2.6vh}
+  .row .n{color:#54a6ff;min-width:3.2em;font-variant-numeric:tabular-nums}
+  .row:nth-child(3n) .n{color:#37d391}
+  .sweep{position:absolute;top:0;right:0;width:48%;height:100%;background:repeating-linear-gradient(90deg,#0f1420 0 3vw,#182234 3vw 6vw)}
+  .marker{position:absolute;top:0;bottom:0;width:.5vw;background:#f5b451;box-shadow:0 0 3vw #f5b451;will-change:transform;animation:sweep 2s linear infinite}
+  @keyframes sweep{from{transform:translateX(0)}to{transform:translateX(calc(48vw - .5vw))}}
+  .tag{position:absolute;top:1.5vh;font-family:ui-monospace,monospace;font-size:1.6vh;color:#6d7789;z-index:2}
+  .col .tag{left:1.5vw;background:#0a0d13;padding:.4vh .8vw;border-radius:4px}
+  .sweep .tag{right:1.5vw}
+  .hud{position:absolute;left:50%;bottom:3vh;transform:translateX(-50%);background:rgba(12,16,24,.94);border:1px solid #20293a;border-radius:14px;padding:2.2vh 2.4vw;min-width:64vw;z-index:6;box-shadow:0 1.4vh 4vh rgba(0,0,0,.55)}
+  .verdict{display:flex;align-items:center;gap:1.4vw;margin-bottom:1.8vh}
+  .dot{width:1.8vh;height:1.8vh;border-radius:50%;background:#6d7789}
+  .verdict.smooth .dot{background:#37d391;box-shadow:0 0 0 .6vh rgba(55,211,145,.16)}
+  .verdict.stall .dot{background:#ff5d5d;box-shadow:0 0 0 .6vh rgba(255,93,93,.18)}
+  .verdict .txt{font-size:3.4vh;font-weight:750;letter-spacing:.01em}
+  .verdict.smooth .txt{color:#37d391}.verdict.stall .txt{color:#ff5d5d}
+  .verdict .sub{font-size:1.9vh;color:#6d7789;font-weight:400;margin-left:auto;text-align:right}
+  .grid{display:grid;grid-template-columns:repeat(4,1fr);gap:1.2vw;margin-bottom:1.4vh}
+  .stat{background:#121826;border:1px solid #20293a;border-radius:10px;padding:1.2vh 1vw}
+  .stat .k{font-size:1.4vh;text-transform:uppercase;letter-spacing:.08em;color:#6d7789}
+  .stat .v{font-family:ui-monospace,Menlo,monospace;font-size:4vh;font-variant-numeric:tabular-nums;margin-top:.4vh}
+  .stat .v small{font-size:1.8vh;color:#6d7789}
+  .log{font-family:ui-monospace,Menlo,monospace;font-size:1.7vh;color:#6d7789;height:2.4vh;overflow:hidden}
+  .log b{color:#ff5d5d}
+  </style></head><body>
+  <div class="bar"><h1>Panel Smoothness Diagnostic</h1><p>Two GPU-composited animations, zero app logic. If the scroll or the yellow bar <b>skips</b> — or the HUD reads STALLING — this <b>panel/hardware</b> is dropping frames.</p></div>
+  <div class="stage">
+    <div class="col"><div class="tag">TEST 1 &middot; vertical scroll</div><div class="roll" id="roll"></div></div>
+    <div class="sweep"><div class="tag">TEST 2 &middot; fast sweep</div><div class="marker"></div></div>
+    <div class="hud">
+      <div class="verdict" id="verdict"><span class="dot"></span><span class="txt" id="vtxt">measuring&hellip;</span><span class="sub" id="vsub">collecting frames</span></div>
+      <div class="grid">
+        <div class="stat"><div class="k">FPS now</div><div class="v" id="fps">&ndash;</div></div>
+        <div class="stat"><div class="k">Refresh est.</div><div class="v" id="hz">&ndash;<small> Hz</small></div></div>
+        <div class="stat"><div class="k">Long frames</div><div class="v" id="long">0<small> &gt;50ms</small></div></div>
+        <div class="stat"><div class="k">Worst stall</div><div class="v" id="worst">0<small> ms</small></div></div>
+      </div>
+      <div class="log" id="log">no stalls yet &middot; a healthy panel shows 0 long frames</div>
+    </div>
+  </div>
+  <script>
+  (function(){
+    var roll=document.getElementById('roll'),half='',i;
+    for(i=1;i<=26;i++){ half+='<div class="row"><span class="n">'+(100+i)+'</span><span class="t">Directory line '+i+'</span></div>'; }
+    roll.innerHTML=half+half;
+    var last=0,worst=0,longCount=0,recent=[],dts=[],started=0,lastPaint=0;
+    var elFps=document.getElementById('fps'),elHz=document.getElementById('hz'),elLong=document.getElementById('long'),
+        elWorst=document.getElementById('worst'),elLog=document.getElementById('log'),verdict=document.getElementById('verdict'),
+        vtxt=document.getElementById('vtxt'),vsub=document.getElementById('vsub');
+    function median(a){ var b=a.slice().sort(function(x,y){return x-y}); return b[Math.floor(b.length/2)]||0; }
+    function paint(ts){
+      var med=median(dts)||16.7;
+      elFps.innerHTML=(1000/med).toFixed(0);
+      elHz.innerHTML=(1000/med).toFixed(0)+'<small> Hz</small>';
+      elLong.innerHTML=longCount+'<small> &gt;50ms</small>';
+      elWorst.innerHTML=worst.toFixed(0)+'<small> ms</small>';
+      if(recent.length) elLog.innerHTML=recent.join(' \\u00b7 ');
+      var el=ts-started;
+      if(el>4000){
+        if(longCount===0){ verdict.className='verdict smooth'; vtxt.innerHTML='SMOOTH'; vsub.innerHTML='0 long frames &mdash; this panel animates cleanly'; }
+        else { verdict.className='verdict stall'; vtxt.innerHTML='STALLING'; vsub.innerHTML=longCount+' long frame'+(longCount>1?'s':'')+' &mdash; this panel is dropping frames'; }
+      } else { vsub.innerHTML='collecting frames&hellip; '+(el/1000).toFixed(0)+'s'; }
+    }
+    function frame(ts){
+      if(!started) started=ts;
+      if(last){ var dt=ts-last; dts.push(dt); if(dts.length>180) dts.shift();
+        if(dt>50){ longCount++; if(dt>worst) worst=dt;
+          recent.unshift('<b>'+dt.toFixed(0)+'ms</b> @ '+((ts-started)/1000).toFixed(0)+'s'); if(recent.length>3) recent.pop(); }
+      }
+      last=ts;
+      if(ts-lastPaint>250){ lastPaint=ts; paint(ts); }
+      requestAnimationFrame(frame);
+    }
+    requestAnimationFrame(frame);
+    // the player appends ?device=<id> to the render URL so telemetry can be keyed to THIS panel.
+    var DEVID=''; try{ var mm=(location.search||'').match(/[?&](?:device|d)=([^&]+)/); if(mm) DEVID=decodeURIComponent(mm[1]); }catch(e){}
+    // report the snapshot back to the server (relative 'telemetry' -> /api/widgets/<id>/telemetry).
+    // text/plain keeps it a CORS-simple request (no preflight) from the null-origin sandboxed iframe.
+    function report(){
+      try{
+        var med=median(dts)||16.7, now=(typeof performance!=='undefined'&&performance.now)?performance.now():Date.now();
+        var payload={device:DEVID,fps:Math.round(1000/med),refreshHz:Math.round(1000/med),longFrames:longCount,worstStallMs:Math.round(worst),
+          elapsedS:started?Math.round((now-started)/1000):0,
+          verdict:(started&&(now-started>4000))?(longCount?'STALLING':'SMOOTH'):'measuring',
+          recent:recent.slice(0,3).map(function(s){return s.replace(/<[^>]+>/g,'');}),
+          vp:window.innerWidth+'x'+window.innerHeight,dpr:window.devicePixelRatio||1,ua:(navigator.userAgent||'').slice(0,180)};
+        fetch('telemetry',{method:'POST',headers:{'Content-Type':'text/plain'},body:JSON.stringify(payload),keepalive:true})['catch'](function(){});
+      }catch(e){}
+    }
+    setInterval(report,2500);
+  })();
+  </script></body></html>`;
 }
 
 module.exports = router;

--- a/server/routes/widgets.js
+++ b/server/routes/widgets.js
@@ -449,9 +449,7 @@ function renderDirectoryBoard(c) {
     mask-image: linear-gradient(to bottom, transparent 0, #000 40px, #000 calc(100% - 40px), transparent 100%);
     -webkit-mask-image: linear-gradient(to bottom, transparent 0, #000 40px, #000 calc(100% - 40px), transparent 100%);
   }
-  .track { position:absolute; top:0; left:0; right:0; will-change: transform; }
-  .block { padding:0 48px 24px; }
-  .block + .block { padding-top:24px; }
+  .track { position:absolute; top:0; left:0; right:0; }
 
   .category { padding:36px 0 16px; }
   .category h2 {
@@ -484,8 +482,6 @@ function renderDirectoryBoard(c) {
   body.light .entry { color:#1a1a2e; }
   body.light .entry.available, body.light .entry.available .id { color:#059669; }
 
-  .gap { height:120px; }
-
   @media (max-width: 1280px) {
     .header h1 { font-size:54px; }
     .header img.logo { max-height:120px; }
@@ -512,8 +508,7 @@ function renderDirectoryBoard(c) {
   var SPEEDS = { slow: 20, medium: 45, fast: 75 };
 
   if (cfg.theme === 'light') document.body.classList.add('light');
-  var GAP_PX = 120; // MUST match the .gap element height (set inline below) — the scroll loop
-                    // translates by baseH+GAP_PX, so any mismatch jumps that many px each cycle.
+  var GAP_PX = 120; // blank space between the end of the directory and where it repeats (loop seam)
   var MIN_SCROLL_PX_SEC = 5; // anti-burn-in minimum when content fits
   var REFRESH_MS = 60000;    // poll data.json this often; re-render ONLY when entries changed
 
@@ -580,97 +575,148 @@ function renderDirectoryBoard(c) {
   var cols = cfg.columns || 'auto';
   if (['auto','1','2','3','4'].indexOf(String(cols)) === -1) cols = 'auto';
 
-  function buildBlock() {
-    var block = document.createElement('div');
-    block.className = 'block';
-    var cats = Array.isArray(cfg.categories) ? cfg.categories : [];
-    cats.forEach(function(cat){
-      var catEl = document.createElement('div');
-      catEl.className = 'category';
-      var h2 = document.createElement('h2');
-      h2.textContent = cat.name || '';
-      catEl.appendChild(h2);
-      var entries = document.createElement('div');
-      entries.className = 'entries';
-      entries.setAttribute('data-cols', String(cols));
-      (cat.entries || []).forEach(function(e){
-        var row = document.createElement('div');
-        row.className = 'entry' + (e.available ? ' available' : '');
-        var id = document.createElement('span');
-        id.className = 'id';
-        id.textContent = (e.identifier || '') + ':';
-        var text = document.createElement('div');
-        text.className = 'text';
-        var nm = document.createElement('span');
-        nm.className = 'nm';
-        nm.textContent = e.name || '';
-        text.appendChild(nm);
-        if (e.subtitle) {
-          var sub = document.createElement('span');
-          sub.className = 'sub';
-          sub.textContent = e.subtitle;
-          text.appendChild(sub);
-        }
-        row.appendChild(id);
-        row.appendChild(text);
-        entries.appendChild(row);
-      });
-      catEl.appendChild(entries);
-      block.appendChild(catEl);
+  function buildCategoryEl(cat) {
+    var catEl = document.createElement('div');
+    catEl.className = 'category';
+    var h2 = document.createElement('h2');
+    h2.textContent = cat.name || '';
+    catEl.appendChild(h2);
+    var entries = document.createElement('div');
+    entries.className = 'entries';
+    entries.setAttribute('data-cols', String(cols));
+    (cat.entries || []).forEach(function(e){
+      var row = document.createElement('div');
+      row.className = 'entry' + (e.available ? ' available' : '');
+      var id = document.createElement('span');
+      id.className = 'id';
+      id.textContent = (e.identifier || '') + ':';
+      var text = document.createElement('div');
+      text.className = 'text';
+      var nm = document.createElement('span');
+      nm.className = 'nm';
+      nm.textContent = e.name || '';
+      text.appendChild(nm);
+      if (e.subtitle) {
+        var sub = document.createElement('span');
+        sub.className = 'sub';
+        sub.textContent = e.subtitle;
+        text.appendChild(sub);
+      }
+      row.appendChild(id);
+      row.appendChild(text);
+      entries.appendChild(row);
     });
-    return block;
+    catEl.appendChild(entries);
+    return catEl;
   }
 
   var track = document.getElementById('track');
-  var scrollStyle = document.createElement('style');
-  scrollStyle.id = 'scroll-kf';
-  document.head.appendChild(scrollStyle);
-  var cycleH = 0, durationS = 0;
 
-  // ----- scroll: an OFF-MAIN-THREAD CSS marquee -----
-  // A CSS @keyframes animation runs on the COMPOSITOR thread, so it stays smooth even under
-  // main-thread jank/GC (a requestAnimationFrame loop dropped ~1 frame per cycle on the panel).
-  // Rebuilt for first paint, resize, and live data changes; a data change PRESERVES the scroll
-  // phase via a negative animation-delay, so an update resumes in place instead of snapping to
-  // the top. Unchanged polls never touch it.
-  function rebuildTrack(preservePhase) {
-    // capture the current scroll phase (0..1) BEFORE we replace the animation
-    var phaseFrac = 0;
-    if (preservePhase && durationS > 0) {
-      try {
-        var a = track.getAnimations && track.getAnimations()[0];
-        if (a) phaseFrac = ((Number(a.currentTime) || 0) % (durationS * 1000)) / (durationS * 1000);
-      } catch (e) {}
-    }
-    track.replaceChildren(); // drop all old nodes in one shot (no detached-node buildup)
-    var baseBlock = buildBlock();
-    track.appendChild(baseBlock);
-    var gap = document.createElement('div');
-    gap.className = 'gap'; gap.style.height = GAP_PX + 'px';
-    track.appendChild(gap);
-    var baseH = baseBlock.getBoundingClientRect().height;
-    cycleH = baseH + GAP_PX; // translate distance per loop; base height + .gap (#197 seam invariant)
-    var viewH = scroller.getBoundingClientRect().height || window.innerHeight;
-    var cloneCount = Math.max(1, Math.ceil((viewH + cycleH) / cycleH));
-    for (var i = 0; i < cloneCount; i++) {
-      track.appendChild(buildBlock());
-      if (i < cloneCount - 1) {
-        var g = document.createElement('div');
-        g.className = 'gap'; g.style.height = GAP_PX + 'px'; // every clone-gap == GAP_PX (seamless)
-        track.appendChild(g);
+  // ----- WINDOWED (virtualized) marquee -----
+  // Only the categories intersecting the viewport (+ a small buffer) are ever in the DOM, each on
+  // its own small compositor layer. As the scroll advances we recycle a tiny element pool instead
+  // of translating one enormous cloned track. That keeps every composited layer ~1 screen tall no
+  // matter how long the directory is, so the GPU never re-rasterizes an oversized layer — which was
+  // the tile-boundary stall (~1 dropped frame every 512px-tile / speed ≈ 11s) that hitched the old
+  // CSS marquee once the track grew past a few thousand px.
+  var vstyle = document.createElement('style');
+  vstyle.textContent =
+    '.track{will-change:auto;animation:none;}' +
+    '.vcat{position:absolute;left:48px;right:48px;top:0;will-change:transform;}' +
+    '.vmeasure{position:absolute;left:0;right:0;top:0;visibility:hidden;padding:0 48px;pointer-events:none;}';
+  document.head.appendChild(vstyle);
+
+  var vlayout = [];   // [{top,h}] per category, in virtual (content) coordinates
+  var loopH = 0;      // full scroll period = total content height + one GAP_PX (the end→repeat gap)
+  var viewH = 0;      // cached scroller height, so the frame loop never forces a layout read
+  var speedPxSec = 0;
+  var pos = 0;        // virtual scroll offset; advances downward, wraps at loopH
+  var pool = [];      // recycled elements: { el, cat (rendered category idx), key ('i:k' or null) }
+  var rafId = null, lastTs = 0;
+
+  // Measure every category's natural height once, at the true render width (hidden flow pass),
+  // and record its virtual top. Cheap: runs on first paint, resize, and real data changes only.
+  function measureLayout() {
+    viewH = scroller.getBoundingClientRect().height || window.innerHeight;
+    var arr = Array.isArray(cfg.categories) ? cfg.categories : [];
+    var meas = document.createElement('div');
+    meas.className = 'vmeasure';
+    track.appendChild(meas);
+    vlayout = [];
+    var top = 0;
+    arr.forEach(function(cat){
+      var el = buildCategoryEl(cat);
+      meas.appendChild(el);
+      var h = el.getBoundingClientRect().height;
+      vlayout.push({ top: top, h: h });
+      top += h;
+    });
+    track.removeChild(meas);
+    loopH = top + GAP_PX;
+    speedPxSec = (top <= viewH) ? MIN_SCROLL_PX_SEC : (SPEEDS[cfg.scroll_speed] || SPEEDS.medium);
+  }
+
+  // Reconcile the visible window: figure out which (category, wrap-copy) instances are on screen,
+  // reuse pooled elements for them, and only repaint an element when its category actually changes.
+  function renderWindow() {
+    if (loopH <= 0) return;
+    var buffer = 140, need = {}, i, k, p;
+    for (i = 0; i < vlayout.length; i++) {
+      var baseY = vlayout[i].top - pos;
+      for (k = -1; k <= 1; k++) { // -1/0/+1 covers the seamless wrap at the loop boundary
+        var y = baseY + k * loopH;
+        if (y + vlayout[i].h >= -buffer && y <= viewH + buffer) need[i + ':' + k] = { i: i, y: y };
       }
     }
-    var speedPxSec = (baseH <= viewH) ? MIN_SCROLL_PX_SEC : (SPEEDS[cfg.scroll_speed] || SPEEDS.medium);
-    durationS = cycleH / speedPxSec;
-    var delay = preservePhase ? (-phaseFrac * durationS).toFixed(3) : 0; // resume at the same phase
-    scrollStyle.textContent =
-      '@keyframes dir-scroll { from { transform: translate3d(0,0,0); } to { transform: translate3d(0,-' + cycleH + 'px,0); } }' +
-      '.track { animation: dir-scroll ' + durationS + 's linear infinite; animation-delay: ' + delay + 's; }';
+    for (p = 0; p < pool.length; p++) { // release elements that scrolled out of the window
+      if (pool[p].key && !need[pool[p].key]) { pool[p].key = null; pool[p].el.style.display = 'none'; }
+    }
+    Object.keys(need).forEach(function(key){
+      var want = need[key], slot = null, q;
+      for (q = 0; q < pool.length; q++) { if (pool[q].key === key) { slot = pool[q]; break; } }
+      if (!slot) {
+        for (q = 0; q < pool.length; q++) { if (!pool[q].key) { slot = pool[q]; break; } }
+        if (!slot) { slot = { el: document.createElement('div'), cat: -1, key: null }; track.appendChild(slot.el); pool.push(slot); }
+        if (slot.cat !== want.i) { // repaint only when the pooled element takes on a new category
+          slot.el.className = 'category vcat';
+          slot.el.innerHTML = buildCategoryEl(cfg.categories[want.i]).innerHTML;
+          slot.cat = want.i;
+        }
+        slot.el.style.display = '';
+        slot.key = key;
+      }
+      slot.el.style.transform = 'translate3d(0,' + want.y + 'px,0)';
+    });
+  }
+
+  function frame(ts) {
+    var dt = lastTs ? (ts - lastTs) / 1000 : 0;
+    lastTs = ts;
+    if (dt < 0 || dt > 0.25) dt = 0; // ignore tab-switch / long-frame jumps (no scroll leap)
+    pos += speedPxSec * dt;
+    if (loopH > 0) { pos %= loopH; if (pos < 0) pos += loopH; }
+    renderWindow();
+    rafId = requestAnimationFrame(frame);
+  }
+
+  function resetPool() { // force a full repaint (widths or data changed) on next renderWindow
+    for (var p = 0; p < pool.length; p++) { pool[p].key = null; pool[p].cat = -1; pool[p].el.style.display = 'none'; }
+  }
+
+  function remeasure(preservePhase) { // re-measure, optionally resuming at the same scroll fraction
+    var frac = (preservePhase && loopH > 0) ? (pos / loopH) : 0;
+    measureLayout();
+    pos = frac * loopH;
+    renderWindow();
   }
 
   function firstPaint() {
     layoutScroller();
-    rebuildTrack(false);
+    measureLayout();
+    pos = 0;
+    if (rafId) cancelAnimationFrame(rafId);
+    lastTs = 0;
+    rafId = requestAnimationFrame(frame);
   }
 
   // wait for images (logo + bgs) to load before the FIRST measure, so heights are correct
@@ -686,11 +732,11 @@ function renderDirectoryBoard(c) {
     setTimeout(build, 5000); // hard timeout so we never hang
   }
 
-  // re-layout on resize (debounced) — rebuild preserves scroll phase
+  // re-layout on resize (debounced) — re-measure at the new width, resume at the same fraction
   var rT;
   window.addEventListener('resize', function(){
     clearTimeout(rT);
-    rT = setTimeout(function(){ layoutScroller(); rebuildTrack(true); }, 250);
+    rT = setTimeout(function(){ layoutScroller(); resetPool(); remeasure(true); }, 250);
   });
 
   // ----- live data refresh: poll data.json; re-render ONLY when the entries changed -----
@@ -708,7 +754,8 @@ function renderDirectoryBoard(c) {
         if (sig === lastSig) return;      // unchanged -> leave the scroll running untouched
         lastSig = sig;
         cfg.categories = cats;
-        rebuildTrack(true);               // re-render in place; phase kept via negative delay
+        resetPool();                      // new data -> pooled elements must repaint
+        remeasure(true);                  // re-measure in place; scroll resumes at the same fraction
       })
       .catch(function(){ /* transient error -> keep last-good board */ });
   }, REFRESH_MS);

--- a/server/routes/widgets.js
+++ b/server/routes/widgets.js
@@ -613,9 +613,9 @@ function renderDirectoryBoard(c) {
   var track = document.getElementById('track');
 
   // ----- WINDOWED (virtualized) marquee -----
-  // Only the categories intersecting the viewport (+ a small buffer) are ever in the DOM, each on
-  // its own small compositor layer. As the scroll advances we recycle a tiny element pool instead
-  // of translating one enormous cloned track. That keeps every composited layer ~1 screen tall no
+  // Each category is pre-built ONCE onto its own small compositor layer; the scroll only shows the
+  // ones intersecting the viewport (+ a small buffer) and moves them with a transform. Nothing is
+  // built, parsed, or laid out per frame. That keeps every composited layer ~1 screen tall no
   // matter how long the directory is, so the GPU never re-rasterizes an oversized layer — which was
   // the tile-boundary stall (~1 dropped frame every 512px-tile / speed ≈ 11s) that hitched the old
   // CSS marquee once the track grew past a few thousand px.
@@ -627,15 +627,22 @@ function renderDirectoryBoard(c) {
   document.head.appendChild(vstyle);
 
   var vlayout = [];   // [{top,h}] per category, in virtual (content) coordinates
+  var insts = [];     // pre-built display instances: [{top,h,k,el,shown}] (one el per category × wrap-copy)
   var loopH = 0;      // full scroll period = total content height + one GAP_PX (the end→repeat gap)
   var viewH = 0;      // cached scroller height, so the frame loop never forces a layout read
   var speedPxSec = 0;
   var pos = 0;        // virtual scroll offset; advances downward, wraps at loopH
-  var pool = [];      // recycled elements: { el, cat (rendered category idx), key ('i:k' or null) }
   var rafId = null, lastTs = 0;
 
-  // Measure every category's natural height once, at the true render width (hidden flow pass),
-  // and record its virtual top. Cheap: runs on first paint, resize, and real data changes only.
+  function clearInsts() {
+    for (var n = 0; n < insts.length; n++) { var e = insts[n].el; if (e.parentNode) e.parentNode.removeChild(e); }
+    insts = [];
+  }
+
+  // Measure each category once at the true render width, then PRE-BUILD every instance that can ever
+  // be on screen (each category × the -1/0/+1 wrap-copies at the loop seam). Runs ONLY on first paint,
+  // resize, and real data changes — never during scroll — so the frame loop only moves finished
+  // elements; it never parses HTML or forces layout. (That per-recycle rebuild was the irregular hitch.)
   function measureLayout() {
     viewH = scroller.getBoundingClientRect().height || window.innerHeight;
     var arr = Array.isArray(cfg.categories) ? cfg.categories : [];
@@ -654,39 +661,33 @@ function renderDirectoryBoard(c) {
     track.removeChild(meas);
     loopH = top + GAP_PX;
     speedPxSec = (top <= viewH) ? MIN_SCROLL_PX_SEC : (SPEEDS[cfg.scroll_speed] || SPEEDS.medium);
+    clearInsts();
+    for (var i = 0; i < arr.length; i++) {
+      for (var k = -1; k <= 1; k++) {
+        var cel = buildCategoryEl(arr[i]);
+        cel.className = 'category vcat';
+        cel.style.display = 'none';
+        track.appendChild(cel);
+        insts.push({ top: vlayout[i].top, h: vlayout[i].h, k: k, el: cel, shown: false });
+      }
+    }
   }
 
-  // Reconcile the visible window: figure out which (category, wrap-copy) instances are on screen,
-  // reuse pooled elements for them, and only repaint an element when its category actually changes.
+  // Per-frame: reposition the pre-built instances. Pure number math + compositor-only transform
+  // writes, zero allocations — nothing here can trigger GC or a layout, so the scroll stays smooth.
   function renderWindow() {
     if (loopH <= 0) return;
-    var buffer = 140, need = {}, i, k, p;
-    for (i = 0; i < vlayout.length; i++) {
-      var baseY = vlayout[i].top - pos;
-      for (k = -1; k <= 1; k++) { // -1/0/+1 covers the seamless wrap at the loop boundary
-        var y = baseY + k * loopH;
-        if (y + vlayout[i].h >= -buffer && y <= viewH + buffer) need[i + ':' + k] = { i: i, y: y };
+    var buffer = 140;
+    for (var n = 0; n < insts.length; n++) {
+      var it = insts[n];
+      var y = it.top - pos + it.k * loopH;
+      if (y + it.h >= -buffer && y <= viewH + buffer) {
+        it.el.style.transform = 'translate3d(0,' + y + 'px,0)';
+        if (!it.shown) { it.el.style.display = ''; it.shown = true; }
+      } else if (it.shown) {
+        it.el.style.display = 'none'; it.shown = false;
       }
     }
-    for (p = 0; p < pool.length; p++) { // release elements that scrolled out of the window
-      if (pool[p].key && !need[pool[p].key]) { pool[p].key = null; pool[p].el.style.display = 'none'; }
-    }
-    Object.keys(need).forEach(function(key){
-      var want = need[key], slot = null, q;
-      for (q = 0; q < pool.length; q++) { if (pool[q].key === key) { slot = pool[q]; break; } }
-      if (!slot) {
-        for (q = 0; q < pool.length; q++) { if (!pool[q].key) { slot = pool[q]; break; } }
-        if (!slot) { slot = { el: document.createElement('div'), cat: -1, key: null }; track.appendChild(slot.el); pool.push(slot); }
-        if (slot.cat !== want.i) { // repaint only when the pooled element takes on a new category
-          slot.el.className = 'category vcat';
-          slot.el.innerHTML = buildCategoryEl(cfg.categories[want.i]).innerHTML;
-          slot.cat = want.i;
-        }
-        slot.el.style.display = '';
-        slot.key = key;
-      }
-      slot.el.style.transform = 'translate3d(0,' + want.y + 'px,0)';
-    });
   }
 
   function frame(ts) {
@@ -699,11 +700,7 @@ function renderDirectoryBoard(c) {
     rafId = requestAnimationFrame(frame);
   }
 
-  function resetPool() { // force a full repaint (widths or data changed) on next renderWindow
-    for (var p = 0; p < pool.length; p++) { pool[p].key = null; pool[p].cat = -1; pool[p].el.style.display = 'none'; }
-  }
-
-  function remeasure(preservePhase) { // re-measure, optionally resuming at the same scroll fraction
+  function remeasure(preservePhase) { // re-measure + rebuild instances, resuming at the same fraction
     var frac = (preservePhase && loopH > 0) ? (pos / loopH) : 0;
     measureLayout();
     pos = frac * loopH;
@@ -736,7 +733,7 @@ function renderDirectoryBoard(c) {
   var rT;
   window.addEventListener('resize', function(){
     clearTimeout(rT);
-    rT = setTimeout(function(){ layoutScroller(); resetPool(); remeasure(true); }, 250);
+    rT = setTimeout(function(){ layoutScroller(); remeasure(true); }, 250);
   });
 
   // ----- live data refresh: poll data.json; re-render ONLY when the entries changed -----
@@ -754,8 +751,7 @@ function renderDirectoryBoard(c) {
         if (sig === lastSig) return;      // unchanged -> leave the scroll running untouched
         lastSig = sig;
         cfg.categories = cats;
-        resetPool();                      // new data -> pooled elements must repaint
-        remeasure(true);                  // re-measure in place; scroll resumes at the same fraction
+        remeasure(true);                  // rebuild instances in place; scroll resumes at the same fraction
       })
       .catch(function(){ /* transient error -> keep last-good board */ });
   }, REFRESH_MS);

--- a/server/routes/widgets.js
+++ b/server/routes/widgets.js
@@ -622,31 +622,35 @@ function renderDirectoryBoard(c) {
   }
 
   var track = document.getElementById('track');
+  var scrollStyle = document.createElement('style');
+  scrollStyle.id = 'scroll-kf';
+  document.head.appendChild(scrollStyle);
+  var cycleH = 0, durationS = 0;
 
-  // ----- scroll engine: a JS-owned offset driven by requestAnimationFrame -----
-  // NOT a CSS @keyframes animation: a keyframe restarts from 0% whenever it's re-injected,
-  // so any live data change (or iframe reload) snapped the scroll to the top. A JS offset
-  // can be rescaled across a rebuild, so the scroll keeps its phase — no jump.
-  var offset = 0, cycleH = 0, speedPxSec = 0, rafId = null, lastTs = 0;
-
-  function computeSpeed(baseH, viewH) {
-    var s = SPEEDS[cfg.scroll_speed] || SPEEDS.medium;
-    return (baseH <= viewH) ? MIN_SCROLL_PX_SEC : s; // content fits -> slow anti-burn-in creep
-  }
-
-  // Build base + gap + enough clones for a seamless loop, re-measure cycleH, and PRESERVE
-  // the current scroll phase. Runs for the first paint, on resize, and on a live data change.
-  function rebuildTrack() {
-    var prevCycle = cycleH;
+  // ----- scroll: an OFF-MAIN-THREAD CSS marquee -----
+  // A CSS @keyframes animation runs on the COMPOSITOR thread, so it stays smooth even under
+  // main-thread jank/GC (a requestAnimationFrame loop dropped ~1 frame per cycle on the panel).
+  // Rebuilt for first paint, resize, and live data changes; a data change PRESERVES the scroll
+  // phase via a negative animation-delay, so an update resumes in place instead of snapping to
+  // the top. Unchanged polls never touch it.
+  function rebuildTrack(preservePhase) {
+    // capture the current scroll phase (0..1) BEFORE we replace the animation
+    var phaseFrac = 0;
+    if (preservePhase && durationS > 0) {
+      try {
+        var a = track.getAnimations && track.getAnimations()[0];
+        if (a) phaseFrac = ((Number(a.currentTime) || 0) % (durationS * 1000)) / (durationS * 1000);
+      } catch (e) {}
+    }
     track.replaceChildren(); // drop all old nodes in one shot (no detached-node buildup)
     var baseBlock = buildBlock();
     track.appendChild(baseBlock);
-    var baseH = baseBlock.getBoundingClientRect().height;
-    cycleH = baseH + GAP_PX; // translate distance per loop; MUST equal base height + .gap (#197)
-    var viewH = scroller.getBoundingClientRect().height || window.innerHeight;
     var gap = document.createElement('div');
     gap.className = 'gap'; gap.style.height = GAP_PX + 'px';
     track.appendChild(gap);
+    var baseH = baseBlock.getBoundingClientRect().height;
+    cycleH = baseH + GAP_PX; // translate distance per loop; base height + .gap (#197 seam invariant)
+    var viewH = scroller.getBoundingClientRect().height || window.innerHeight;
     var cloneCount = Math.max(1, Math.ceil((viewH + cycleH) / cycleH));
     for (var i = 0; i < cloneCount; i++) {
       track.appendChild(buildBlock());
@@ -656,29 +660,17 @@ function renderDirectoryBoard(c) {
         track.appendChild(g);
       }
     }
-    speedPxSec = computeSpeed(baseH, viewH);
-    // keep scroll phase: map the old offset into the new cycle so a content change never jumps
-    if (prevCycle > 0 && cycleH > 0) offset = (offset / prevCycle) * cycleH;
-    if (cycleH > 0) { offset %= cycleH; if (offset < 0) offset += cycleH; }
-    track.style.transform = 'translate3d(0,' + (-offset) + 'px,0)';
-  }
-
-  function tick(ts) {
-    var dt = lastTs ? (ts - lastTs) / 1000 : 0;
-    lastTs = ts;
-    if (dt > 0.25) dt = 0; // resumed from a backgrounded/throttled tab -> skip, never jump
-    if (cycleH > 0 && speedPxSec > 0) {
-      offset += speedPxSec * dt;
-      if (offset >= cycleH) offset -= cycleH;
-      track.style.transform = 'translate3d(0,' + (-offset) + 'px,0)';
-    }
-    rafId = requestAnimationFrame(tick);
+    var speedPxSec = (baseH <= viewH) ? MIN_SCROLL_PX_SEC : (SPEEDS[cfg.scroll_speed] || SPEEDS.medium);
+    durationS = cycleH / speedPxSec;
+    var delay = preservePhase ? (-phaseFrac * durationS).toFixed(3) : 0; // resume at the same phase
+    scrollStyle.textContent =
+      '@keyframes dir-scroll { from { transform: translate3d(0,0,0); } to { transform: translate3d(0,-' + cycleH + 'px,0); } }' +
+      '.track { animation: dir-scroll ' + durationS + 's linear infinite; animation-delay: ' + delay + 's; }';
   }
 
   function firstPaint() {
     layoutScroller();
-    rebuildTrack();
-    if (rafId == null) { lastTs = 0; rafId = requestAnimationFrame(tick); }
+    rebuildTrack(false);
   }
 
   // wait for images (logo + bgs) to load before the FIRST measure, so heights are correct
@@ -698,7 +690,7 @@ function renderDirectoryBoard(c) {
   var rT;
   window.addEventListener('resize', function(){
     clearTimeout(rT);
-    rT = setTimeout(function(){ layoutScroller(); rebuildTrack(); }, 250);
+    rT = setTimeout(function(){ layoutScroller(); rebuildTrack(true); }, 250);
   });
 
   // ----- live data refresh: poll data.json; re-render ONLY when the entries changed -----
@@ -716,7 +708,7 @@ function renderDirectoryBoard(c) {
         if (sig === lastSig) return;      // unchanged -> leave the scroll running untouched
         lastSig = sig;
         cfg.categories = cats;
-        rebuildTrack();                   // re-render rows in place; phase preserved -> no jump
+        rebuildTrack(true);               // re-render in place; phase kept via negative delay
       })
       .catch(function(){ /* transient error -> keep last-good board */ });
   }, REFRESH_MS);

--- a/server/routes/widgets.js
+++ b/server/routes/widgets.js
@@ -515,6 +515,7 @@ function renderDirectoryBoard(c) {
   var GAP_PX = 120; // MUST match the .gap element height (set inline below) — the scroll loop
                     // translates by baseH+GAP_PX, so any mismatch jumps that many px each cycle.
   var MIN_SCROLL_PX_SEC = 5; // anti-burn-in minimum when content fits
+  var REFRESH_MS = 60000;    // poll data.json this often; re-render ONLY when entries changed
 
   // ----- header -----
   var header = document.getElementById('header');
@@ -621,75 +622,104 @@ function renderDirectoryBoard(c) {
   }
 
   var track = document.getElementById('track');
-  var baseBlock = buildBlock();
-  track.appendChild(baseBlock);
 
-  // ----- measure + clone enough copies to fill (seamless loop) -----
-  function setupScroll() {
-    // remove any previous clones (on resize)
-    while (track.children.length > 1) track.removeChild(track.lastChild);
-    var gap = document.createElement('div');
-    gap.className = 'gap';
-    gap.style.height = GAP_PX + 'px'; // MUST equal GAP_PX — the loop translates by baseH+GAP_PX;
-    track.appendChild(gap);           // a mismatch (was CSS 120 vs GAP_PX 100) jumps 20px each cycle.
+  // ----- scroll engine: a JS-owned offset driven by requestAnimationFrame -----
+  // NOT a CSS @keyframes animation: a keyframe restarts from 0% whenever it's re-injected,
+  // so any live data change (or iframe reload) snapped the scroll to the top. A JS offset
+  // can be rescaled across a rebuild, so the scroll keeps its phase — no jump.
+  var offset = 0, cycleH = 0, speedPxSec = 0, rafId = null, lastTs = 0;
 
+  function computeSpeed(baseH, viewH) {
+    var s = SPEEDS[cfg.scroll_speed] || SPEEDS.medium;
+    return (baseH <= viewH) ? MIN_SCROLL_PX_SEC : s; // content fits -> slow anti-burn-in creep
+  }
+
+  // Build base + gap + enough clones for a seamless loop, re-measure cycleH, and PRESERVE
+  // the current scroll phase. Runs for the first paint, on resize, and on a live data change.
+  function rebuildTrack() {
+    var prevCycle = cycleH;
+    track.replaceChildren(); // drop all old nodes in one shot (no detached-node buildup)
+    var baseBlock = buildBlock();
+    track.appendChild(baseBlock);
     var baseH = baseBlock.getBoundingClientRect().height;
-    var cycleH = baseH + GAP_PX; // distance to translate per loop
+    cycleH = baseH + GAP_PX; // translate distance per loop; MUST equal base height + .gap (#197)
     var viewH = scroller.getBoundingClientRect().height || window.innerHeight;
-
-    // Clone enough times so track fills scroller + at least one full cycle
-    // Minimum 1 clone (so we can loop). Target: track_height >= view + cycle.
+    var gap = document.createElement('div');
+    gap.className = 'gap'; gap.style.height = GAP_PX + 'px';
+    track.appendChild(gap);
     var cloneCount = Math.max(1, Math.ceil((viewH + cycleH) / cycleH));
     for (var i = 0; i < cloneCount; i++) {
       track.appendChild(buildBlock());
       if (i < cloneCount - 1) {
         var g = document.createElement('div');
-        g.className = 'gap';
-        g.style.height = GAP_PX + 'px'; // keep every clone-gap == GAP_PX (seamless loop)
+        g.className = 'gap'; g.style.height = GAP_PX + 'px'; // every clone-gap == GAP_PX (seamless)
         track.appendChild(g);
       }
     }
-
-    // speed
-    var contentFits = baseH <= viewH;
-    var speedName = cfg.scroll_speed || 'medium';
-    var speedPxSec = SPEEDS[speedName] || SPEEDS.medium;
-    if (contentFits) speedPxSec = MIN_SCROLL_PX_SEC;
-
-    var duration = cycleH / speedPxSec;
-
-    // inject keyframes
-    var oldStyle = document.getElementById('scroll-kf');
-    if (oldStyle) oldStyle.remove();
-    var style = document.createElement('style');
-    style.id = 'scroll-kf';
-    style.textContent =
-      '@keyframes dir-scroll { from { transform: translateY(0); } to { transform: translateY(-' + cycleH + 'px); } }' +
-      '.track { animation: dir-scroll ' + duration + 's linear infinite; }';
-    document.head.appendChild(style);
+    speedPxSec = computeSpeed(baseH, viewH);
+    // keep scroll phase: map the old offset into the new cycle so a content change never jumps
+    if (prevCycle > 0 && cycleH > 0) offset = (offset / prevCycle) * cycleH;
+    if (cycleH > 0) { offset %= cycleH; if (offset < 0) offset += cycleH; }
+    track.style.transform = 'translate3d(0,' + (-offset) + 'px,0)';
   }
 
-  // wait for images (logo + bgs) to load before measuring, so heights are correct
+  function tick(ts) {
+    var dt = lastTs ? (ts - lastTs) / 1000 : 0;
+    lastTs = ts;
+    if (dt > 0.25) dt = 0; // resumed from a backgrounded/throttled tab -> skip, never jump
+    if (cycleH > 0 && speedPxSec > 0) {
+      offset += speedPxSec * dt;
+      if (offset >= cycleH) offset -= cycleH;
+      track.style.transform = 'translate3d(0,' + (-offset) + 'px,0)';
+    }
+    rafId = requestAnimationFrame(tick);
+  }
+
+  function firstPaint() {
+    layoutScroller();
+    rebuildTrack();
+    if (rafId == null) { lastTs = 0; rafId = requestAnimationFrame(tick); }
+  }
+
+  // wait for images (logo + bgs) to load before the FIRST measure, so heights are correct
   var pendingImgs = Array.from(document.images).filter(function(i){ return !i.complete; });
   if (pendingImgs.length === 0) {
-    setupScroll();
+    firstPaint();
   } else {
-    var done = 0;
+    var built = false, build = function(){ if (!built) { built = true; firstPaint(); } };
     pendingImgs.forEach(function(i){
-      var onDone = function(){ done++; if (done === pendingImgs.length) setupScroll(); };
-      i.addEventListener('load', onDone, { once:true });
-      i.addEventListener('error', onDone, { once:true });
+      i.addEventListener('load', build, { once:true });
+      i.addEventListener('error', build, { once:true });
     });
-    // hard timeout so we never hang
-    setTimeout(function(){ if (document.getElementById('scroll-kf') == null) setupScroll(); }, 5000);
+    setTimeout(build, 5000); // hard timeout so we never hang
   }
 
-  // re-layout on resize (debounced)
+  // re-layout on resize (debounced) — rebuild preserves scroll phase
   var rT;
   window.addEventListener('resize', function(){
     clearTimeout(rT);
-    rT = setTimeout(function(){ layoutScroller(); setupScroll(); }, 250);
+    rT = setTimeout(function(){ layoutScroller(); rebuildTrack(); }, 250);
   });
+
+  // ----- live data refresh: poll data.json; re-render ONLY when the entries changed -----
+  // Mirrors the directory-search poll. data.json is THIS board's own feed (relative URL,
+  // CORS-open, no-store). Diff the categories signature and rebuild IN PLACE only on a real
+  // change, so an unchanged poll never touches the running scroll (no periodic reset).
+  var lastSig = JSON.stringify(cfg.categories || []);
+  setInterval(function(){
+    if (document.hidden) return;
+    fetch('data.json', { cache: 'no-store' })
+      .then(function(r){ return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function(data){
+        var cats = data && Array.isArray(data.categories) ? data.categories : [];
+        var sig = JSON.stringify(cats);
+        if (sig === lastSig) return;      // unchanged -> leave the scroll running untouched
+        lastSig = sig;
+        cfg.categories = cats;
+        rebuildTrack();                   // re-render rows in place; phase preserved -> no jump
+      })
+      .catch(function(){ /* transient error -> keep last-good board */ });
+  }, REFRESH_MS);
 
   // ----- pixel shift (anti-burn-in): every 5 min, shift .page 0-3px random dir -----
   var page = document.getElementById('page');

--- a/server/server.js
+++ b/server/server.js
@@ -560,6 +560,8 @@ const { PUBLIC_ROUTERS, JWT_ONLY_ROUTERS, AGENCY_ROUTERS } = require('./config/a
 // BEFORE their parent router mount so the _skipAuth bypass / the limiter fire first.
 app.get('/api/widgets/:id/render', (req, res, next) => { req._skipAuth = true; next(); });
 app.get('/api/widgets/:id/data.json', (req, res, next) => { req._skipAuth = true; next(); });
+app.post('/api/widgets/:id/telemetry', (req, res, next) => { req._skipAuth = true; next(); }); // diag widget reports frame stats (null-origin iframe)
+app.get('/api/widgets/:id/telemetry', (req, res, next) => { req._skipAuth = true; next(); });
 app.get('/api/widgets/preview-session/:id', (req, res, next) => { req._skipAuth = true; next(); });
 app.use('/api/widgets/preview', rateLimit(60000, 30)); // base64 inline = memory-intensive
 app.use('/api/widgets/preview-session', rateLimit(60000, 30)); // preview session creation retains rendered HTML in memory for 5min

--- a/tizen/js/app.js
+++ b/tizen/js/app.js
@@ -586,10 +586,10 @@
   }
 
   // ---- playback ----
-  var player = new PlaylistPlayer(elStage, function () { return serverUrl.replace(/\/+$/, ''); });
+  var player = new PlaylistPlayer(elStage, function () { return serverUrl.replace(/\/+$/, ''); }, function () { return deviceId || ''; });
   // Multi-zone layout renderer (matches the Android player). app.js picks the renderer
   // per playlist-update from payload.layout; the two never run at once.
-  var zoneRenderer = new ZoneRenderer(elStage, function () { return serverUrl.replace(/\/+$/, ''); });
+  var zoneRenderer = new ZoneRenderer(elStage, function () { return serverUrl.replace(/\/+$/, ''); }, function () { return deviceId || ''; });
   // #162: player and zoneRenderer SHARE the single #stage node. Track who currently owns it so we
   // only blank the OTHER renderer when actually switching modes — never on a same-mode unchanged
   // update, which (combined with each renderer's unchanged-sig short-circuit) used to leave the

--- a/tizen/js/player.js
+++ b/tizen/js/player.js
@@ -18,9 +18,10 @@ var TIZEN_I18N = {
 var TZ_LANG = (function () { try { return (localStorage.getItem('rd_lang') || navigator.language || 'en').split('-')[0]; } catch (e) { return 'en'; } })();
 function tzt(k) { return (TIZEN_I18N[TZ_LANG] && TIZEN_I18N[TZ_LANG][k]) || TIZEN_I18N.en[k] || k; }
 
-function PlaylistPlayer(stageEl, getBase) {
+function PlaylistPlayer(stageEl, getBase, getDeviceId) {
   this.stage = stageEl;
   this.getBase = getBase;
+  this.getDeviceId = getDeviceId || function () { return ''; };
   this.items = [];
   this.index = 0;
   this.timer = null;
@@ -547,7 +548,7 @@ PlaylistPlayer.prototype.renderYouTube = function (item, single) {
 };
 
 PlaylistPlayer.prototype.renderWidget = function (item, single) {
-  var src = this.getBase() + '/api/widgets/' + item.widget_id + '/render';
+  var src = this.getBase() + '/api/widgets/' + item.widget_id + '/render' + (this.getDeviceId() ? '?device=' + encodeURIComponent(this.getDeviceId()) : '');
   this.renderFrame(src, single ? 0 : this.durationMs(item));
 };
 
@@ -582,9 +583,10 @@ PlaylistPlayer.prototype.youtubeId = function (url) {
  * the FIRST zone only. Single-zone playback stays in PlaylistPlayer; app.js chooses the
  * renderer from payload.layout.
  */
-function ZoneRenderer(stageEl, getBase) {
+function ZoneRenderer(stageEl, getBase, getDeviceId) {
   this.stage = stageEl;
   this.getBase = getBase;
+  this.getDeviceId = getDeviceId || function () { return ''; };
   this.timezone = null;
   this.zones = [];
   this.timers = {}; // zoneId -> timeout id
@@ -744,7 +746,7 @@ ZoneRenderer.prototype.showItem = function (zone, list, index) {
       zone.el.appendChild(zrFrame(ysrc, 'autoplay; encrypted-media', yvert));
       if (multi) this.scheduleAdvance(zone, dur, advance);
     } else if (a.widget_type || (a.widget_id && !a.content_id)) {
-      zone.el.appendChild(zrFrame(this.getBase() + '/api/widgets/' + a.widget_id + '/render'));
+      zone.el.appendChild(zrFrame(this.getBase() + '/api/widgets/' + a.widget_id + '/render' + (this.getDeviceId() ? '?device=' + encodeURIComponent(this.getDeviceId()) : '')));
       if (multi) this.scheduleAdvance(zone, dur, advance);
     } else if (mime.indexOf('video/') === 0) {
       var v = document.createElement('video');


### PR DESCRIPTION
Bundles three related changes (see the branch's scoped commits):

- **Directory board** — replace the scroll engine with a ring of 4 viewport-tall, compositor-animated panels (no per-frame JS, each layer ~1 screen). Smooth on both Blink and Gecko (stays under Firefox's OMTA prerender gate and off Chromium's oversized-tile path), and a 60s data change swaps a panel's content while it's off-screen, so the board never blanks or resets on refresh.
- **Diag** — new `diag-smoothness` widget: two GPU-composited animations + an on-screen HUD, reporting live frame stats (FPS/refresh/long-frames/worst-stall/verdict) to a public CORS-open telemetry endpoint keyed per device, surfaced on the dashboard device Info tab. Lets us measure real-hardware smoothness remotely.
- **Players** — web/Android/Tizen append `?device=<id>` to widget render URLs so telemetry attributes to the reporting panel.

Verified: affected server tests pass (directory-board render, widget-render-xss, ota-check); diag telemetry confirmed reporting per-device from a real Android panel on alpha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)