### PR TITLE
fix(android): visible D-pad focus stroke on setup buttons

### DIFF
--- a/android/app/src/main/res/drawable/button_primary.xml
+++ b/android/app/src/main/res/drawable/button_primary.xml
@@ -1,10 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  Keeps the touch press ripple, and adds a high-contrast white stroke on
+  state_focused so D-pad navigation on Android TV is visible from across the
+  room (the bare <ripple> only reacted to state_pressed). See issue #209.
+-->
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
     android:color="#2563EB">
     <item>
-        <shape android:shape="rectangle">
-            <solid android:color="#3B82F6" />
-            <corners android:radius="8dp" />
-        </shape>
+        <selector>
+            <item android:state_focused="true">
+                <shape android:shape="rectangle">
+                    <solid android:color="#3B82F6" />
+                    <stroke android:width="3dp" android:color="#FFFFFF" />
+                    <corners android:radius="8dp" />
+                </shape>
+            </item>
+            <item>
+                <shape android:shape="rectangle">
+                    <solid android:color="#3B82F6" />
+                    <corners android:radius="8dp" />
+                </shape>
+            </item>
+        </selector>
     </item>
 </ripple>


### PR DESCRIPTION
## Problem
Setup-screen buttons used a bare `<ripple>`, which only reacts to `state_pressed` (touch). D-pad navigation on Android TV triggers `state_focused` — ignored by the ripple — so the focused button was nearly invisible from across the room against the dark `#111827` background.

## Fix
`button_primary.xml` now wraps the button shape in a `<selector>` **kept inside the ripple** (so touch still gets the press ripple) with a bright **3dp white stroke on `state_focused`**. Applies to every setup/provisioning/owner-accessibility button since they all share this drawable.

## Testing
- Android TV emulator with D-pad: focused "Enable"/"Set" button now shows a clear white border.
- Touch: press ripple unchanged.

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)