### PR TITLE
Keep every field on screen during first-run setup

### DIFF
--- a/frontend/js/lib/login-form-state.js
+++ b/frontend/js/lib/login-form-state.js
@@ -1,0 +1,39 @@
+/*
+ * What the login form shows, as a pure decision.
+ *
+ * Extracted because it got this wrong in a way nobody could see from reading the handlers: the
+ * state lived in two mutable flags updated from four event listeners, and one of those listeners
+ * undid first-run setup on the first keystroke.
+ *
+ * THE BUG. On a fresh install with no users, the page set identified = true so both fields were
+ * available, because there is nobody to identify - the operator is creating the first account.
+ * Then typing in the email box fired the "editing the address returns to the identifier step"
+ * listener, which set identified = false and re-applied the state, hiding the password field
+ * mid-typing and relabelling the button "Next".
+ *
+ * Identifier-first exists to ask the server which identity provider an EXISTING address uses, so
+ * an SSO-only user is never shown a password box that will be refused. With an empty user table
+ * there is no such question, so the whole two-step flow has to be inert - not merely initialised
+ * to a state that a later event can undo.
+ */
+
+/**
+ * @param {{isSetup: boolean, identified: boolean, ssoOnlyDomain: boolean}} state
+ * @returns {{showPassword: boolean, showButton: boolean, buttonKey: string}}
+ */
+export function loginFormState({ isSetup, identified, ssoOnlyDomain }) {
+  // First-run setup: every field is needed at once and no event may take one away. Deliberately
+  // ignores `identified` and `ssoOnlyDomain` rather than trusting them to hold the right values -
+  // that trust is what broke.
+  if (isSetup) {
+    return { showPassword: true, showButton: true, buttonKey: 'auth.create_admin_account' };
+  }
+
+  const known = identified && !ssoOnlyDomain;
+  return {
+    showPassword: known,
+    // An SSO-only domain has nothing to press: the provider button is the only way in.
+    showButton: !ssoOnlyDomain,
+    buttonKey: known ? 'auth.sign_in' : 'auth.next',
+  };
+}

--- a/frontend/js/views/login.js
+++ b/frontend/js/views/login.js
@@ -1,4 +1,5 @@
 import { showToast } from '../components/toast.js';
+import { loginFormState } from '../lib/login-form-state.js';
 import { t } from '../i18n.js';
 import { esc } from '../utils.js';
 
