### PR TITLE
An APK download with no external storage went nowhere, silently

### DIFF
--- a/android/app/src/main/java/com/remotedisplay/player/service/UpdateChecker.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/service/UpdateChecker.kt
@@ -311,10 +311,35 @@ class UpdateChecker(private val context: Context) {
     // Returns TRUE only when a verified APK is in hand and an install has been launched (the
     // caller may then count an attempt); FALSE on any download/verify failure — the caller must
     // NOT count those, so a transient network problem can't burn a healthy device's budget. #139
+    /*
+     * Where a downloaded APK is staged.
+     *
+     * getExternalFilesDir() returns NULL whenever external storage is not mounted/available — and
+     * on a signage panel that is not exotic: no emulated volume, a vendor ROM that never mounts one,
+     * an SD card ejected, storage still unmounted early in boot.
+     *
+     * The bug this replaces: `File(context.getExternalFilesDir(...), name)`. Java's File(File,String)
+     * treats a NULL parent as "no parent" and silently produces a RELATIVE path, so the download
+     * targeted `ScreenTinker-x.y.z.apk` in the process working directory — `/` — which is not
+     * writable. The write threw, the generic catch swallowed it, and the caller reported only
+     * "failed to download or failed signature verification". Nothing was ever written, so there was
+     * no partial file to find and nothing in the message pointed at storage. It fails on EVERY
+     * attempt, forever, on an affected panel — and identically for the pushed-APK path, which had
+     * the same line.
+     *
+     * Internal storage always exists, so fall back to it. It costs nothing when external is present.
+     * NOTE: the intent-based install fallback resolves this file through FileProvider, so
+     * res/xml/file_paths.xml must expose this directory too — see the <files-path> entry there.
+     */
+    private fun apkDir(): File {
+        context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS)?.let { return it }
+        Log.w(TAG, "External storage unavailable — staging APKs in internal storage instead")
+        return File(context.filesDir, "Download").apply { mkdirs() }
+    }
+
     private fun downloadAndInstall(url: String, version: String): Boolean {
         try {
-            val apkFile = File(context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS),
-                "ScreenTinker-$version.apk")
+            val apkFile = File(apkDir(), "ScreenTinker-$version.apk")
 
             // #139: reuse a previously-downloaded, verified APK for this version instead of
             // re-pulling ~8.7 MB every cycle. The file also stays on disk as the artifact for a
@@ -378,7 +403,7 @@ class UpdateChecker(private val context: Context) {
             try {
                 val base = url.substringAfterLast('/').substringBefore('?').ifBlank { "app.apk" }
                 val fileName = "pushed-" + (if (base.endsWith(".apk")) base else "$base.apk")
-                val apkFile = File(context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS), fileName)
+                val apkFile = File(apkDir(), fileName)
                 if (apkFile.exists()) apkFile.delete()
                 val response = client.newCall(Request.Builder().url(url).build()).execute()
                 if (!response.isSuccessful) { Log.e(TAG, "installFromUrl: download failed ${response.code}"); return@Thread }

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -2,4 +2,11 @@
 <paths>
     <external-files-path name="downloads" path="Download/" />
     <external-files-path name="apk" path="." />
+    <!-- UpdateChecker.apkDir() stages APKs in internal storage when external storage is not
+         available (getExternalFilesDir returns null). The silent PackageInstaller path streams the
+         file itself and needs nothing here, but the intent-based install FALLBACK resolves it
+         through FileProvider — without this entry that fallback throws
+         IllegalArgumentException ("Failed to find configured root"), turning an already-degraded
+         panel into one that cannot install at all. -->
+    <files-path name="internal_downloads" path="Download/" />
 </paths>


### PR DESCRIPTION
A panel on alpha could not install `1.9.34-alpha7` by OTA **or** by the dashboard's "Push an APK" button. Both fail for the same reason.

### The bug

```kotlin
File(context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS), name)
```

`getExternalFilesDir()` returns **null** when external storage is unavailable — not exotic on signage hardware: no emulated volume, a vendor ROM that never mounts one, an ejected card, storage still unmounted early in boot.

Java's `File(File, String)` treats a null parent as *no parent* and silently produces a **relative** path. So the download targeted `ScreenTinker-x.y.z.apk` in the process working directory — `/` — which isn't writable. The write threw, the generic `catch` swallowed it, and the caller reported only *"failed to download or failed signature verification"*.

### Why it was expensive to diagnose

That one message covers seven distinct failures, and every signal pointed away from the real cause:

- the **HTTP request succeeds** — the server logs a served download at the exact second of each failure, so it doesn't look like a download problem
- the **signing key is fine** — both APKs are v1+v3 with an identical cert, and the device had already OTA'd successfully on that key hours earlier
- **nothing is ever written**, so there's no partial file to find
- it **never recovers** — every attempt fails identically, forever

`installFromUrl` (the "Push an APK" button) had the same line, so the obvious workaround for an affected panel was broken by the same bug.

### The fix

A shared `apkDir()` used by both paths, falling back to internal storage. `filesDir` can't be unmounted — if it's gone, the app isn't running. Costs nothing when external storage is present.

`file_paths.xml` gains a `<files-path>` for that directory. The silent `PackageInstaller` path streams the file itself and needs nothing there, but the **intent-based install fallback** resolves it through `FileProvider` and would throw `Failed to find configured root` — turning an already-degraded panel into one that can't install at all.

Streaming straight into `PackageInstaller.Session.openWrite()` was considered — it avoids disk entirely — but it forfeits `verifyApkSignature()`, which needs a real file path via `getPackageArchiveInfo()`. On a device-owner panel doing silent installs that's the one protection worth keeping, and it also loses the #139 verified-APK cache.

### ⚠️ Cannot self-heal over the air

The broken download path **is** the delivery mechanism, and Push APK shares the bug. A panel already in this state needs one manual install (adb/USB/file manager) to escape. This release protects panels that aren't yet affected; it cannot rescue one that is.

### Confidence

Root cause is inferred from converging evidence on an Android 9 panel: HTTP served at each failure, no APK anywhere on the device, the app's own external files dir denied to its own UID, both paths failing identically, and signing verified at parity against the release it had already installed. Handling a null return is correct regardless — it must never silently become a relative path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYAVwBKQBKCi43X1QCn13i