### PR TITLE
Stop shipping a licence we would rather not have to explain

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -87,8 +87,24 @@ dependencies {
     implementation("androidx.media3:media3-exoplayer:1.2.1")
     implementation("androidx.media3:media3-ui:1.2.1")
 
-    // Socket.IO client
-    implementation("io.socket:socket.io-client:2.1.0")
+    // Socket.IO client.
+    //
+    // org.json is excluded deliberately. socket.io-client pulls org.json:json:20090211
+    // transitively, and that artifact was being packaged into the APK in full — 19 classes,
+    // including CDL, XML, JSONML and its own Test class. It carries the JSON License, whose
+    // "shall be used for Good, not Evil" clause is not OSI-approved, is treated as non-free by
+    // Debian and Fedora, and is Category X at Apache. Shipping it in a commercially distributed
+    // binary is an avoidable licensing problem: it is not copyleft, but it is not a licence we
+    // want to have to explain.
+    //
+    // Nothing is lost. Android provides org.json in the platform (since API 1, and minSdk is 24),
+    // and the only classes either side actually touches are JSONObject, JSONArray and JSONTokener.
+    // The full method surface used — by socket.io/engine.io and by our own Kotlin — is
+    // get/getString/getLong/getJSONArray/getJSONObject/has/keys/length/isNull/put/NULL,
+    // the opt* family, and JSONTokener.nextValue. Every one is platform API.
+    implementation("io.socket:socket.io-client:2.1.0") {
+        exclude(group = "org.json", module = "json")
+    }
 
     // WorkManager for background downloads
     implementation("androidx.work:work-runtime-ktx:2.9.0")

--- a/frontend/vendor/README.md
+++ b/frontend/vendor/README.md
@@ -4,9 +4,16 @@ Third-party libraries committed directly to the repo (not fetched from a CDN or 
 from npm) so self-hosted / air-gapped instances work with no external dependency and no
 build step.
 
+**Anything added here ships in the release tarball**, so it must carry its licence notice —
+a minified bundle usually has its headers stripped, which is exactly when the notice has to
+be kept as a separate file next to it. Record the licence below and add a `<name>.LICENSE`.
+
 ## redoc.standalone.js
 - **Library:** Redoc — renders the OpenAPI reference served at `/docs`.
 - **Version:** 2.3.9
+- **Licence:** MIT — Copyright (c) 2015-present, Rebilly, Inc. Full text in
+  [`redoc.LICENSE`](redoc.LICENSE). The bundle itself carries no header (stripped by the
+  upstream minifier), which is why the notice is kept separately.
 - **Source:** https://cdn.redoc.ly/redoc/v2.3.9/bundles/redoc.standalone.js
 - **Why committed:** the API reference must render on offline instances — no CDN, no build step.
 - **Regenerate / update:**

--- a/frontend/vendor/redoc.LICENSE
+++ b/frontend/vendor/redoc.LICENSE
@@ -1,0 +1,31 @@
+Redoc — https://github.com/Redocly/redoc
+Version vendored here: 2.3.9 (see redoc.standalone.js)
+
+The bundle in this directory is minified and its license headers were stripped upstream, so
+the notice is kept alongside it instead. MIT requires this notice to accompany the software
+wherever it is distributed, and redoc.standalone.js is included in the ScreenTinker release
+tarball.
+
+--------------------------------------------------------------------------------
+
+The MIT License (MIT)
+
+Copyright (c) 2015-present, Rebilly, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "screentinker",
       "version": "1.9.36",
+      "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^5.2.1",
         "@jsquash/avif": "^1.3.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "screentinker",
   "version": "1.9.36",
+  "license": "MIT",
   "description": "ScreenTinker - Digital Signage Management Server",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
An audit of what actually reaches customers. **No GPL or AGPL anywhere in the product** — but two findings are the kind of detail that undermines a claim to track licences at all.

### org.json was being packaged into the APK

`socket.io-client` pulls `org.json:json:20090211` transitively, and it was landing in the dex **in full** — 19 classes, including `CDL`, `XML`, `JSONML` and the library's own `Test` class.

That release carries the **JSON Licence**, whose *"shall be used for Good, not Evil"* clause is not OSI-approved, is treated as non-free by Debian and Fedora, and is **Category X at Apache**. Not copyleft — but not something to have in a commercially distributed binary.

Excluded. **Nothing is lost**: Android has provided `org.json` in the platform since API 1, and minSdk is 24.

**Verified, not assumed.** The full surface used — by socket.io/engine.io *and* our own Kotlin — is three classes:

| | methods |
|---|---|
| `JSONObject` | `get` `getString` `getLong` `getJSONArray` `getJSONObject` `has` `keys` `put` `NULL` + `opt*` |
| `JSONArray` | `get` `getString` `isNull` `length` `put` |
| `JSONTokener` | `nextValue` |

Every one is platform API.

Rebuilt APK: **0 org.json classes defined (was 19)**, all three still *referenced* so they resolve against the platform, 25 KB smaller, v1 JAR signature intact.

Then installed on a real panel, because a missing platform method is a **runtime** `NoSuchMethodError`, not a build failure:

```
WebSocketService: Registered as: c4217479-b899-4c1d-baca-266e880a9531
WebSocketService: Paired as: lobby search
WebSocketService: Playlist update received, assignments=1
PlaylistController: Received JSONArray with 1 items
```

Socket handshake, registration, playlist parse — clean.

### Redoc shipped with no licence notice

`frontend/vendor/redoc.standalone.js` is in the release tarball, minified with every header stripped — no `@license`, no SPDX line, no copyright string anywhere in 1.1 MB. The vendor README recorded version and source but not licence.

MIT requires the notice to travel with the software. Added `redoc.LICENSE` (MIT, © 2015-present Rebilly, Inc.), plus a note in the README that **anything vendored here ships and therefore needs one**.

### The server manifest declared no licence

`server/package.json` had no `license` field despite the repo being MIT. Tooling and auditors read the manifest, not just the root `LICENSE`. Set to MIT, lockfile synced so `npm ci` can't disagree (one line, no version drift).

### Scope note

Audited against **production's own installed tree**, not a developer checkout — a dev checkout carries `sharp` (and its LGPL-bearing `@img/sharp-wasm32`) as a test-fixture generator, which never ships:

```
Scope: 365 installed packages (production only, --omit=dev)
  305 MIT   25 ISC   17 Apache-2.0   6 BSD-3-Clause   5 BlueOak-1.0.0   ...
COPYLEFT / ATTENTION
  none
```

The 14 GLSL transition shaders are original work and already carry `// Author: Dan (ByteTinker)` / `// License: MIT` in-file — no Shadertoy, gl-transitions or glslsandbox provenance anywhere.

1676/1676 server tests, Android build + unit tests, `npm ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYAVwBKQBKCi43X1QCn13i