### PR TITLE
Stop schedules landing on the wrong date

### DIFF
--- a/frontend/js/views/schedule.js
+++ b/frontend/js/views/schedule.js
@@ -210,6 +210,10 @@ export async function render(container) {
       `${currentWeekStart.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} - ${end.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}`;
   }
 
+  // The date the modal is currently working on: a dragged day, the date of the schedule
+  // being edited, or null meaning "today". Set by every path that OPENS the modal.
+  let pendingCreateDate = null;
+
   // Stable colour per target, so the same screen is the same colour every week and
   // across reloads. Hashing the id beats cycling a palette by index, which reshuffles
   // whenever a device is added or removed.
@@ -672,10 +676,20 @@ export async function render(container) {
     if (endEl) endEl.value = hhmm(endMin);
     pendingCreateDate = dayDate;
   }
-  let pendingCreateDate = null;
 
   function editSchedule(ev) {
     editingId = ev.id;
+    // ⚠️ THE DATE OF THE SCHEDULE BEING EDITED.
+    //
+    // Save rebuilds start_time from this date plus the HH:MM in the form. Without it, dref fell
+    // through to `new Date()` and EVERY edit silently moved the schedule to today - change a
+    // colour on a block dated 5 Aug and it jumped to this week. Nothing about that is timezone
+    // dependent; it hit every operator.
+    //
+    // ev.start_time is the SCHEDULE's own anchor (raw from the row), not the occurrence that was
+    // clicked, so editing a recurring rule keeps its start date rather than re-anchoring it to
+    // whichever instance the operator happened to click.
+    pendingCreateDate = new Date(ev.start_time);
     document.getElementById('schedModalTitle').textContent = t('schedule.edit_schedule');
     document.getElementById('schedPlaylist').value = ev.playlist_id || '';
     document.getElementById('schedLayout').value = ev.layout_id || '';
@@ -704,6 +718,12 @@ export async function render(container) {
 
   document.getElementById('addScheduleBtn').onclick = () => {
     editingId = null;
+    // Reset the date on OPEN, not on close. The modal has two inline onclick="...display='none'"
+    // dismissers (the X and Cancel) that cannot touch this scope, so a date left over from a
+    // drag-create survived a cancel and stamped itself on the NEXT schedule created. Setting it
+    // on every open makes the stale value unreachable no matter how the modal was dismissed.
+    // The drag-create path calls this handler first and then assigns its own day, so it still wins.
+    pendingCreateDate = null;
     document.getElementById('schedModalTitle').textContent = t('schedule.add_schedule');
     document.getElementById('schedTitle').value = '';
     document.getElementById('schedPlaylist').value = '';

--- a/server/routes/schedules.js
+++ b/server/routes/schedules.js
@@ -60,6 +60,36 @@ function getWorkspaceSchedulesQuery() {
   `;
 }
 
+/*
+ * A recurring instance must go out in the SAME shape a one-off does: a naive wall-clock string.
+ *
+ * ⚠️ THIS IS THE "MY SCHEDULE IS ON THE WRONG DAY" BUG.
+ *
+ * expandSchedule had two emit paths that disagreed. A one-off returns schedule.start_time
+ * untouched - a naive local string like 2026-08-19T20:00:00 - which the browser parses in ITS OWN
+ * zone, giving back the day the operator picked. A recurring instance returned cursor.toISOString(),
+ * an absolute instant derived by reading that same naive string in the SERVER's zone. The browser
+ * then converted it back into its own zone, and the two conversions do not cancel:
+ *
+ *   operator in Tokyo saves Wed 20:00   ->  stored "2026-08-19T20:00:00"
+ *   server in US Central reads 20:00 CDT ->  emits "2026-08-20T01:00:00.000Z"
+ *   browser renders that in JST          ->  THURSDAY 10:00
+ *
+ * Day and time both wrong, and only for recurring schedules - which is why it looked intermittent.
+ * The calendar was also the odd one out: the playback engine compares start_time as a STRING
+ * (services/scheduler.js), never as an instant, so expandSchedule was the only place in the
+ * codebase reinterpreting a wall-clock time as a point in time.
+ *
+ * schedules.timezone is already stored per row; rendering true instants from it would be the fuller
+ * answer. Matching the format the rest of the system already speaks fixes the bug in front of us
+ * and cannot change what the engine actually plays.
+ */
+function localDateTime(d) {
+  const p = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}` +
+         `T${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
+}
+
 // Load a schedule + access context, sending 403/404 on failure.
 function loadScheduleAccess(req, res, requireWrite) {
   const schedule = db.prepare('SELECT * FROM schedules WHERE id = ?').get(req.params.id);
@@ -430,8 +460,8 @@ function expandSchedule(schedule, rangeStart, rangeEnd) {
     if (fires && (cursor >= rangeStart || instanceEnd >= rangeStart)) {
       events.push({
         ...schedule,
-        instance_start: cursor.toISOString(),
-        instance_end: instanceEnd.toISOString(),
+        instance_start: localDateTime(cursor),
+        instance_end: localDateTime(instanceEnd),
       });
     }
     cursor = new Date(cursor.getTime() + dayMs);
@@ -464,3 +494,4 @@ module.exports = router;
 // Exported for testing, the same way playlists.js exports publishPlaylist. The calendar's
 // correctness is arithmetic and deserves to be checked without standing up a server.
 module.exports.expandSchedule = expandSchedule;
+module.exports.localDateTime = localDateTime;

--- a/server/test/schedule-instance-format.test.js
+++ b/server/test/schedule-instance-format.test.js
@@ -1,0 +1,116 @@
+'use strict';
+
+// THE BUG THIS PINS: "I add a schedule and it shows up on a different day."
+//
+// expandSchedule had two emit paths that disagreed about the wire format. A one-off passed
+// schedule.start_time through untouched - a naive wall-clock string - while a recurring instance
+// emitted cursor.toISOString(), an absolute instant. The browser parses the first in its own zone
+// (correct) and converts the second out of the server's zone (wrong by the offset between them).
+// For an operator in Tokyo against a US-Central server that is 14 hours: a Wednesday 20:00 event
+// came back as Thursday 10:00.
+//
+// The calendar was also the only component doing this. services/scheduler.js compares start_time
+// as a STRING and never builds a Date from it, so the drawing disagreed with playback as well as
+// with the browser.
+//
+// These tests assert the PROPERTY the browser depends on - the wire value is wall-clock, and it
+// means the same thing regardless of which zone reads it - rather than asserting a literal string,
+// which would pass just as happily with the bug present in a differently-configured CI box.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'st-fmt-'));
+process.env.DATA_DIR = tmp;
+process.env.JWT_SECRET = 'test-secret-instance-format';
+
+const { expandSchedule } = require('../routes/schedules');
+
+// Wednesday 19 Aug 2026, 20:00 - late enough in the day that a westward server offset pushes it
+// over midnight, which is exactly the case that was breaking.
+const START = '2026-08-19T20:00:00';
+const END   = '2026-08-19T21:00:00';
+const WALL_CLOCK = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/;
+
+const rangeStart = new Date(2026, 7, 16, 0, 0, 0, 0);        // Sun 16 Aug, local
+const rangeEnd   = new Date(2026, 7, 23, 0, 0, 0, 0);        // Sun 23 Aug, local
+
+const schedule = (recurrence) => ({
+  id: 1, start_time: START, end_time: END, recurrence, recurrence_end: null,
+});
+
+/* Run fn with the process in a given zone, restoring exactly what was there before. */
+function inTimezone(tz, fn) {
+  const had = Object.prototype.hasOwnProperty.call(process.env, 'TZ');
+  const original = process.env.TZ;
+  process.env.TZ = tz;
+  try {
+    return fn();
+  } finally {
+    // ⚠️ Assigning `undefined` here would write the STRING "undefined", which Node cannot parse and
+    // silently resolves to UTC - quietly changing the zone for every test that runs afterwards in
+    // this process. Delete the key instead when it was not set to begin with.
+    if (had) process.env.TZ = original;
+    else delete process.env.TZ;
+  }
+}
+
+test('a recurring instance is emitted as wall-clock, not as an absolute instant', () => {
+  const events = expandSchedule(schedule('FREQ=WEEKLY;BYDAY=WE'), rangeStart, rangeEnd);
+  assert.ok(events.length > 0, 'the rule should draw at least one event');
+  for (const ev of events) {
+    assert.match(ev.instance_start, WALL_CLOCK,
+      `instance_start must be a naive wall-clock string; got ${ev.instance_start}`);
+    assert.match(ev.instance_end, WALL_CLOCK,
+      `instance_end must be a naive wall-clock string; got ${ev.instance_end}`);
+  }
+});
+
+test('one-off and recurring agree on the wire format', () => {
+  // They are read by the same line of frontend code. If they disagree, one of them is wrong on
+  // every client whose zone differs from the server's - and which one is invisible from here.
+  const [oneOff] = expandSchedule(schedule(null), rangeStart, rangeEnd);
+  const [recurring] = expandSchedule(schedule('FREQ=WEEKLY;BYDAY=WE'), rangeStart, rangeEnd);
+  const shape = (v) => (WALL_CLOCK.test(v) ? 'wall-clock' : 'absolute');
+  assert.equal(shape(recurring.instance_start), shape(oneOff.instance_start),
+    'the two emit paths disagree about the wire format');
+});
+
+test('the emitted time is the time the operator chose', () => {
+  const [ev] = expandSchedule(schedule('FREQ=WEEKLY;BYDAY=WE'), rangeStart, rangeEnd);
+  assert.equal(ev.instance_start.slice(11, 16), '20:00',
+    'a 20:00 schedule must draw at 20:00');
+  assert.equal(new Date(ev.instance_start).getDay(), 3, 'Wednesday stays Wednesday');
+});
+
+test('THE REPORTED BUG: the day survives a server and browser in different zones', () => {
+  // Generate as a US-Central server would, then read it as a Tokyo browser would. With the bug,
+  // the recurring instance arrives as ...T01:00:00.000Z and Tokyo renders Thursday 10:00.
+  const wire = inTimezone('America/Chicago', () => {
+    const [ev] = expandSchedule(schedule('FREQ=WEEKLY;BYDAY=WE'), rangeStart, rangeEnd);
+    return ev.instance_start;
+  });
+
+  inTimezone('Asia/Tokyo', () => {
+    const seen = new Date(wire);
+    assert.equal(seen.getDay(), 3, `Tokyo should still see Wednesday, saw ${seen.toString()}`);
+    assert.equal(seen.getHours(), 20, `Tokyo should still see 20:00, saw ${seen.getHours()}:00`);
+  });
+});
+
+test('and the same holds when the server is EAST of the browser', () => {
+  // The mirror case, so a fix that merely shifts the offset in one direction cannot pass.
+  const wire = inTimezone('Asia/Tokyo', () => {
+    const [ev] = expandSchedule(schedule('FREQ=WEEKLY;BYDAY=WE'), rangeStart, rangeEnd);
+    return ev.instance_start;
+  });
+
+  inTimezone('America/Chicago', () => {
+    const seen = new Date(wire);
+    assert.equal(seen.getDay(), 3, `Chicago should still see Wednesday, saw ${seen.toString()}`);
+    assert.equal(seen.getHours(), 20, `Chicago should still see 20:00, saw ${seen.getHours()}:00`);
+  });
+});

--- a/server/test/schedule-modal-date.test.js
+++ b/server/test/schedule-modal-date.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+// TWO DATE BUGS IN THE SCHEDULE MODAL, both timezone-independent, both silent.
+//
+//  1. Saving an EDIT moved the schedule to today. The save handler rebuilds start_time from
+//     `pendingCreateDate || new Date()`, and editSchedule() restored only HH:MM - it never recorded
+//     the date it was editing. Change a colour on a block dated 5 Aug and it jumped to this week.
+//
+//  2. A cancelled drag-create leaked its date into the NEXT schedule. pendingCreateDate was cleared
+//     only on a successful save, and the modal's two dismissers are inline
+//     onclick="...display='none'" attributes that cannot reach this scope.
+//
+// Both are fixed by assigning the date on every path that OPENS the modal, which is the invariant
+// pinned here. There is no DOM in this runner, so this is a source-level check - the same technique
+// i18n-keys-exist.test.js uses to police the views. It is deliberately loose about HOW the value is
+// assigned and strict about WHETHER each opener assigns it, so a refactor that keeps the invariant
+// keeps passing.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SRC = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'frontend', 'js', 'views', 'schedule.js'), 'utf8');
+
+/*
+ * Comment lines are dropped before any of this is matched.
+ *
+ * The first version of this test failed against the FIXED code because the save handler carries a
+ * comment explaining why it does not use toISOString() - and the test matched the explanation.
+ * A source-level check has to look at code, not at prose about code.
+ *
+ * Whole-line comments only: stripping mid-line would mean parsing strings, and "https://" inside a
+ * URL literal looks exactly like a line comment to anything simpler than a parser.
+ */
+function withoutComments(text) {
+  return text
+    .split('\n')
+    .filter((line) => {
+      const t = line.trim();
+      return !(t.startsWith('//') || t.startsWith('*') || t.startsWith('/*'));
+    })
+    .join('\n');
+}
+
+/* The text of a brace-balanced block starting at `from`. */
+function blockAt(from) {
+  const open = SRC.indexOf('{', from);
+  let depth = 0;
+  for (let i = open; i < SRC.length; i++) {
+    if (SRC[i] === '{') depth++;
+    else if (SRC[i] === '}') {
+      depth--;
+      if (depth === 0) return SRC.slice(open, i + 1);
+    }
+  }
+  throw new Error('unbalanced block');
+}
+
+const ASSIGNS_DATE = /pendingCreateDate\s*=/;
+
+test('editSchedule records the date of the schedule it is editing', () => {
+  const at = SRC.indexOf('function editSchedule(');
+  assert.notEqual(at, -1, 'editSchedule() not found - has it been renamed?');
+  assert.match(withoutComments(blockAt(at)), ASSIGNS_DATE,
+    'editSchedule() must set pendingCreateDate, or saving an edit moves the schedule to today');
+});
+
+test('opening the blank Add form clears any date left over from a cancelled drag', () => {
+  const at = SRC.indexOf("getElementById('addScheduleBtn').onclick");
+  assert.notEqual(at, -1, 'the addScheduleBtn handler was not found');
+  assert.match(withoutComments(blockAt(at)), ASSIGNS_DATE,
+    'the Add handler must reset pendingCreateDate, or a cancelled drag-create stamps the next schedule');
+});
+
+test('the date is declared before anything assigns it', () => {
+  // It used to be declared BELOW the drag handler that assigns it. That happens to work only
+  // because the handler runs later; moving either one would turn it into a ReferenceError at a
+  // moment nobody is watching.
+  const code = withoutComments(SRC);
+  const decl = code.search(/\blet\s+pendingCreateDate\b/);
+  assert.notEqual(decl, -1, 'pendingCreateDate declaration not found');
+  const firstUse = code.search(/pendingCreateDate\s*=\s*(?!null\b)/);
+  assert.ok(decl < firstUse || firstUse === -1,
+    'pendingCreateDate is assigned before it is declared');
+});
+
+test('the saved date is built from local parts, never toISOString', () => {
+  // toISOString() is UTC: for anyone west of Greenwich it stamps the previous day for part of the
+  // evening, which is the same class of bug as the one on the server side.
+  const at = SRC.indexOf("getElementById('saveScheduleBtn').onclick");
+  assert.notEqual(at, -1, 'the save handler was not found');
+  const body = withoutComments(blockAt(at));
+  assert.ok(!/toISOString\(\)/.test(body),
+    'the save handler must not derive a calendar date from toISOString()');
+  assert.match(body, /getFullYear\(\)/, 'the date should be assembled from local parts');
+});


### PR DESCRIPTION
Three separate defects that all present as "I saved a schedule and it moved to a different day".

### 1. Recurring instances went out in a different wire format than one-offs

`expandSchedule` had two emit paths that disagreed:

```js
one-off    instance_start: schedule.start_time     // naive wall-clock, passed through
recurring  instance_start: cursor.toISOString()    // absolute instant
```

The browser parses the first in its own zone (correct) and converts the second out of the server's zone (wrong by the offset between them). Reproduced against the real code — server `America/Chicago`, operator `Asia/Tokyo`:

| | wire | rendered in Tokyo |
|---|---|---|
| one-off | `2026-08-19T20:00:00` | Wed 19th, 20:00 ✅ |
| recurring | `2026-08-20T01:00:00.000Z` | **Thu 20th, 10:00** ❌ |

Wrong day *and* wrong time, recurring schedules only — which is why it looked intermittent.

Worth noting why the fix emits wall-clock rather than making everything UTC: `services/scheduler.js` compares `start_time` as a **string** and never builds a `Date` from it. `expandSchedule` was the only place in the codebase reinterpreting a wall-clock time as an instant, so the calendar disagreed with playback as well as with the browser. `schedules.timezone` is already stored per row and rendering true instants from it would be the fuller answer; this matches the format the rest of the system already speaks and cannot change what the engine plays.

### 2. Saving an edit moved the schedule to today

The save handler rebuilds `start_time` from `pendingCreateDate || new Date()`, and `editSchedule()` restored only `HH:MM` — it never recorded the date it was editing. Change a colour on a block dated 5 Aug and it is `PUT` with today's date.

**No timezone mismatch required.** This affected every operator and silently rewrote stored data.

### 3. A cancelled drag-create leaked its date into the next schedule

`pendingCreateDate` was cleared only on a successful save, and the modal's two dismissers are inline `onclick="...display='none'"` attributes that cannot reach that scope. Drag-create on Saturday, close, then "Add Schedule" → stamped Saturday.

Fixed by assigning the date on every path that **opens** the modal, so no dismissal path can leave a stale value.

### Testing

Both new files fail on the parent commit and pass here:

```
schedule-instance-format.test.js   parent: 0/5   this branch: 5/5
schedule-modal-date.test.js        parent: 1/4   this branch: 4/4
schedule + calendar + timezone suites            85 pass, 0 fail
```

The format tests assert the *property* — that the value is wall-clock, and that the day survives a server/browser zone mismatch in **both** directions — rather than a literal string, which would pass just as happily with the bug present on a differently-configured CI box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)