### PR TITLE
Drop sharp: pure-JS image ops on a worker thread

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@
 # No TLS in the image: it listens on plain HTTP :3001. Front it with a
 # TLS-terminating reverse proxy / Cloudflare in production.
 
-# --- builder: install production deps (native: better-sqlite3, sharp) ---
+# --- builder: install production deps (better-sqlite3 is the only native one left; image
+# decoding is pure JS + WASM since sharp was dropped, and sharp is now a devDependency that
+# --omit=dev leaves out entirely) ---
 FROM node:20-slim AS builder
 WORKDIR /app/server
 # build toolchain in case a native prebuild is missing for the target arch

--- a/server/lib/content-ingest.js
+++ b/server/lib/content-ingest.js
@@ -46,18 +46,23 @@ async function deriveMediaMetadata(sourcePath, filepath, mime) {
       thumbnailPath = filepath;
     } else if (mime.startsWith('image/')) {
       const imageOps = require('./image-ops');
-      const metadata = await imageOps.metadata(sourcePath);
+      const thumbName = `thumb_${filepath}`;
+      // Measure and thumbnail from ONE decode. Asking separately costs two, and a decode is the
+      // single most expensive thing on this path (~1s for a 12MP photo — unlike sharp, whose
+      // .metadata() only read the header). #170: rotation is implicit, the decoder auto-orients,
+      // so the recorded dimensions and the thumbnail agree without an explicit rotate.
+      const metadata = await imageOps.measureAndThumbnail(
+        sourcePath, path.join(config.contentDir, thumbName), config.thumbnailWidth, 70);
       // #170: honor EXIF orientation so a portrait photo isn't stored as landscape. The decoder
       // applies it and reports orientation 1, so this is a no-op pass-through today — kept so the
       // rule lives in one place regardless of which decoder is underneath.
       ({ width, height } = imageDisplayDims(metadata));
-      // Assign thumbnailPath only AFTER the write succeeds: a decode failure used to
-      // return the already-assigned name for a file that was never written, storing a
-      // phantom thumbnail_path that the UI then requests forever as a broken image.
-      const thumbName = `thumb_${filepath}`;
-      // #170: rotation is implicit — the decode already auto-oriented, so the thumbnail matches.
-      await imageOps.writeThumbnail(sourcePath, path.join(config.contentDir, thumbName), config.thumbnailWidth, 70);
-      thumbnailPath = thumbName;
+      // Assign thumbnailPath only if the write actually succeeded: naming it unconditionally used
+      // to store a phantom thumbnail_path for a file that was never created, which the UI then
+      // requests forever as a broken image. The dimensions above survive that failure on purpose —
+      // they are independently useful, and losing them would letterbox the asset wrongly.
+      if (metadata.thumbnailWritten) thumbnailPath = thumbName;
+      else console.warn(`Thumbnail write failed for ${filepath}: ${metadata.thumbnailError}`);
     } else if (mime.startsWith('video/')) {
       try {
         // execFile, NOT execFileSync. These two spawns each carry a 15s timeout, and run

--- a/server/lib/content-ingest.js
+++ b/server/lib/content-ingest.js
@@ -31,7 +31,7 @@ function safeFilename(name) {
  * orientation bug (#170) that the ingest path fixes with imageDisplayDims + .rotate(). A second
  * copy of this logic is a second place for it to rot; there is now one.
  *
- * Best-effort by contract: a missing ffprobe or a sharp failure yields nulls and a warning, never
+ * Best-effort by contract: a missing ffprobe or a decode failure yields nulls and a warning, never
  * a throw — the file itself is already stored and is worth more than its metadata.
  *
  * @returns {{width:number|null, height:number|null, durationSec:number|null, thumbnailPath:string|null}}
@@ -39,24 +39,24 @@ function safeFilename(name) {
 async function deriveMediaMetadata(sourcePath, filepath, mime) {
   let width = null, height = null, durationSec = null, thumbnailPath = null;
   try {
-    // SVG is deliberately NOT handed to sharp: rasterising it goes through librsvg, which
-    // is where the outstanding libvips CVEs live, and an SVG is already its own thumbnail.
+    // SVG is deliberately NOT rasterised: it is already its own thumbnail. (It also used to be
+    // the one format kept away from sharp, because rasterising went through librsvg — where the
+    // outstanding libvips CVEs live. Nothing rasterises it now either.)
     if (mime === 'image/svg+xml') {
       thumbnailPath = filepath;
     } else if (mime.startsWith('image/')) {
-      const sharp = require('sharp');
-      const metadata = await sharp(sourcePath).metadata();
-      // #170: honor EXIF orientation so a portrait photo isn't stored as landscape.
+      const imageOps = require('./image-ops');
+      const metadata = await imageOps.metadata(sourcePath);
+      // #170: honor EXIF orientation so a portrait photo isn't stored as landscape. The decoder
+      // applies it and reports orientation 1, so this is a no-op pass-through today — kept so the
+      // rule lives in one place regardless of which decoder is underneath.
       ({ width, height } = imageDisplayDims(metadata));
-      // Assign thumbnailPath only AFTER the write succeeds: a sharp failure used to
+      // Assign thumbnailPath only AFTER the write succeeds: a decode failure used to
       // return the already-assigned name for a file that was never written, storing a
       // phantom thumbnail_path that the UI then requests forever as a broken image.
       const thumbName = `thumb_${filepath}`;
-      await sharp(sourcePath)
-        .rotate() // #170: auto-orient per EXIF (and strip the tag) so the thumbnail matches
-        .resize(config.thumbnailWidth)
-        .jpeg({ quality: 70 })
-        .toFile(path.join(config.contentDir, thumbName));
+      // #170: rotation is implicit — the decode already auto-oriented, so the thumbnail matches.
+      await imageOps.writeThumbnail(sourcePath, path.join(config.contentDir, thumbName), config.thumbnailWidth, 70);
       thumbnailPath = thumbName;
     } else if (mime.startsWith('video/')) {
       try {

--- a/server/lib/image-ops-core.js
+++ b/server/lib/image-ops-core.js
@@ -1,0 +1,111 @@
+'use strict';
+
+/*
+ * Pure-JavaScript image operations — the two things the ingest path ever asked sharp for:
+ * measure an image, and write a thumbnail.
+ *
+ * THIS FILE IS THE WORK, NOT THE ENTRY POINT. Callers use ./image-ops, which runs these on a
+ * worker thread; everything here is CPU-bound pure JS that would otherwise stall the event loop
+ * for ~1s per 12MP photo. Requiring this module directly is only correct inside the worker (or in
+ * image-ops' inline fallback). See ./image-ops for why.
+ *
+ * WHY NOT SHARP: sharp is a native module wrapping libvips. That costs us a prebuilt binary per
+ * platform/ABI, and when there isn't one (or Node moves ABI) the failure is
+ * ERR_DLOPEN_FAILED/NODE_MODULE_VERSION at require time — the same class of breakage
+ * lib/preflight-deps.js exists to explain for better-sqlite3. Nothing in here is native, so the
+ * server runs anywhere Node runs, including the embedded targets that have no toolchain.
+ *
+ * FORMAT COVERAGE vs the sharp it replaces:
+ *   jpeg png gif tiff bmp   Jimp, natively
+ *   webp avif               @jsquash/* — WebAssembly, bundled, no network (see wasmDecode below)
+ *   svg                     never reaches here; callers thumbnail an SVG with itself
+ *   heic                    unsupported — and it already was. sharp lists `heif`, but its
+ *                           prebuilt libvips has AV1 only and refuses HEVC ("Unsupported
+ *                           compression"), so .heic uploads have never produced a thumbnail.
+ *
+ * ORIENTATION (#170): Jimp applies EXIF orientation when it decodes and rewrites the tag to 1,
+ * so what comes back is already DISPLAY dimensions — the rotation sharp needed an explicit
+ * .rotate() for. metadata() therefore reports orientation 1 and lets imageDisplayDims() run as a
+ * no-op rather than swapping W/H a second time. Report the tag honestly and that helper stays
+ * correct for any future decoder that does NOT auto-orient.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const { sniffMime } = require('./upload-sniff');
+
+// Jimp is ESM-first but ships a CJS entry; require() is fine and keeps this file loadable from
+// the CommonJS server. Deferred so a caller that never touches an image never pays for it.
+let _jimp = null;
+function jimp() {
+  if (!_jimp) _jimp = require('jimp');
+  return _jimp;
+}
+
+/*
+ * @jsquash's decoders are browser-first: they locate their .wasm with
+ * `fetch(new URL('...wasm', import.meta.url))`. Under Node that URL is a file:// one and Node's
+ * fetch does not implement file://, so the bundled binary never loads and the only symptom is a
+ * bare "fetch failed". The binary IS on disk in the package — read and compile it ourselves, then
+ * hand the Module to init(). No network, at install time or after.
+ */
+const WASM_CODECS = {
+  'image/webp': { pkg: '@jsquash/webp', wasm: '@jsquash/webp/codec/dec/webp_dec.wasm' },
+  'image/avif': { pkg: '@jsquash/avif', wasm: '@jsquash/avif/codec/dec/avif_dec.wasm' },
+};
+const decoderCache = new Map();
+
+async function wasmDecode(mime, buf) {
+  const spec = WASM_CODECS[mime];
+  if (!spec) return null;
+  if (!decoderCache.has(mime)) {
+    decoderCache.set(mime, (async () => {
+      const mod = await import(`${spec.pkg}/decode.js`);
+      await mod.init(await WebAssembly.compile(fs.readFileSync(require.resolve(spec.wasm))));
+      return mod.default;
+    })());
+  }
+  const decode = await decoderCache.get(mime);
+  return decode(buf);   // -> ImageData-ish { data, width, height }
+}
+
+/*
+ * Decode to a Jimp image whatever the format. Reuses sniffMime rather than carrying a second copy
+ * of the magic-byte table — routes/media.js already duplicating it once is noted there as a smell.
+ * Throws on anything undecodable, which is the contract callers already handle (a failure yields
+ * null metadata and no thumbnail, never a lost upload).
+ */
+async function readImage(src) {
+  const buf = await fs.promises.readFile(src);
+  const mime = sniffMime(buf);
+
+  if (WASM_CODECS[mime]) {
+    const raw = await wasmDecode(mime, buf);
+    if (!raw) throw new Error(`no decoder for ${mime}`);
+    return jimp().Jimp.fromBitmap({ data: Buffer.from(raw.data), width: raw.width, height: raw.height });
+  }
+  return jimp().Jimp.read(buf);
+}
+
+/*
+ * Display dimensions, shaped like the sharp metadata the callers already destructure.
+ * orientation is 1 because the decode above already applied it — see ORIENTATION note at the top.
+ */
+async function metadata(src) {
+  const img = await readImage(src);
+  return { width: img.bitmap.width, height: img.bitmap.height, orientation: 1 };
+}
+
+/*
+ * Write a JPEG thumbnail `width` px wide, aspect preserved — sharp's
+ * .rotate().resize(width).jpeg({quality}).toFile(). Rotation is implicit in the decode.
+ * Never upscales: sharp's resize() would enlarge a small source, but a thumbnail bigger than its
+ * original is pure waste, and the callers only ever shrink.
+ */
+async function writeThumbnail(src, destPath, width, quality = 70) {
+  const img = await readImage(src);
+  if (img.bitmap.width > width) img.resize({ w: width });
+  await fs.promises.writeFile(destPath, await img.getBuffer('image/jpeg', { quality }));
+}
+
+module.exports = { metadata, writeThumbnail, readImage };

--- a/server/lib/image-ops-core.js
+++ b/server/lib/image-ops-core.js
@@ -97,15 +97,46 @@ async function metadata(src) {
 }
 
 /*
- * Write a JPEG thumbnail `width` px wide, aspect preserved — sharp's
- * .rotate().resize(width).jpeg({quality}).toFile(). Rotation is implicit in the decode.
- * Never upscales: sharp's resize() would enlarge a small source, but a thumbnail bigger than its
- * original is pure waste, and the callers only ever shrink.
+ * Resize-and-encode an ALREADY DECODED image. Never upscales: sharp's resize() would enlarge a
+ * small source, but a thumbnail bigger than its original is pure waste and callers only shrink.
+ * Mutates img, so measure before calling.
  */
-async function writeThumbnail(src, destPath, width, quality = 70) {
-  const img = await readImage(src);
+async function encodeThumbnail(img, destPath, width, quality) {
   if (img.bitmap.width > width) img.resize({ w: width });
   await fs.promises.writeFile(destPath, await img.getBuffer('image/jpeg', { quality }));
 }
 
-module.exports = { metadata, writeThumbnail, readImage };
+/*
+ * Write a JPEG thumbnail `width` px wide, aspect preserved — sharp's
+ * .rotate().resize(width).jpeg({quality}).toFile(). Rotation is implicit in the decode.
+ */
+async function writeThumbnail(src, destPath, width, quality = 70) {
+  await encodeThumbnail(await readImage(src), destPath, width, quality);
+}
+
+/*
+ * Measure AND thumbnail from a SINGLE decode — what ingest actually wants.
+ *
+ * Calling metadata() then writeThumbnail() decodes the file twice. That was free under sharp,
+ * whose .metadata() only parses the header, but here every decode is the full ~1s of a 12MP
+ * photo, so the naive pairing doubled the most expensive thing the ingest path does.
+ *
+ * A thumbnail failure must NOT discard the dimensions: they are independently useful (the player
+ * needs them to letterbox correctly) and that is how the two-call version behaved, since width and
+ * height were already assigned before the thumbnail was written. So the write is reported, not
+ * thrown — and the caller assigns a thumbnail_path only when thumbnailWritten is true, keeping the
+ * phantom-path discipline that stops the UI requesting a file that was never created.
+ * A DECODE failure still throws: there is nothing to report about an unreadable image.
+ */
+async function measureAndThumbnail(src, destPath, width, quality = 70) {
+  const img = await readImage(src);
+  const measured = { width: img.bitmap.width, height: img.bitmap.height, orientation: 1 };
+  try {
+    await encodeThumbnail(img, destPath, width, quality);
+    return { ...measured, thumbnailWritten: true, thumbnailError: null };
+  } catch (err) {
+    return { ...measured, thumbnailWritten: false, thumbnailError: err && err.message ? err.message : String(err) };
+  }
+}
+
+module.exports = { metadata, writeThumbnail, measureAndThumbnail, readImage };

--- a/server/lib/image-ops-worker.js
+++ b/server/lib/image-ops-worker.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/*
+ * Worker-thread host for image-ops-core. One job per message, one reply per job, keyed by id.
+ *
+ * Deliberately thin: every decision (queueing, lifecycle, fallback) lives in ../lib/image-ops so
+ * there is one place to reason about them. This end only does the work and reports what happened.
+ *
+ * Errors come back as a message rather than a thrown exception, so one undecodable upload does
+ * not tear down the worker and take the queued jobs of unrelated callers with it.
+ */
+
+const { parentPort } = require('worker_threads');
+const core = require('./image-ops-core');
+
+const OPS = {
+  metadata: (job) => core.metadata(job.src),
+  writeThumbnail: (job) => core.writeThumbnail(job.src, job.dest, job.width, job.quality),
+};
+
+parentPort.on('message', async (job) => {
+  try {
+    const op = OPS[job.op];
+    if (!op) throw new Error(`unknown image op: ${job.op}`);
+    parentPort.postMessage({ id: job.id, ok: true, result: await op(job) });
+  } catch (err) {
+    parentPort.postMessage({ id: job.id, ok: false, error: err && err.message ? err.message : String(err) });
+  }
+});

--- a/server/lib/image-ops-worker.js
+++ b/server/lib/image-ops-worker.js
@@ -16,6 +16,7 @@ const core = require('./image-ops-core');
 const OPS = {
   metadata: (job) => core.metadata(job.src),
   writeThumbnail: (job) => core.writeThumbnail(job.src, job.dest, job.width, job.quality),
+  measureAndThumbnail: (job) => core.measureAndThumbnail(job.src, job.dest, job.width, job.quality),
 };
 
 parentPort.on('message', async (job) => {

--- a/server/lib/image-ops.js
+++ b/server/lib/image-ops.js
@@ -127,6 +127,15 @@ function writeThumbnail(src, dest, width, quality = 70) {
   return submit({ op: 'writeThumbnail', src, dest, width, quality });
 }
 
+/*
+ * Both of the above from ONE decode -> { width, height, orientation, thumbnailWritten,
+ * thumbnailError }. Prefer this wherever both are wanted: a decode here is the full ~1s of a 12MP
+ * photo, not sharp's cheap header parse, so the pair costs double. See image-ops-core.
+ */
+function measureAndThumbnail(src, dest, width, quality = 70) {
+  return submit({ op: 'measureAndThumbnail', src, dest, width, quality });
+}
+
 /* Drop the worker now rather than waiting out the idle timer. For shutdown paths and tests. */
 async function shutdown() {
   clearIdleTimer();
@@ -135,4 +144,4 @@ async function shutdown() {
   if (w) await w.terminate();
 }
 
-module.exports = { metadata, writeThumbnail, shutdown };
+module.exports = { metadata, writeThumbnail, measureAndThumbnail, shutdown };

--- a/server/lib/image-ops.js
+++ b/server/lib/image-ops.js
@@ -1,0 +1,106 @@
+'use strict';
+
+/*
+ * Pure-JavaScript image operations — the two things the ingest path ever asked sharp for:
+ * measure an image, and write a thumbnail.
+ *
+ * WHY NOT SHARP: sharp is a native module wrapping libvips. That costs us a prebuilt binary per
+ * platform/ABI, and when there isn't one (or Node moves ABI) the failure is
+ * ERR_DLOPEN_FAILED/NODE_MODULE_VERSION at require time — the same class of breakage
+ * lib/preflight-deps.js exists to explain for better-sqlite3. Nothing in here is native, so the
+ * server runs anywhere Node runs, including the embedded targets that have no toolchain.
+ *
+ * FORMAT COVERAGE vs the sharp it replaces:
+ *   jpeg png gif tiff bmp   Jimp, natively
+ *   webp avif               @jsquash/* — WebAssembly, bundled, no network (see wasmDecode below)
+ *   svg                     never reaches here; callers thumbnail an SVG with itself
+ *   heic                    unsupported — and it already was. sharp lists `heif`, but its
+ *                           prebuilt libvips has AV1 only and refuses HEVC ("Unsupported
+ *                           compression"), so .heic uploads have never produced a thumbnail.
+ *
+ * ORIENTATION (#170): Jimp applies EXIF orientation when it decodes and rewrites the tag to 1,
+ * so what comes back is already DISPLAY dimensions — the rotation sharp needed an explicit
+ * .rotate() for. metadata() therefore reports orientation 1 and lets imageDisplayDims() run as a
+ * no-op rather than swapping W/H a second time. Report the tag honestly and that helper stays
+ * correct for any future decoder that does NOT auto-orient.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const { sniffMime } = require('./upload-sniff');
+
+// Jimp is ESM-first but ships a CJS entry; require() is fine and keeps this file loadable from
+// the CommonJS server. Deferred so a caller that never touches an image never pays for it.
+let _jimp = null;
+function jimp() {
+  if (!_jimp) _jimp = require('jimp');
+  return _jimp;
+}
+
+/*
+ * @jsquash's decoders are browser-first: they locate their .wasm with
+ * `fetch(new URL('...wasm', import.meta.url))`. Under Node that URL is a file:// one and Node's
+ * fetch does not implement file://, so the bundled binary never loads and the only symptom is a
+ * bare "fetch failed". The binary IS on disk in the package — read and compile it ourselves, then
+ * hand the Module to init(). No network, at install time or after.
+ */
+const WASM_CODECS = {
+  'image/webp': { pkg: '@jsquash/webp', wasm: '@jsquash/webp/codec/dec/webp_dec.wasm' },
+  'image/avif': { pkg: '@jsquash/avif', wasm: '@jsquash/avif/codec/dec/avif_dec.wasm' },
+};
+const decoderCache = new Map();
+
+async function wasmDecode(mime, buf) {
+  const spec = WASM_CODECS[mime];
+  if (!spec) return null;
+  if (!decoderCache.has(mime)) {
+    decoderCache.set(mime, (async () => {
+      const mod = await import(`${spec.pkg}/decode.js`);
+      await mod.init(await WebAssembly.compile(fs.readFileSync(require.resolve(spec.wasm))));
+      return mod.default;
+    })());
+  }
+  const decode = await decoderCache.get(mime);
+  return decode(buf);   // -> ImageData-ish { data, width, height }
+}
+
+/*
+ * Decode to a Jimp image whatever the format. Reuses sniffMime rather than carrying a second copy
+ * of the magic-byte table — routes/media.js already duplicating it once is noted there as a smell.
+ * Throws on anything undecodable, which is the contract callers already handle (a failure yields
+ * null metadata and no thumbnail, never a lost upload).
+ */
+async function readImage(src) {
+  const buf = await fs.promises.readFile(src);
+  const mime = sniffMime(buf);
+
+  if (WASM_CODECS[mime]) {
+    const raw = await wasmDecode(mime, buf);
+    if (!raw) throw new Error(`no decoder for ${mime}`);
+    return jimp().Jimp.fromBitmap({ data: Buffer.from(raw.data), width: raw.width, height: raw.height });
+  }
+  return jimp().Jimp.read(buf);
+}
+
+/*
+ * Display dimensions, shaped like the sharp metadata the callers already destructure.
+ * orientation is 1 because the decode above already applied it — see ORIENTATION note at the top.
+ */
+async function metadata(src) {
+  const img = await readImage(src);
+  return { width: img.bitmap.width, height: img.bitmap.height, orientation: 1 };
+}
+
+/*
+ * Write a JPEG thumbnail `width` px wide, aspect preserved — sharp's
+ * .rotate().resize(width).jpeg({quality}).toFile(). Rotation is implicit in the decode.
+ * Never upscales: sharp's resize() would enlarge a small source, but a thumbnail bigger than its
+ * original is pure waste, and the callers only ever shrink.
+ */
+async function writeThumbnail(src, destPath, width, quality = 70) {
+  const img = await readImage(src);
+  if (img.bitmap.width > width) img.resize({ w: width });
+  await fs.promises.writeFile(destPath, await img.getBuffer('image/jpeg', { quality }));
+}
+
+module.exports = { metadata, writeThumbnail, readImage };

--- a/server/lib/image-ops.js
+++ b/server/lib/image-ops.js
@@ -1,106 +1,138 @@
 'use strict';
 
 /*
- * Pure-JavaScript image operations — the two things the ingest path ever asked sharp for:
- * measure an image, and write a thumbnail.
+ * Image operations, off the main thread.
  *
- * WHY NOT SHARP: sharp is a native module wrapping libvips. That costs us a prebuilt binary per
- * platform/ABI, and when there isn't one (or Node moves ABI) the failure is
- * ERR_DLOPEN_FAILED/NODE_MODULE_VERSION at require time — the same class of breakage
- * lib/preflight-deps.js exists to explain for better-sqlite3. Nothing in here is native, so the
- * server runs anywhere Node runs, including the embedded targets that have no toolchain.
+ * WHY THIS EXISTS: image-ops-core is pure JavaScript, so unlike the native sharp it replaced —
+ * which handed work to a libvips threadpool — its CPU cost lands on whatever thread calls it. A
+ * 12MP photo measures at ~1.0s of solid, uninterruptible main-thread work. That is not a slow
+ * upload, it is a stalled event loop: no heartbeats, no socket traffic, nothing. lib/thumbnail-
+ * backfill.js walks an entire content library at boot, so in-process it reproduces #240 exactly
+ * (blocked loop -> missed heartbeats -> panels marked offline -> reconnect churn), arriving from
+ * our own maintenance. The same reasoning already moved this file's video branch from
+ * execFileSync to execFile; this is that fix for the image branch.
  *
- * FORMAT COVERAGE vs the sharp it replaces:
- *   jpeg png gif tiff bmp   Jimp, natively
- *   webp avif               @jsquash/* — WebAssembly, bundled, no network (see wasmDecode below)
- *   svg                     never reaches here; callers thumbnail an SVG with itself
- *   heic                    unsupported — and it already was. sharp lists `heif`, but its
- *                           prebuilt libvips has AV1 only and refuses HEVC ("Unsupported
- *                           compression"), so .heic uploads have never produced a thumbnail.
+ * The work is therefore hosted on a worker thread and this module is the only entry point.
  *
- * ORIENTATION (#170): Jimp applies EXIF orientation when it decodes and rewrites the tag to 1,
- * so what comes back is already DISPLAY dimensions — the rotation sharp needed an explicit
- * .rotate() for. metadata() therefore reports orientation 1 and lets imageDisplayDims() run as a
- * no-op rather than swapping W/H a second time. Report the tag honestly and that helper stays
- * correct for any future decoder that does NOT auto-orient.
+ * ONE JOB AT A TIME, deliberately. Decoding holds a full RGBA bitmap — a 12MP photo is ~48MB — so
+ * letting jobs overlap multiplies peak memory by the queue depth, which is exactly the wrong
+ * failure on the small targets this whole change is meant to reach. Serialized, the ceiling is one
+ * image regardless of how many uploads land at once. It also costs nothing in throughput: the work
+ * is CPU-bound, and a single busy worker already saturates the core it runs on.
+ *
+ * The worker is unref'd while idle so it never holds the process open — scripts/backfill-rotation-
+ * dims.js is a CLI that must exit, and `node --test` would otherwise hang forever — and ref'd only
+ * while a job is in flight, so an in-progress thumbnail cannot be cut short by the process exiting.
  */
 
 const path = require('path');
-const fs = require('fs');
-const { sniffMime } = require('./upload-sniff');
 
-// Jimp is ESM-first but ships a CJS entry; require() is fine and keeps this file loadable from
-// the CommonJS server. Deferred so a caller that never touches an image never pays for it.
-let _jimp = null;
-function jimp() {
-  if (!_jimp) _jimp = require('jimp');
-  return _jimp;
+const WORKER_PATH = path.join(__dirname, 'image-ops-worker.js');
+const IDLE_SHUTDOWN_MS = 60_000;   // release the decoder heap (jimp + the WASM codecs) when quiet
+
+let worker = null;
+let idleTimer = null;
+let inFlight = null;               // { id, resolve, reject } — at most one, by design
+let inlineOnly = false;            // set if a worker cannot be created at all; see runInline
+let nextId = 1;
+const queue = [];
+
+function clearIdleTimer() {
+  if (idleTimer) { clearTimeout(idleTimer); idleTimer = null; }
 }
 
-/*
- * @jsquash's decoders are browser-first: they locate their .wasm with
- * `fetch(new URL('...wasm', import.meta.url))`. Under Node that URL is a file:// one and Node's
- * fetch does not implement file://, so the bundled binary never loads and the only symptom is a
- * bare "fetch failed". The binary IS on disk in the package — read and compile it ourselves, then
- * hand the Module to init(). No network, at install time or after.
- */
-const WASM_CODECS = {
-  'image/webp': { pkg: '@jsquash/webp', wasm: '@jsquash/webp/codec/dec/webp_dec.wasm' },
-  'image/avif': { pkg: '@jsquash/avif', wasm: '@jsquash/avif/codec/dec/avif_dec.wasm' },
-};
-const decoderCache = new Map();
-
-async function wasmDecode(mime, buf) {
-  const spec = WASM_CODECS[mime];
-  if (!spec) return null;
-  if (!decoderCache.has(mime)) {
-    decoderCache.set(mime, (async () => {
-      const mod = await import(`${spec.pkg}/decode.js`);
-      await mod.init(await WebAssembly.compile(fs.readFileSync(require.resolve(spec.wasm))));
-      return mod.default;
-    })());
-  }
-  const decode = await decoderCache.get(mime);
-  return decode(buf);   // -> ImageData-ish { data, width, height }
+function scheduleIdleShutdown() {
+  clearIdleTimer();
+  if (!worker || inFlight || queue.length) return;
+  idleTimer = setTimeout(() => {
+    idleTimer = null;
+    if (worker && !inFlight && !queue.length) { const w = worker; worker = null; w.terminate(); }
+  }, IDLE_SHUTDOWN_MS);
+  idleTimer.unref?.();
 }
 
-/*
- * Decode to a Jimp image whatever the format. Reuses sniffMime rather than carrying a second copy
- * of the magic-byte table — routes/media.js already duplicating it once is noted there as a smell.
- * Throws on anything undecodable, which is the contract callers already handle (a failure yields
- * null metadata and no thumbnail, never a lost upload).
- */
-async function readImage(src) {
-  const buf = await fs.promises.readFile(src);
-  const mime = sniffMime(buf);
-
-  if (WASM_CODECS[mime]) {
-    const raw = await wasmDecode(mime, buf);
-    if (!raw) throw new Error(`no decoder for ${mime}`);
-    return jimp().Jimp.fromBitmap({ data: Buffer.from(raw.data), width: raw.width, height: raw.height });
-  }
-  return jimp().Jimp.read(buf);
+// Reject everything outstanding. Called when the worker dies underneath us — a crash means OOM or
+// a bug, not a bad image (image-ops-worker catches decode failures and replies normally), so there
+// is nothing to usefully retry and callers already treat a rejection as "no metadata".
+function failAll(reason) {
+  const dead = [inFlight, ...queue].filter(Boolean);
+  inFlight = null;
+  queue.length = 0;
+  for (const job of dead) job.reject(new Error(reason));
 }
 
-/*
- * Display dimensions, shaped like the sharp metadata the callers already destructure.
- * orientation is 1 because the decode above already applied it — see ORIENTATION note at the top.
- */
-async function metadata(src) {
-  const img = await readImage(src);
-  return { width: img.bitmap.width, height: img.bitmap.height, orientation: 1 };
+function ensureWorker() {
+  if (worker) return worker;
+  const { Worker } = require('worker_threads');
+  worker = new Worker(WORKER_PATH);
+  worker.unref();
+  worker.on('message', (msg) => {
+    const job = inFlight;
+    if (!job || job.id !== msg.id) return;   // a reply from a terminated generation; ignore
+    inFlight = null;
+    if (msg.ok) job.resolve(msg.result); else job.reject(new Error(msg.error));
+    pump();
+  });
+  worker.on('error', (err) => { worker = null; failAll(`image worker failed: ${err.message}`); });
+  worker.on('exit', (code) => {
+    worker = null;
+    if (inFlight || queue.length) failAll(`image worker exited (code ${code})`);
+  });
+  return worker;
 }
 
-/*
- * Write a JPEG thumbnail `width` px wide, aspect preserved — sharp's
- * .rotate().resize(width).jpeg({quality}).toFile(). Rotation is implicit in the decode.
- * Never upscales: sharp's resize() would enlarge a small source, but a thumbnail bigger than its
- * original is pure waste, and the callers only ever shrink.
- */
-async function writeThumbnail(src, destPath, width, quality = 70) {
-  const img = await readImage(src);
-  if (img.bitmap.width > width) img.resize({ w: width });
-  await fs.promises.writeFile(destPath, await img.getBuffer('image/jpeg', { quality }));
+function pump() {
+  if (inFlight) return;
+  if (!queue.length) { worker?.unref(); scheduleIdleShutdown(); return; }
+  clearIdleTimer();
+  inFlight = queue.shift();
+  const w = ensureWorker();
+  w.ref();   // a job is running: hold the process open until it finishes
+  w.postMessage(inFlight.job);
 }
 
-module.exports = { metadata, writeThumbnail, readImage };
+// Last resort: if worker_threads cannot give us a thread at all, do the work in-process rather
+// than refuse to thumbnail. Stalls the loop — that is the bug this module exists to avoid — so it
+// is announced rather than silent.
+async function runInline(job) {
+  const core = require('./image-ops-core');
+  return job.op === 'metadata'
+    ? core.metadata(job.src)
+    : core.writeThumbnail(job.src, job.dest, job.width, job.quality);
+}
+
+function submit(job) {
+  if (inlineOnly) return runInline(job);
+  job.id = nextId++;
+  return new Promise((resolve, reject) => {
+    try {
+      ensureWorker();
+    } catch (err) {
+      inlineOnly = true;
+      console.warn(`[image-ops] no worker thread (${err.message}) — decoding in-process, which blocks the event loop`);
+      return resolve(runInline(job));
+    }
+    queue.push({ id: job.id, job, resolve, reject });
+    pump();
+  });
+}
+
+/* Display dimensions, shaped like the sharp metadata callers destructure. See image-ops-core. */
+function metadata(src) {
+  return submit({ op: 'metadata', src });
+}
+
+/* Write a JPEG thumbnail `width` px wide, aspect preserved. Rotation is implicit in the decode. */
+function writeThumbnail(src, dest, width, quality = 70) {
+  return submit({ op: 'writeThumbnail', src, dest, width, quality });
+}
+
+/* Drop the worker now rather than waiting out the idle timer. For shutdown paths and tests. */
+async function shutdown() {
+  clearIdleTimer();
+  const w = worker;
+  worker = null;
+  if (w) await w.terminate();
+}
+
+module.exports = { metadata, writeThumbnail, shutdown };

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.9.34-alpha6",
       "dependencies": {
         "@azure/msal-node": "^5.2.1",
+        "@jsquash/avif": "^1.3.0",
+        "@jsquash/webp": "^1.5.0",
         "archiver": "^7.0.1",
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^9.4.3",
@@ -16,6 +18,7 @@
         "express": "^4.18.2",
         "express-rate-limit": "^8.3.1",
         "helmet": "^8.1.0",
+        "jimp": "^1.6.1",
         "jsonwebtoken": "^9.0.3",
         "multer": "^1.4.5-lts.1",
         "nodemailer": "^6.9.16",
@@ -53,6 +56,16 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -582,6 +595,457 @@
         "node": ">=12"
       }
     },
+    "node_modules/@jimp/core": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-1.6.1.tgz",
+      "integrity": "sha512-+BoKC5G6hkrSy501zcJ2EpfnllP+avPevcBfRcZe/CW+EwEfY6X1EZ8QWyT7NpDIvEEJb1fdJnMMfUnFkxmw9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/file-ops": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "await-to-js": "^3.0.0",
+        "exif-parser": "^0.1.12",
+        "file-type": "^21.3.3",
+        "mime": "3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/core/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@jimp/diff": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/diff/-/diff-1.6.1.tgz",
+      "integrity": "sha512-YkKDPdHjLgo1Api3+Bhc0GLAygldlpt97NfOKoNg1U6IUNXA6X2MgosCjPfSBiSvJvrrz1fsIR+/4cfYXBI/HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "pixelmatch": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/file-ops": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/file-ops/-/file-ops-1.6.1.tgz",
+      "integrity": "sha512-T+gX6osHjprbDRad0/B71Evyre7ZdVY1z/gFGEG9Z8KOtZPKboWvPeP2UjbZYWQLy9UKCPQX1FNAnDiOPkJL7w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-bmp": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-bmp/-/js-bmp-1.6.1.tgz",
+      "integrity": "sha512-xzWzNT4/u5zGrTT3Tme9sGU7YzIKxi13+BCQwLqACbt5DXf9SAfdzRkopZQnmDko+6In5nqaT89Gjs43/WdnYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "bmp-ts": "^1.0.9"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-gif": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-gif/-/js-gif-1.6.1.tgz",
+      "integrity": "sha512-YjY2W26rQa05XhanYhRZ7dingCiNN+T2Ymb1JiigIbABY0B28wHE3v3Cf1/HZPWGu0hOg36ylaKgV5KxF2M58w==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "gifwrap": "^0.10.1",
+        "omggif": "^1.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-jpeg": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-jpeg/-/js-jpeg-1.6.1.tgz",
+      "integrity": "sha512-HT9H3yOmlOFzYmdI15IYdfy6ggQhSRIaHeA+OTJSEORXBqEo97sUZu/DsgHIcX5NJ7TkJBTgZ9BZXsV6UbsyMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "jpeg-js": "^0.4.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-png": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-png/-/js-png-1.6.1.tgz",
+      "integrity": "sha512-SZ/KVhI5UjcSzzlXsXdIi/LhJ7UShf2NkMOtVrbZQcGzsqNtynAelrOXeoTxcanfVqmNhAoVHg8yR2cYoqrYjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "pngjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/js-png/node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
+    },
+    "node_modules/@jimp/js-tiff": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/js-tiff/-/js-tiff-1.6.1.tgz",
+      "integrity": "sha512-jDG/eJquID1M4MBlKMmDRBmz2TpXMv7TUyu2nIRUxhlUc2ogC82T+VQUkca9GJH1BBJ9dx5sSE5dGkWNjIbZxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "utif2": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-blit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-1.6.1.tgz",
+      "integrity": "sha512-MwnI7C7K81uWddY9FLw1fCOIy6SsPIUftUz36Spt7jisCn8/40DhQMlSxpxTNelnZb/2SnloFimQfRZAmHLOqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-blur": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-1.6.1.tgz",
+      "integrity": "sha512-lIo7Tzp5jQu30EFFSK/phXANK3citKVEjepDjQ6ljHoIFtuMRrnybnmI2Md24ulvWlDaz+hh3n6qrMb8ydwhZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/utils": "1.6.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-circle": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-1.6.1.tgz",
+      "integrity": "sha512-kK1PavY6cKHNNKce37vdV4Tmpc1/zDKngGoeOV3j+EMatoHFZUinV3s6F9aWryPs3A0xhCLZgdJ6Zeea1d5LCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-color": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-1.6.1.tgz",
+      "integrity": "sha512-LtUN1vAP+LRlZAtTNVhDRSiXx+26Kbz3zJaG6a5k59gQ95jgT5mknnF8lxkHcqJthM4MEk3/tPxkdJpEybyF/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "tinycolor2": "^1.6.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-contain": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-1.6.1.tgz",
+      "integrity": "sha512-m0qhrfA8jkTqretGv4w+T/ADFR4GwBpE0sCOC2uJ0dzr44/ddOMsIdrpi89kabqYiPYIrxkgdCVCLm3zn1Vkkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/plugin-blit": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-cover": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-1.6.1.tgz",
+      "integrity": "sha512-hZytnsth0zoll6cPf434BrT+p/v569Wr5tyO6Dp0dH1IDPhzhB5F38sZGMLDo7bzQiN9JFVB3fxkcJ/WYCJ3Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/plugin-crop": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-crop": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-1.6.1.tgz",
+      "integrity": "sha512-EerRSLlclXyKDnYc/H9w/1amZW7b7v3OGi/VlerPd2M/pAu5X8TkyYWtfqYCXnNp1Ixtd8oCo9zGfY9zoXT4rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-displace": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-1.6.1.tgz",
+      "integrity": "sha512-K07QVl7xQwIfD6KfxRV/c3E9e7ZBXxUXdWuvoTWcKHL2qV48MOF5Nqbz/aJW4ThnQARIsxvYlZjPFiqkCjlU+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-dither": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-1.6.1.tgz",
+      "integrity": "sha512-+2V+GCV2WycMoX1/z977TkZ8Zq/4MVSKElHYatgUqtwXMi2fDK2gKYU2g9V39IqFvTJsTIsK0+58VFz/ROBVew==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-fisheye": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-1.6.1.tgz",
+      "integrity": "sha512-XtS5ZyoZ0vxZxJ6gkqI63SivhtI58vX95foMPM+cyzYkRsJXMOYCr8DScxF5bp4Xr003NjYm/P+7+08tibwzHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-flip": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-1.6.1.tgz",
+      "integrity": "sha512-ws38W/sGj7LobNRayQ83garxiktOyWxM5vO/y4a/2cy9v65SLEUzVkrj+oeAaUSSObdz4HcCEla7XtGlnAGAaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-hash": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-hash/-/plugin-hash-1.6.1.tgz",
+      "integrity": "sha512-sZt6ZcMX6i8vFWb4GYnw0pR/o9++ef0dTVcboTB5B/g7nrxCODIB4wfEkJ/YqZM5wUvol77K1qeS0/rVO6z21A==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/js-bmp": "1.6.1",
+        "@jimp/js-jpeg": "1.6.1",
+        "@jimp/js-png": "1.6.1",
+        "@jimp/js-tiff": "1.6.1",
+        "@jimp/plugin-color": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "any-base": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-mask": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-1.6.1.tgz",
+      "integrity": "sha512-SIG0/FcmEj3tkwFxc7fAGLO8o4uNzMpSOdQOhbCgxefQKq5wOVMk9BQx/sdMPBwtMLr9WLq0GzLA/rk6t2v20A==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-print": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-1.6.1.tgz",
+      "integrity": "sha512-BYVz/X3Xzv8XYilVeDy11NOp0h7BTDjlOtu0BekIFHP1yHVd24AXNzbOy52XlzYZWQ0Dl36HOHEpl/nSNrzc6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/js-jpeg": "1.6.1",
+        "@jimp/js-png": "1.6.1",
+        "@jimp/plugin-blit": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "parse-bmfont-ascii": "^1.0.6",
+        "parse-bmfont-binary": "^1.0.6",
+        "parse-bmfont-xml": "^1.1.6",
+        "simple-xml-to-json": "^1.2.2",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-quantize": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-quantize/-/plugin-quantize-1.6.1.tgz",
+      "integrity": "sha512-J2En9PLURfP+vwYDtuZ9T8yBW6BWYZBScydAjRiPBmJfEhTcNQqiiQODrZf7EqbbX/Sy5H6dAeRiqkgoV9N6Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "image-q": "^4.0.0",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-resize": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.1.tgz",
+      "integrity": "sha512-CLkrtJoIz2HdWnpYiN6p8KYcPc00rCH/SUu6o+lfZL05Q4uhecJlnvXuj9x+U6mDn3ldPmJj6aZqMHuUJzdVqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-rotate": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-1.6.1.tgz",
+      "integrity": "sha512-nOjVjbbj705B02ksysKnh0POAwEBXZtJ9zQ5qC+X7Tavl3JNn+P3BzQovbBxLPSbUSld6XID9z5ijin4PtOAUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/plugin-crop": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/plugin-threshold": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-1.6.1.tgz",
+      "integrity": "sha512-JOKv9F8s6tnVLf4sB/2fF0F339EFnHvgEdFYugO6VhowKLsap0pEZmLyE/DlRnYtIj2RddHZVxVMp/eKJ04l2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/plugin-color": "1.6.1",
+        "@jimp/plugin-hash": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/types": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-1.6.1.tgz",
+      "integrity": "sha512-leI7YbveTNi565m910XgIOwXyuu074H5qazAD1357HImJSv2hqxnWXpwxQbadGWZ7goZRYBDZy5lpqud0p7q5w==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jimp/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-veFPRd93FCnS7AgmCkPgARVGoDRrJ9cm1ujuNyA+UfQ5VKbED2002sm5XfFLFwTsKC8j04heTrwe+tU1dluXOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/types": "1.6.1",
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jsquash/avif": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsquash/avif/-/avif-1.3.0.tgz",
+      "integrity": "sha512-N6zH27O/AioCPNGxaf33PYnUEQZmAjUz0JwwAf9eMHRdYItn+CxwxlsHSSOkFmZKW+v9uVX6c7ZPQ4RTXArL7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "wasm-feature-detect": "^1.2.11"
+      }
+    },
+    "node_modules/@jsquash/webp": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jsquash/webp/-/webp-1.5.0.tgz",
+      "integrity": "sha512-KggLoj2MnRSfIqTeKe1EmbljTX2vuV7mh79k89PCL1pyqiDULcPM1L47twxXt0hkb68F70bXiL31MxsuoZtKFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "wasm-feature-detect": "^1.2.11"
+      }
+    },
     "node_modules/@otplib/core": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/@otplib/core/-/core-12.0.1.tgz",
@@ -856,6 +1320,52 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/inflate/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tokenizer/inflate/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -959,6 +1469,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/any-base": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
+      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
+      "license": "MIT"
     },
     "node_modules/append-field": {
       "version": "1.0.0",
@@ -1143,6 +1659,15 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
+    },
+    "node_modules/await-to-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/await-to-js/-/await-to-js-3.0.0.tgz",
+      "integrity": "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/b4a": {
       "version": "1.8.0",
@@ -1352,6 +1877,12 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "license": "MIT"
+    },
+    "node_modules/bmp-ts": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bmp-ts/-/bmp-ts-1.0.9.tgz",
+      "integrity": "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==",
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -2232,6 +2763,11 @@
         "bare-events": "^2.7.0"
       }
     },
+    "node_modules/exif-parser": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
+      "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -2389,6 +2925,24 @@
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -2603,6 +3157,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/gifwrap": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.10.1.tgz",
+      "integrity": "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==",
+      "license": "MIT",
+      "dependencies": {
+        "image-q": "^4.0.0",
+        "omggif": "^1.0.10"
+      }
+    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -2811,6 +3375,21 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/image-q": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
+      "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "16.9.1"
+      }
+    },
+    "node_modules/image-q/node_modules/@types/node": {
+      "version": "16.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "license": "MIT"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2888,6 +3467,50 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
+    },
+    "node_modules/jimp": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.1.tgz",
+      "integrity": "sha512-hNQh6rZtWfSVWSNVmvq87N5BPJsNH7k7I7qyrXf9DOma9xATQk3fsyHazCQe51nCjdkoWdTmh0vD7bjVSLoxxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jimp/core": "1.6.1",
+        "@jimp/diff": "1.6.1",
+        "@jimp/js-bmp": "1.6.1",
+        "@jimp/js-gif": "1.6.1",
+        "@jimp/js-jpeg": "1.6.1",
+        "@jimp/js-png": "1.6.1",
+        "@jimp/js-tiff": "1.6.1",
+        "@jimp/plugin-blit": "1.6.1",
+        "@jimp/plugin-blur": "1.6.1",
+        "@jimp/plugin-circle": "1.6.1",
+        "@jimp/plugin-color": "1.6.1",
+        "@jimp/plugin-contain": "1.6.1",
+        "@jimp/plugin-cover": "1.6.1",
+        "@jimp/plugin-crop": "1.6.1",
+        "@jimp/plugin-displace": "1.6.1",
+        "@jimp/plugin-dither": "1.6.1",
+        "@jimp/plugin-fisheye": "1.6.1",
+        "@jimp/plugin-flip": "1.6.1",
+        "@jimp/plugin-hash": "1.6.1",
+        "@jimp/plugin-mask": "1.6.1",
+        "@jimp/plugin-print": "1.6.1",
+        "@jimp/plugin-quantize": "1.6.1",
+        "@jimp/plugin-resize": "1.6.1",
+        "@jimp/plugin-rotate": "1.6.1",
+        "@jimp/plugin-threshold": "1.6.1",
+        "@jimp/types": "1.6.1",
+        "@jimp/utils": "1.6.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/js-yaml": {
       "version": "4.3.0",
@@ -3297,6 +3920,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/omggif": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -3430,6 +4059,34 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parse-bmfont-ascii": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
+      "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-bmfont-binary": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
+      "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-bmfont-xml": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
+      "integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-parse-from-string": "^1.0.0",
+        "xml2js": "^0.5.0"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3485,6 +4142,27 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pixelmatch": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
+      "integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^6.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/pixelmatch/node_modules/pngjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
+      }
     },
     "node_modules/pngjs": {
       "version": "5.0.0",
@@ -3831,6 +4509,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -4097,6 +4784,15 @@
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-xml-to-json": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/simple-xml-to-json/-/simple-xml-to-json-1.2.7.tgz",
+      "integrity": "sha512-mz9VXphOxQWX3eQ/uXCtm6upltoN0DLx8Zb5T4TFC4FHB7S9FDPGre8CfLWqPWQQH/GrQYd2AXhhVM5LDpYx6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.12.2"
       }
     },
     "node_modules/smart-buffer": {
@@ -4492,6 +5188,22 @@
         }
       }
     },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -4560,6 +5272,12 @@
         "node": ">=0.2.6"
       }
     },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -4567,6 +5285,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/tslib": {
@@ -4614,6 +5350,18 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
     },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