@@ -328,6 +329,9 @@ function setupHandlers(config, isSetup) {
    * their domain must get a fresh answer rather than keep the previous domain's one.
    */
   document.getElementById('loginEmail')?.addEventListener('input', () => {
+    // Nothing to step back to during first-run setup - there is no identifier step. This used to
+    // fire on the first keystroke and hide the password field the operator was about to fill in.
+    if (isSetup) return;
     if (!identified) return;
     identified = false;
     applyFormState();
@@ -578,8 +582,10 @@ function setupHandlers(config, isSetup) {
   let ssoOnlyDomain = false;
 
   function applyFormState() {
-    const showPassword = identified && !ssoOnlyDomain;
-    const show = showPassword ? '' : 'none';
+    // One decision, in one place, from ../lib/login-form-state.js. It used to be computed inline
+    // from two mutable flags, which is how first-run setup ended up being undone by a keystroke.
+    const state = loginFormState({ isSetup, identified, ssoOnlyDomain });
+    const show = state.showPassword ? '' : 'none';
     /*
      * ⚠️ Hide the password FIELD, never its .form-group — the organization SSO slot lives inside
      * that same group, so hiding the container took the single sign-on button down with it.
@@ -594,8 +600,8 @@ function setupHandlers(config, isSetup) {
      * rather than two, so there is never a choice about which to press.
      */
     const btn = document.getElementById('loginBtn');
-    if (btn) btn.textContent = identified && !ssoOnlyDomain ? t('auth.sign_in') : t('auth.next');
-    if (btn) btn.style.display = ssoOnlyDomain ? 'none' : '';
+    if (btn) btn.textContent = t(state.buttonKey);
+    if (btn) btn.style.display = state.showButton ? '' : 'none';
 
     /*
      * The instance's own providers stay visible at ALL times, by explicit decision: they are the

--- a/server/test/login-form-state.test.js
+++ b/server/test/login-form-state.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+// THE BUG: on a fresh install with no users, typing an email address made the password field
+// disappear.
+//
+// The login form is identifier-first for normal sign-in: it asks the server which identity provider
+// an address uses before offering a credential, so an SSO-only user is never shown a password box
+// that will be refused. First-run setup set `identified = true` up front so both fields were
+// available - there is nobody to identify, the operator is creating the first account - and then the
+// "editing the address returns to the identifier step" listener fired on the first keystroke, set it
+// back to false, and hid the password field mid-typing. The same re-render relabelled the button
+// from "Create admin account" to "Next".
+//
+// The decision now lives in frontend/js/lib/login-form-state.js as a pure function so the whole
+// truth table can be pinned, including the state the old code could not represent: setup mode where
+// `identified` has been clobbered.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const MOD = pathToFileURL(
+  path.join(__dirname, '..', '..', 'frontend', 'js', 'lib', 'login-form-state.js')).href;
+
+let loginFormState;
+test('load the module', async () => {
+  ({ loginFormState } = await import(MOD));
+  assert.equal(typeof loginFormState, 'function');
+});
+
+test('THE BUG: during setup the password survives a keystroke in the email box', async () => {
+  ({ loginFormState } = await import(MOD));
+  // identified:false is exactly what the input listener used to leave behind. Setup must not care.
+  const s = loginFormState({ isSetup: true, identified: false, ssoOnlyDomain: false });
+  assert.equal(s.showPassword, true, 'the password field must stay visible during first-run setup');
+  assert.equal(s.buttonKey, 'auth.create_admin_account', 'and the button must not become Next');
+});
+
+test('setup shows both fields regardless of any other flag', async () => {
+  ({ loginFormState } = await import(MOD));
+  for (const identified of [true, false]) {
+    for (const ssoOnlyDomain of [true, false]) {
+      const s = loginFormState({ isSetup: true, identified, ssoOnlyDomain });
+      assert.equal(s.showPassword, true,
+        `setup must show the password (identified=${identified} ssoOnly=${ssoOnlyDomain})`);
+      assert.equal(s.showButton, true, 'and must always offer the button');
+      assert.equal(s.buttonKey, 'auth.create_admin_account');
+    }
+  }
+});
+
+test('normal sign-in still hides the password until an address is submitted', async () => {
+  ({ loginFormState } = await import(MOD));
+  const before = loginFormState({ isSetup: false, identified: false, ssoOnlyDomain: false });
+  assert.equal(before.showPassword, false, 'identifier-first: no password box yet');
+  assert.equal(before.buttonKey, 'auth.next');
+
+  const after = loginFormState({ isSetup: false, identified: true, ssoOnlyDomain: false });
+  assert.equal(after.showPassword, true);
+  assert.equal(after.buttonKey, 'auth.sign_in');
+});
+
+test('an SSO-only domain gets neither a password box nor a submit button', async () => {
+  ({ loginFormState } = await import(MOD));
+  // The provider button is the only way in; offering a password that will be refused, or a submit
+  // that cannot work, is worse than offering nothing.
+  const s = loginFormState({ isSetup: false, identified: true, ssoOnlyDomain: true });
+  assert.equal(s.showPassword, false);
+  assert.equal(s.showButton, false);
+});
+
+test('the button key is always a real translation key', async () => {
+  ({ loginFormState } = await import(MOD));
+  // t() renders the KEY when it is undefined, so a typo here puts a bare identifier on the button.
+  const fs = require('node:fs');
+  const en = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'frontend', 'js', 'i18n', 'en.js'), 'utf8');
+  const seen = new Set();
+  for (const isSetup of [true, false]) {
+    for (const identified of [true, false]) {
+      for (const ssoOnlyDomain of [true, false]) {
+        seen.add(loginFormState({ isSetup, identified, ssoOnlyDomain }).buttonKey);
+      }
+    }
+  }
+  for (const key of seen) {
+    assert.ok(en.includes(`'${key}'`), `${key} is not defined in en.js`);
+  }
+});

--- a/server/test/login-identifier-first.test.js
+++ b/server/test/login-identifier-first.test.js
@@ -17,16 +17,23 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const LOGIN = fs.readFileSync(path.join(__dirname, '..', '..', 'frontend', 'js', 'views', 'login.js'), 'utf8');
+// The visibility decision itself now lives in a pure module - see login-form-state.test.js for its
+// truth table. It moved because computing it inline from two mutable flags let a keystroke undo
+// first-run setup. These assertions follow it there rather than pinning it to its old address.
+const STATE = fs.readFileSync(path.join(__dirname, '..', '..', 'frontend', 'js', 'lib', 'login-form-state.js'), 'utf8');
 
 test('password visibility depends on BOTH identification and SSO-only', () => {
-  assert.match(LOGIN, /const showPassword = identified && !ssoOnlyDomain;/,
+  assert.match(STATE, /identified && !ssoOnlyDomain/,
     'the two drivers must be combined in one place so they cannot disagree');
+  assert.match(LOGIN, /loginFormState\(\{ isSetup, identified, ssoOnlyDomain \}\)/,
+    'the view must take its state from that one place rather than recomputing it');
 });
 
 test('the primary button advances before it signs in', () => {
   assert.match(LOGIN, /if \(identified && !ssoOnlyDomain\) return doLogin\(\);\s*\n\s*identify\(\);/,
     'the button must identify first and only sign in once an address is known');
-  assert.match(LOGIN, /btn\.textContent = identified && !ssoOnlyDomain \? t\('auth\.sign_in'\) : t\('auth\.next'\)/);
+  assert.match(STATE, /'auth\.sign_in'[\s\S]{0,80}'auth\.next'/,
+    'the label must still advance through Next before offering Sign in');
 });
 
 test('editing the address returns to the identifier step', () => {


### PR DESCRIPTION
On a fresh install with no users, typing an email address made the **password field disappear**.

### Cause

Identifier-first login asks the server which identity provider an address uses *before* offering a credential, so someone whose organization requires its own IdP is never shown a password box that will be refused.

First-run setup opted out of that by setting `identified = true` up front — there is nobody to identify, the operator is creating the first account. Then this listener fired on the very first keystroke:

```js
document.getElementById('loginEmail')?.addEventListener('input', () => {
  if (!identified) return;
  identified = false;      // ← undoes first-run setup
  applyFormState();        // ← password field gone, mid-typing
});
```

The same re-render also replaced "Create admin account" on the button with "Sign in", then "Next".

**Initialising a flag to the right value is not the same as the flow being inert.** Any later event could undo it, and one did.

### Fix

The decision moves into `frontend/js/lib/login-form-state.js` as a pure function that ignores `identified` and `ssoOnlyDomain` entirely when there are no users — so no event can take a field away:

```js
if (isSetup) {
  return { showPassword: true, showButton: true, buttonKey: 'auth.create_admin_account' };
}
```

The input listener also returns early during setup, which additionally stops it spending an org-lookup rate-limit budget that has nothing to answer.

### Verification

The pre-fix logic, extracted and run against the reported state, reproduces the symptom exactly:

```
old logic, setup + one keystroke -> showPassword=false  button=auth.next
expected                         -> showPassword=true   button=auth.create_admin_account
```

The new truth table covers all eight combinations of the three inputs, plus that every `buttonKey` it can return is a real key in `en.js` (`t()` renders the key itself when undefined, which would put a bare identifier on the button).

```
i18n / login / auth / session / sso suites    main: 108 pass    this branch: 116 pass    0 fail
```

Two assertions in `login-identifier-first.test.js` pinned those expressions to their old address inside `login.js`. Their intent — *"the two drivers must be combined in one place so they cannot disagree"* — is better served by the extracted module, so they follow the logic there rather than being loosened.

### Not fixed here

`loadAuthConfig()` has no error handling and caches its first result, so a `/api/auth/config` that fails or is slow leaves `needsSetup` undefined and the form falls back to the restrictive layout — the same visible symptom from a different cause. Worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)