### PR TITLE
fix(content): respect current folder when uploading files

### DIFF
--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -83,9 +83,10 @@ export const api = {
     body: JSON.stringify({ parent_id: parentId || null })
   }),
   deleteFolder: (id) => request(`/folders/${id}`, { method: 'DELETE' }),
-  uploadContent: async (file, onProgress) => {
+  uploadContent: async (file, onProgress, folderId) => {
     const formData = new FormData();
     formData.append('file', file);
+    if (folderId) formData.append('folder_id', folderId);
 
     return new Promise((resolve, reject) => {
       const xhr = new XMLHttpRequest();

--- a/frontend/js/views/content-library.js
+++ b/frontend/js/views/content-library.js
@@ -231,7 +231,7 @@ async function handleFiles(files) {
       await api.uploadContent(file, (pct) => {
         progressFill.style.width = pct + '%';
         progressText.textContent = t('content.upload_progress_named_pct', { name: file.name, pct });
-      });
+      }, state.currentFolderId);
       showToast(t('content.toast.uploaded_named', { name: file.name }), 'success');
     } catch (err) {
       showToast(t('content.toast.upload_failed_named', { name: file.name, error: err.message }), 'error');

--- a/server/routes/content.js
+++ b/server/routes/content.js
@@ -99,7 +99,7 @@ router.post('/', checkStorageLimit, upload.single('file'), async (req, res) => {
     if (!req.file) return res.status(400).json({ error: 'No file uploaded' });
 
     // #73: shared ingest - identical processing + insert for dashboard and agency uploads.
-    const content = await ingestUploadedFile({ file: req.file, userId: req.user.id, workspaceId: req.workspaceId });
+    const content = await ingestUploadedFile({ file: req.file, userId: req.user.id, workspaceId: req.workspaceId, folderId: req.body.folder_id || null });
     res.status(201).json(content);
   } catch (err) {
     console.error('Upload error:', err);


### PR DESCRIPTION
## Problem

When navigating into a folder in the content library and uploading files, they always land at root (`folder_id=NULL`) instead of inside the currently open folder. Users have to manually drag each file into the folder after upload.

## Root Cause

The upload flow never reads or forwards the current folder context:

| Layer | What was happening |
|-------|-------------------|
| **Frontend** (`content-library.js`) | `handleFiles()` calls `api.uploadContent(file, onProgress)` without passing `state.currentFolderId` |
| **API client** (`api.js`) | `uploadContent()` builds FormData with only the `file` field — no `folder_id` |
| **Server** (`content.js`) | `POST /api/content` calls `ingestUploadedFile()` without a `folderId` parameter (defaults to `null`) |

## Fix

3 lines across 3 files — copies the exact pattern already used by the agency upload endpoint:

- `api.js`: added optional `folderId` param, appended to FormData when present
- `content-library.js`: `handleFiles()` now passes `state.currentFolderId`
- `content.js`: server reads `req.body.folder_id` from the multipart form and forwards it

## Files

| File | Change |
|------|--------|
| `frontend/js/api.js` | +2/-1 |
| `frontend/js/views/content-library.js` | +1/-1 |
| `server/routes/content.js` | +1/-1 |

## Testing

1. Navigate into a folder in the content library
2. Upload a file via drag-and-drop or file picker
3. File should appear inside the current folder, not at root
4. Upload from root should still work correctly (no folder_id = root)