### PR TITLE
fix(dashboard): make the "Reload now" update toast actually clickable

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -619,7 +619,19 @@ async function checkVersion() {
       if (toast) {
         const notice = document.createElement('div');
         notice.className = 'toast info';
-        notice.innerHTML = '<span>Dashboard updated. <a href="javascript:location.reload()" style="color:var(--accent);text-decoration:underline;font-weight:600">Reload now</a></span>';
+        const span = document.createElement('span');
+        span.textContent = 'Dashboard updated. ';
+        const link = document.createElement('a');
+        link.textContent = 'Reload now';
+        link.href = '#';
+        link.style.cssText = 'color:var(--accent);text-decoration:underline;font-weight:600';
+        // The dashboard CSP is `script-src 'self'` (no 'unsafe-inline'), which blocks
+        // `javascript:` URIs — so the old `href="javascript:location.reload()"` link was dead
+        // (click did nothing, only a CSP console warning). Use a real click listener, which
+        // runs as first-party script and is CSP-clean.
+        link.addEventListener('click', (e) => { e.preventDefault(); location.reload(); });
+        span.appendChild(link);
+        notice.appendChild(span);
         toast.appendChild(notice);
       }
     }


### PR DESCRIPTION
## Problem
After a deploy, `checkVersion()` polls `/api/version`, sees the `hash` change, and pops a **"Dashboard updated. Reload now"** toast. But the "Reload now" link was `href="javascript:location.reload()"`, and the dashboard CSP is `script-src 'self'` (no `'unsafe-inline'`) — which **blocks `javascript:` URIs**. So the link was dead: clicking it did nothing but log a CSP violation, and users had to hard-refresh manually.

(Ironically the CSP allows `script-src-attr 'unsafe-inline'` — i.e. `onclick=` handlers — just not `javascript:` hrefs.)

## Fix
Build the link and attach a real `addEventListener('click', …)` (first-party script from `app.js`, CSP-clean) instead of the inline `javascript:` href. Same text, same styling — the link just works now.

Surfaced by the `1.9.11→1.9.14` prod deploy, which changed the version hash and popped this toast on every open dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)