@@ -4649,6 +5397,15 @@
         "fs-extra": "^11.2.0",
         "graceful-fs": "^4.2.2",
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/utif2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/utif2/-/utif2-4.1.0.tgz",
+      "integrity": "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.11"
       }
     },
     "node_modules/util-deprecate": {
@@ -4687,6 +5444,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.9.0.tgz",
+      "integrity": "sha512-zonE+xlIIYtxPy++L24ow0hAD8CICb4+FgPyROd3buyXIqsJvUEDkBgfCCoXOd1Hu3DUr0GOfnPIdcGV+YpNaA==",
+      "license": "Apache-2.0"
     },
     "node_modules/webdriver-bidi-protocol": {
       "version": "0.4.1",
@@ -4832,6 +5595,34 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-parse-from-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
+      "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==",
+      "license": "MIT"
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xmlhttprequest-ssl": {
@@ -5022,7 +5813,6 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@azure/msal-node": "^5.2.1",
+    "@jsquash/avif": "^1.3.0",
+    "@jsquash/webp": "^1.5.0",
     "archiver": "^7.0.1",
     "bcryptjs": "^3.0.3",
     "better-sqlite3": "^9.4.3",
@@ -18,12 +20,12 @@
     "express": "^4.18.2",
     "express-rate-limit": "^8.3.1",
     "helmet": "^8.1.0",
+    "jimp": "^1.6.1",
     "jsonwebtoken": "^9.0.3",
     "multer": "^1.4.5-lts.1",
     "nodemailer": "^6.9.16",
     "otplib": "^12.0.1",
     "qrcode": "^1.5.4",
-    "sharp": "^0.35.3",
     "socket.io": "^4.7.2",
     "stripe": "^20.4.1",
     "unzipper": "^0.12.3",
@@ -32,6 +34,7 @@
   "devDependencies": {
     "js-yaml": "^4.2.0",
     "puppeteer-core": "^24.43.1",
+    "sharp": "^0.35.3",
     "socket.io-client": "^4.8.3"
   }
 }

