### PR TITLE
Fix a load-time crash that took down any install collecting statistics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,12 @@ jobs:
         working-directory: server
         env:
           SELF_HOSTED: 'true'
+          # Boot WITH the collector on. This block is config-gated and only the
+          # statistics-collecting deployment sets the flag, so it had never executed in CI,
+          # on alpha, or in any test - and a load-time crash inside it took production down
+          # while every check was green. Code only one deployment runs is exactly the code
+          # CI has to execute.
+          TELEMETRY_COLLECTOR: '1'
         run: |
           node server.js > "$RUNNER_TEMP/server.log" 2>&1 &
           echo $! > "$RUNNER_TEMP/server.pid"
@@ -130,6 +136,21 @@ jobs:
           test "$(echo "$STATUS" | jq -r .status)" = "ok"
           test "$REPORTED" = "$EXPECTED"
           echo "OK: status ok, version $REPORTED matches VERSION"
+
+      # Booting is not enough on its own - the collector could be mounted and broken. Prove
+      # the routes it adds actually answer, so a fault inside that block fails here rather
+      # than on the single deployment that turns it on.
+      - name: Assert the collector routes answer when enabled
+        run: |
+          STATS="$(curl -sf http://localhost:3001/api/public/stats)"
+          echo "stats: $STATS"
+          test "$(echo "$STATS" | jq -r 'has("screens") and has("installs")')" = "true"
+          REPORT="$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+            -H 'Content-Type: application/json' -d '{"bad":1}' \
+            http://localhost:3001/api/telemetry/report)"
+          echo "malformed report -> HTTP $REPORT"
+          test "$REPORT" = "400"
+          echo "OK: collector mounted and answering"
 
       - name: Stop server
         if: always()

--- a/server/server.js
+++ b/server/server.js
@@ -983,7 +983,13 @@ app.use('/api/status', require('./routes/status'));
  * TELEMETRY_COLLECTOR=1, so a normal self-hosted install exposes neither.
  */
 if (process.env.TELEMETRY_COLLECTOR === '1') {
-  app.use('/api', require('./routes/telemetry-collector')(db));
+  /* `require('./db/database').db`, not the module-scope `db` — that binding is declared far
+     below this line, so naming it here throws "Cannot access 'db' before initialization" at
+     load and the process never starts. The inline handler this replaced only touched `db`
+     inside a request callback, which runs long after the binding exists; passing it to a
+     factory made the reference eager. Every neighbouring call site in this region resolves
+     the same lazy way. */
+  app.use('/api', require('./routes/telemetry-collector')(require('./db/database').db));
   console.log('[telemetry] collector enabled at POST /api/telemetry/report (+ GET /api/public/stats)');
 }
 


### PR DESCRIPTION
**1.9.35 cannot start with `TELEMETRY_COLLECTOR=1`.** It throws before listening and systemd restarts it in a loop:

```
ReferenceError: Cannot access 'db' before initialization
    at Object.<anonymous> (/opt/screentinker/server/server.js:986:59)
```

Production was down until rolled back to 1.9.34.

### The fault

The mount passed the module-scope `db` into the collector's factory:

```js
app.use('/api', require('./routes/telemetry-collector')(db));   // line 986
...
const { db } = require('./db/database');                        // line 1261
```

The inline handler this replaced only touched `db` **inside a request callback**, which runs long after the binding exists. Moving the same reference into a factory argument turned a lazy read into an eager one, and `const` has no hoisted value to read.

Fixed by resolving it the way every neighbouring call site in that region already does — `require('./db/database').db`.

### Why nothing caught it

The block is gated on a flag that **only the statistics-collecting deployment sets**. It had never executed in CI, on alpha, or in any test.

1676 tests, four green CI jobs, and a clean alpha deploy — and the crashing line had still never run. The unit tests mount the router directly and hand it a `db`, which is exactly the part that worked.

So the boot smoke now boots **with the collector enabled** and asserts its routes answer:

- `/api/public/stats` returns the expected shape
- a malformed report is refused with `400`

Booting alone wouldn't be enough — the collector could mount and be broken.

### Verification

Reproduced the crash on the released code, confirmed it's gone with the fix, and exercised the endpoints for real (`{"ok":true}` on a valid report, `400` on a malformed one). 1676/1676 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYAVwBKQBKCi43X1QCn13i