### PR TITLE
ci(android): cache Gradle to stop wrapper-download flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,12 @@ jobs:
         with:
           distribution: temurin
           java-version: '17'
+          # Cache ~/.gradle/caches AND ~/.gradle/wrapper. The wrapper cache holds the
+          # Gradle distribution (gradle-8.5-bin.zip); without it every run re-downloaded
+          # ~130MB from services.gradle.org, and a transient reset there failed the job
+          # before any test ran (org.gradle.wrapper.Install.forceFetch). On a cache hit the
+          # distribution is already present, so the download — and its flake — is skipped.
+          cache: gradle
       - uses: android-actions/setup-android@v3
       # ScheduleEvalTest reads the SHARED shared/schedule-vectors.json (wired via
       # the test task in app/build.gradle.kts), so a ScheduleEval.kt change that


### PR DESCRIPTION
## Why the CI failed (the "lol")
The `android-test` job failed on **run 30063222009** (the npm-audit-fix PR) with:
```
Downloading https://services.gradle.org/distributions/gradle-8.5-bin.zip
Exception in thread "main" java.net.SocketException: Connection reset
    at org.gradle.wrapper.Install.forceFetch(...)
```
It was **not** a test or code failure — the job died while the Gradle **wrapper downloaded its distribution**, before a single test ran. A plain re-run passed, confirming a transient network flake.

## Root cause
The job runs `./gradlew` with **no Gradle caching**, so *every* run re-downloads the full `gradle-8.5-bin.zip` (~130 MB) from `services.gradle.org`. That's a network dependency on the hot path of every CI run; when the download resets, the whole job fails. Low-frequency (≈1 in ~20 runs today) but avoidable.

## Fix
Add `cache: gradle` to the existing `setup-java` step. It caches `~/.gradle/caches` **and `~/.gradle/wrapper`** — the wrapper cache is where the distribution zip lives, so on a cache hit the wrapper finds Gradle already present and **skips the download entirely**, removing the flaky network call. Bonus: build-cache reuse speeds the job up.

One line of real change (plus a comment explaining it).

## Residual
A **cold** cache (first run per key, or a `gradle-wrapper.properties` change) still downloads once. If even that proves flaky, a download retry can be layered on — but this turns "download every run" into "download rarely", which kills the flake in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)