--- a/server/scripts/backfill-rotation-dims.js
+++ b/server/scripts/backfill-rotation-dims.js
@@ -31,13 +31,14 @@ function probeVideoDims(filePath) {
 }
 
 async function probeImageDims(filePath) {
-  const sharp = require('sharp');
-  return imageDisplayDims(await sharp(filePath).metadata());
+  const imageOps = require('../lib/image-ops');
+  return imageDisplayDims(await imageOps.metadata(filePath));
 }
 
 async function regenImageThumb(filePath, thumbName) {
-  const sharp = require('sharp');
-  await sharp(filePath).rotate().resize(config.thumbnailWidth).jpeg({ quality: 70 }).toFile(path.join(config.contentDir, thumbName));
+  const imageOps = require('../lib/image-ops');
+  // Rotation is implicit: the decoder auto-orients per EXIF, which is what .rotate() bought here.
+  await imageOps.writeThumbnail(filePath, path.join(config.contentDir, thumbName), config.thumbnailWidth, 70);
 }
 
 (async () => {

--- a/server/test/image-ops.test.js
+++ b/server/test/image-ops.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+// Image decoding is pure JavaScript now (no native sharp), so its CPU cost lands on whichever
+// thread runs it — ~1s of solid work for a 12MP photo. In-process that is a stalled event loop:
+// no heartbeats, no socket traffic, panels marked offline, reconnect churn — #240 arriving from
+// our own thumbnail backfill. lib/image-ops therefore hosts the work on a worker thread, and
+// these bites pin the properties that makes it safe, none of which a functional test would catch.
+
+const { test, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const sharp = require('sharp');            // devDependency: fixture generator only, never shipped
+const imageOps = require('../lib/image-ops');
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'image-ops-'));
+after(async () => { await imageOps.shutdown(); fs.rmSync(tmp, { recursive: true, force: true }); });
+
+// 12MP — a phone photo, and the size the thresholds below are calibrated against. Smaller is
+// tempting for test speed but defeats the point: at 4MP the inline path stalls only ~350ms, which
+// slips under any threshold loose enough not to be flaky, so the guard stops detecting the very
+// regression it exists for. Measured: inline ~1000ms stall / ~2 timers serviced, worker ~0ms / ~90.
+async function bigPhoto(name = 'big.jpg') {
+  const p = path.join(tmp, name);
+  if (!fs.existsSync(p)) {
+    // Random pixels, not a flat fill: a solid colour compresses to almost nothing and decodes far
+    // faster than any real photo, which would quietly defeat the timing assertion below.
+    const px = Buffer.allocUnsafe(4000 * 3000 * 3);
+    for (let i = 0; i < px.length; i++) px[i] = (i * 2654435761) & 0xff;
+    fs.writeFileSync(p, await sharp(px, { raw: { width: 4000, height: 3000, channels: 3 } }).jpeg().toBuffer());
+  }
+  return p;
+}
+
+test('image work does not stall the event loop (#240)', async () => {
+  const src = await bigPhoto();
+
+  let ticks = 0, worstGap = 0, last = Date.now();
+  const timer = setInterval(() => { ticks++; worstGap = Math.max(worstGap, Date.now() - last - 10); last = Date.now(); }, 10);
+  const started = Date.now();
+  await imageOps.writeThumbnail(src, path.join(tmp, 'thumb.jpg'), 320, 70);
+  const elapsed = Date.now() - started;
+  clearInterval(timer);
+
+  // The point is not that it was fast — it is that the loop kept running while it was slow.
+  // Thresholds sit in the gap between the two behaviours (worker ~90 ticks / ~0ms stall, inline
+  // ~2 ticks / ~1000ms stall), far enough from both to bite without being flaky.
+  assert.ok(ticks >= 20, `event loop serviced only ${ticks} timers in ${elapsed}ms — it is being blocked`);
+  assert.ok(worstGap < 200, `event loop stalled ${worstGap}ms in one go — image work is on the main thread`);
+  assert.ok(fs.existsSync(path.join(tmp, 'thumb.jpg')), 'thumbnail was still written');
+});
+
+test('an undecodable image rejects without killing the worker', async () => {
+  const bad = path.join(tmp, 'corrupt.jpg');
+  fs.writeFileSync(bad, Buffer.from('not an image'));
+  await assert.rejects(() => imageOps.metadata(bad), 'corrupt input must reject, so ingest records nulls');
+
+  // Crash isolation: one bad upload must not take out the queued work of unrelated callers.
+  const ok = path.join(tmp, 'fine.png');
+  fs.writeFileSync(ok, await sharp({ create: { width: 40, height: 25, channels: 3, background: '#123456' } }).png().toBuffer());
+  assert.deepEqual(await imageOps.metadata(ok), { width: 40, height: 25, orientation: 1 });
+});
+
+test('concurrent callers are serialized, and each still gets its own answer', async () => {
+  // Serialization bounds peak memory to ONE decoded bitmap (a 12MP photo is ~48MB of RGBA);
+  // overlapping jobs would multiply that by the queue depth on exactly the small targets this
+  // change exists to reach. Correctness under concurrency is what is asserted here.
+  const sizes = [[30, 10], [60, 20], [90, 30], [120, 40]];
+  const files = await Promise.all(sizes.map(async ([w, h], i) => {
+    const p = path.join(tmp, `c${i}.png`);
+    fs.writeFileSync(p, await sharp({ create: { width: w, height: h, channels: 3, background: '#0a0' } }).png().toBuffer());
+    return p;
+  }));
+  const got = await Promise.all(files.map(f => imageOps.metadata(f)));
+  assert.deepEqual(got.map(m => [m.width, m.height]), sizes, 'replies must not be crossed between queued jobs');
+});
+
+test('#170 EXIF orientation is applied by the decoder, so dimensions are as DISPLAYED', async () => {
+  // orientation 6 = "rotate 90° CW to display": a 30x100 stored buffer DISPLAYS as 100x30.
+  const p = path.join(tmp, 'rot6.jpg');
+  fs.writeFileSync(p, await sharp({ create: { width: 30, height: 100, channels: 3, background: '#00ff00' } })
+    .withMetadata({ orientation: 6 }).jpeg().toBuffer());
+
+  const meta = await imageOps.metadata(p);
+  assert.equal(meta.width, 100, 'EXIF-rotated image measures as displayed, not as stored');
+  assert.equal(meta.height, 30);
+  // Reported as 1 because the rotation is already applied — imageDisplayDims() must NOT swap again.
+  assert.equal(meta.orientation, 1, 'a tag of 6 here would double-rotate downstream');
+});

--- a/server/test/image-ops.test.js
+++ b/server/test/image-ops.test.js
@@ -6,7 +6,7 @@
 // our own thumbnail backfill. lib/image-ops therefore hosts the work on a worker thread, and
 // these bites pin the properties that makes it safe, none of which a functional test would catch.
 
-const { test, after } = require('node:test');
+const { test, after, mock } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
@@ -74,6 +74,48 @@ test('concurrent callers are serialized, and each still gets its own answer', as
   }));
   const got = await Promise.all(files.map(f => imageOps.metadata(f)));
   assert.deepEqual(got.map(m => [m.width, m.height]), sizes, 'replies must not be crossed between queued jobs');
+});
+
+test('measureAndThumbnail decodes the file exactly once', async () => {
+  // Counted, not timed: a wall-clock comparison against metadata()+writeThumbnail() would be
+  // flaky under load, and this is an exact property. Asserted against image-ops-core directly
+  // because the decode happens on the worker thread, out of reach of a spy set up here.
+  // readImage() is the only reader in core, so readFile calls == decodes.
+  const core = require('../lib/image-ops-core');
+  const fsp = require('node:fs/promises');
+  const src = path.join(tmp, 'once.png');
+  fs.writeFileSync(src, await sharp({ create: { width: 200, height: 80, channels: 3, background: '#246' } }).png().toBuffer());
+
+  const spy = mock.method(fsp, 'readFile');
+  // Count reads OF THIS FILE only. Node's ESM loader also reads through fs.promises.readFile, so
+  // a raw call count picks up jimp's and the WASM codecs' lazy module loading on first use.
+  const decodes = () => spy.mock.calls.filter(c => String(c.arguments[0]) === src).length;
+  try {
+    const r = await core.measureAndThumbnail(src, path.join(tmp, 'once-thumb.jpg'), 100, 70);
+    assert.equal(decodes(), 1, 'combined op must decode once, not once per answer');
+    assert.deepEqual([r.width, r.height], [200, 80]);
+    assert.equal(r.thumbnailWritten, true);
+
+    // The pairing it replaces, for contrast — this is the cost being removed.
+    spy.mock.resetCalls();
+    await core.metadata(src);
+    await core.writeThumbnail(src, path.join(tmp, 'twice-thumb.jpg'), 100, 70);
+    assert.equal(decodes(), 2, 'the separate calls are what cost two decodes');
+  } finally { spy.mock.restore(); }
+});
+
+test('a thumbnail that cannot be written still yields dimensions', async () => {
+  // Dimensions are independently useful — the player needs them to letterbox — and the two-call
+  // version kept them, because width/height were assigned before the thumbnail was attempted.
+  // Merging the calls must not quietly turn a thumbnail failure into a total metadata failure.
+  const src = path.join(tmp, 'ok.png');
+  fs.writeFileSync(src, await sharp({ create: { width: 150, height: 60, channels: 3, background: '#654' } }).png().toBuffer());
+
+  const undirectable = path.join(tmp, 'no-such-dir', 'thumb.jpg');   // parent does not exist
+  const r = await imageOps.measureAndThumbnail(src, undirectable, 100, 70);
+  assert.deepEqual([r.width, r.height], [150, 60], 'dimensions survive a thumbnail write failure');
+  assert.equal(r.thumbnailWritten, false);
+  assert.match(r.thumbnailError || '', /ENOENT|no such file/i);
 });
 
 test('#170 EXIF orientation is applied by the decoder, so dimensions are as DISPLAYED', async () => {


### PR DESCRIPTION
Replaces the native `sharp` dependency with pure-JavaScript image decoding, moved onto a worker thread.

### Why

`sharp` wraps libvips as a native module, so it needs a prebuilt binary per platform and Node ABI. When there isn't one — or Node moves ABI — the failure is `ERR_DLOPEN_FAILED` / `NODE_MODULE_VERSION` at load, which reads like database corruption. That's the class of breakage `lib/preflight-deps.js` exists to explain for `better-sqlite3`, and it bit twice while writing this. Nothing in the new path is native, so the server runs anywhere Node runs.

The prompt was investigating whether the server could run on BrightSign hardware. It still shouldn't — that argument is about storage (2.2 GB of uploads and SQLite WAL churn on internal flash), not buildability. The reason to take this is fleet-wide: it removes a whole class of install failure.

### What

`lib/image-ops.js` is the entire surface — `metadata()`, `writeThumbnail()`, `measureAndThumbnail()` — dispatching to a worker that hosts `image-ops-core.js`.

**Format parity holds.** jpeg/png/gif/tiff/bmp are native to Jimp; webp and avif go through `@jsquash` WASM. Their bundled `.wasm` has to be compiled by hand because the packages locate it with `fetch(file://)` and Node has no `file://` fetch — the only symptom otherwise is a bare `fetch failed`. `heic` is unsupported, as it already was: sharp advertises `heif` but its prebuilt libvips refuses HEVC, so `.heic` has never produced a thumbnail.

**#170 is preserved by a different mechanism.** Jimp applies EXIF orientation at decode and rewrites the tag to 1, so `metadata()` reports display dimensions and `imageDisplayDims()` runs as a no-op instead of swapping W/H a second time.

**Work is off the main thread.** Pure-JS decoding costs ~1s for a 12MP photo. In-process that is a stalled event loop, and `thumbnail-backfill.js` walks a whole library at boot — reproducing #240 (blocked loop → missed heartbeats → panels offline → reconnect churn) from our own maintenance. sharp never did this because libvips uses a threadpool.

Jobs are serialized deliberately: a decoded 12MP bitmap is ~48 MB of RGBA, so overlapping jobs multiply peak memory by queue depth. The worker is `unref`'d while idle so CLI scripts exit and `node --test` doesn't hang.

**One decode per ingest.** `metadata()` + `writeThumbnail()` decoded twice — free under sharp, whose `.metadata()` only parsed the header, but doubled the dominant cost here. A thumbnail *write* failure still returns dimensions (the player needs them to letterbox); a *decode* failure still throws.

### Measurements

| | before | after |
|---|---|---|
| 12MP thumbnail, wall | 65 ms (sharp) | ~950 ms |
| 12MP thumbnail, loop stalled | 0 ms | **0 ms** |
| full ingest, 12MP | ~1.9 s (2 decodes) | 1150 ms |
| `node_modules` | sharp 1.1 MB | jimp 3.3 MB + jsquash 7.7 MB |

The honest cost is ~17× wall time per image, inherent to pure JS. It is off the main thread, and ingest is not latency-critical.

### Verification

- 1649/1649 tests pass.
- Ingest exercised in a child process with `node_modules/sharp` moved aside: jpeg, EXIF-rotated jpeg, png, webp, avif, gif all measured and thumbnailed; corrupt input yields nulls with no phantom `thumbnail_path`.
- `test/image-ops.test.js` pins loop liveness, crash isolation, queue correctness, single-decode, and #170. The loop-liveness thresholds were mutation-tested against the inline path — the first version passed there too (4MP stalls only ~355 ms), so the fixture is 12MP and the thresholds sit in the gap between the behaviours. It now fails inline, as a guard must.

sharp moves to `devDependencies` (tests use it as a fixture generator). `npm ci --omit=dev` leaves it out of the image entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYAVwBKQBKCi43X1QCn13i