### PR TITLE
Show the player on the player, and the diagnostics when something is wrong

### DIFF
--- a/brightsign/server/bs-server-boot.js
+++ b/brightsign/server/bs-server-boot.js
@@ -30,6 +30,7 @@
 
 const os = require('os');
 const net = require('net');
+const http = require('http');
 
 /*
  * ⚠️ GIVE THE PAGE NODE'S TIMERS.
@@ -268,6 +269,37 @@ let lastLoggedInstall = null;
  * So prove it rather than infer it - a real TCP connect to the port, on the same interval as the
  * status frame. Cheap, and it cannot be fooled by the server having got halfway up.
  */
+/*
+ * Has anyone created the first account yet?
+ *
+ * The screen has three states, and this is the one the server has to be asked about: a server that
+ * is up but has no users is not ready to show a player, it is waiting for someone to open the
+ * dashboard and create an admin. /api/auth/config answers it and is public by design.
+ *
+ * Asked HERE rather than from the page because the page is loaded from file:// - origin "null" -
+ * and the server sets no CORS headers on its own API. This process is already talking to it.
+ *
+ * null means "not known yet", which is deliberately distinct from false: the page must not flip to
+ * the player on a probe that has not answered.
+ */
+let needsSetup = null;
+function probeSetup() {
+  if (!serving) { needsSetup = null; return; }
+  const req = http.request(
+    { host: '127.0.0.1', port: Number(currentPort()), path: '/api/auth/config', timeout: 3000 },
+    (res) => {
+      let body = '';
+      res.on('data', (c) => { body += c; });
+      res.on('end', () => {
+        try { needsSetup = !!JSON.parse(body).needsSetup; }
+        catch (e) { /* a malformed answer is not an answer */ }
+      });
+    });
+  req.on('error', () => { /* server not answering yet; leave the previous value */ });
+  req.on('timeout', () => req.destroy());
+  req.end();
+}
+
 let serving = false;
 function probeListening() {
   const port = Number(currentPort());
@@ -296,6 +328,7 @@ function statusFrame() {
     disk: diskFor(DATA_DIR),
     install: installState,
     serving,
+    needsSetup,
     dbMb: dbBytes(path.join(DATA_DIR, 'db')),
     log: logRing.slice(-14),
   };
@@ -309,7 +342,7 @@ post({ type: 'st-server-boot', node: process.versions.node, arch: process.arch, 
 // A frame straight away so the screen is never blank while the server warms up, then on a timer.
 // 2s is a compromise: fast enough to watch a boot, slow enough that a 3-core player is not being
 // asked to serialise state constantly while it is also serving.
-const timer = setInterval(() => { probeListening(); post(statusFrame()); }, 2000);
+const timer = setInterval(() => { probeListening(); probeSetup(); post(statusFrame()); }, 2000);
 if (typeof timer.unref === 'function') timer.unref();
 post(statusFrame());
 
@@ -417,7 +450,6 @@ function status() {
 
 const STATUS_PORT = Number(process.env.ST_STATUS_PORT || 8182);
 try {
-  const http = require('http');
   const statusServer = http.createServer((req, res) => {
     // The page is loaded from file://, whose origin is "null" - it needs CORS to read this at all.
     res.writeHead(200, {

--- a/brightsign/server/node-server.html
+++ b/brightsign/server/node-server.html
@@ -32,10 +32,16 @@
   .bad { color: #f87171; }
   /* Not green: green reads as "ready", and it is not ready. */
   .url.pending { color: #7d8da5; }
+  /* The player is a full-screen layer ABOVE the diagnostics, shown only once the server is
+     genuinely ready. Diagnostics stay mounted underneath so they can be revealed instantly. */
+  #player { position: fixed; inset: 0; width: 100%; height: 100%; border: 0; display: none;
+            background: #000; z-index: 10; }
   #log { background: #060911; border: 1px solid #1e2a3d; border-radius: 6px; padding: 14px 18px;
          font-size: 17px; line-height: 1.45; height: 34vh; overflow: hidden; color: #9fb3cd;
          white-space: pre-wrap; }
 </style>
+
+<iframe id="player" title="ScreenTinker player" allow="autoplay; fullscreen"></iframe>
 
 <div class="wrap">
   <h1>ScreenTinker server</h1>
@@ -49,6 +55,9 @@
     <tr><td class="k">node</td><td id="node">&mdash;</td>
         <td class="k">load</td><td id="load">&mdash;</td></tr>
   </table>
+  <div id="setupNote" style="display:none;font-size:26px;color:#fbbf24;margin:-10px 0 22px">
+    Open the address above and create the first account to finish setup.
+  </div>
   <div id="log">waiting for the server&hellip;</div>
 </div>
 
@@ -93,8 +102,85 @@
     try { xhr.send(); } catch (e) { lastError = String(e && e.message ? e.message : e); paint(); }
   }
 
+  /*
+   * WHICH LAYER IS ON SCREEN.
+   *
+   * Three states, and the transitions between them are the whole point:
+   *
+   *   installing / down / failed   diagnostics. The operator can see why.
+   *   up, but no account yet       diagnostics, plus the address to go and create one. A player
+   *                                with no account to belong to has nothing to show, and hiding
+   *                                the address would leave the box unsetuppable - it has no
+   *                                keyboard.
+   *   up, account exists           the player, full screen.
+   *
+   * ⚠️ THE PLAYER IS AN IFRAME, NOT A NAVIGATION. Setting location.href would replace this
+   * document, and with it the poller that is the only thing able to notice the server failing
+   * later. As a layer, the diagnostics are always one style change away from being back on screen -
+   * which is exactly what should happen if the server dies at 3am.
+   *
+   * needsSetup === null means the probe has not answered yet, and is deliberately NOT treated as
+   * false: flipping to the player on an unanswered probe would show a blank player to an operator
+   * who is still waiting to be told where to sign up.
+   */
+  /*
+   * WHICH LAYER BELONGS ON SCREEN. Pure, so the transition table can be tested - see
+   * server/test/brightsign-screen-state.test.js.
+   *
+   *   'diagnostics'  installing, down, or failed. The operator can see why.
+   *   'setup'        up, but nobody has created an account. Diagnostics PLUS the address to go
+   *                  and create one: a player with no account has nothing to show, and hiding the
+   *                  address would leave the box unsetuppable - it has no keyboard.
+   *   'player'       up, and an account exists.
+   *
+   * needsSetup === null means the probe has not answered yet, and is deliberately NOT false:
+   * flipping to the player on an unanswered probe shows a blank player to someone who is still
+   * waiting to be told where to sign up.
+   */
+  function screenState(s) {
+    if (!s || !s.serving || s.fatal) return 'diagnostics';
+    if (s.needsSetup === true) return 'setup';
+    if (s.needsSetup === false) return 'player';
+    return 'diagnostics';
+  }
+
+  /*
+   * ⚠️ THE PLAYER IS AN IFRAME, NOT A NAVIGATION. Setting location.href would replace this
+   * document and with it the poller - the only thing able to notice the server failing later. As a
+   * layer, the diagnostics are always one style change away from being back on screen, which is
+   * exactly what should happen if the server dies at 3am.
+   */
+  var playerShown = false;
+
+  function applyLayer(s) {
+    var state = screenState(s);
+    var frame = el('player');
+
+    if (state === 'player') {
+      if (!playerShown) {
+        // (Re)load on every transition INTO player. If the server had been down, whatever the
+        // player last rendered is an error page and it will not recover on its own.
+        frame.src = 'http://127.0.0.1:' + s.port + '/player/';
+        frame.style.display = 'block';
+        playerShown = true;
+      }
+      return true;
+    }
+
+    if (playerShown) {
+      // Blank the frame so a dead server is not being hammered by a player retrying behind an
+      // invisible layer.
+      frame.style.display = 'none';
+      frame.removeAttribute('src');
+      playerShown = false;
+    }
+    el('setupNote').style.display = state === 'setup' ? 'block' : 'none';
+    return false;
+  }
+
   function paint() {
     var s = last;
+    if (applyLayer(s)) return;
     if (!s) {
       // Before the first successful poll there is genuinely nothing to report. Say that, rather
       // than paint zeros that look like a running server with no traffic.

--- a/server/test/brightsign-screen-state.test.js
+++ b/server/test/brightsign-screen-state.test.js
@@ -1,0 +1,103 @@
+'use strict';
+
+// What a BrightSign shows: the server's own diagnostics, or the player.
+//
+// The box is both server and player, so the screen has to be one or the other at any moment, and
+// the interesting part is the transitions:
+//
+//   - a fresh install has nothing to play and nobody to play it for, so it must show the address
+//     where the first account gets created. There is no keyboard on a player; hiding that address
+//     leaves the device unsetuppable.
+//   - once an account exists it should get out of the way and be a screen.
+//   - if the server later fails, the diagnostics must come BACK, or a black display is the only
+//     symptom of a server that died overnight.
+//
+// That last requirement is why the player is an iframe layer rather than a navigation: navigating
+// would replace the document and kill the poller that notices the failure.
+//
+// The decision lives in node-server.html, which ships in autorun.zip and cannot be imported. It is
+// written as one pure function so the table below can pin it; the test lifts that function out of
+// the page rather than restating it, so a change to the page is a change to what is tested.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PAGE = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'brightsign', 'server', 'node-server.html'), 'utf8');
+
+function loadScreenState() {
+  const at = PAGE.indexOf('function screenState(');
+  assert.notEqual(at, -1, 'screenState() not found in node-server.html');
+  const open = PAGE.indexOf('{', at);
+  let depth = 0, end = -1;
+  for (let i = open; i < PAGE.length; i++) {
+    if (PAGE[i] === '{') depth++;
+    else if (PAGE[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
+  }
+  assert.notEqual(end, -1, 'unbalanced screenState()');
+  // eslint-disable-next-line no-new-func
+  return new Function(`${PAGE.slice(at, end + 1)}; return screenState;`)();
+}
+
+const screenState = loadScreenState();
+
+const frame = (over) => Object.assign(
+  { serving: true, fatal: null, needsSetup: false, port: '8181' }, over);
+
+test('a healthy server with an account shows the player', () => {
+  assert.equal(screenState(frame()), 'player');
+});
+
+test('a healthy server with NO account shows setup, not a blank player', () => {
+  // The whole point of requirement 1: stay on the config screen until someone has signed up.
+  assert.equal(screenState(frame({ needsSetup: true })), 'setup');
+});
+
+test('an unanswered setup probe is not treated as "no setup needed"', () => {
+  // null means we have not been told yet. Guessing "false" here would flip a fresh box to a player
+  // that has nothing to show, and take the sign-up address off the screen while doing it.
+  assert.equal(screenState(frame({ needsSetup: null })), 'diagnostics');
+  assert.equal(screenState(frame({ needsSetup: undefined })), 'diagnostics');
+});
+
+test('nothing listening means diagnostics, whatever else is true', () => {
+  assert.equal(screenState(frame({ serving: false })), 'diagnostics');
+  assert.equal(screenState(frame({ serving: false, needsSetup: false })), 'diagnostics');
+});
+
+test('THE RECOVERY CASE: a server that fails takes the player off the screen', () => {
+  // Requirement 2. A box that has been playing for weeks and then throws must show the operator
+  // something other than black.
+  const playing = frame();
+  assert.equal(screenState(playing), 'player');
+
+  const broken = frame({ fatal: 'server failed to start TypeError: ...' });
+  assert.equal(screenState(broken), 'diagnostics', 'a fatal must reveal the diagnostics again');
+
+  const gone = frame({ serving: false });
+  assert.equal(screenState(gone), 'diagnostics', 'so must the port going away');
+});
+
+test('no status at all is diagnostics rather than a crash', () => {
+  // The first paint happens before the first poll answers.
+  assert.equal(screenState(null), 'diagnostics');
+  assert.equal(screenState(undefined), 'diagnostics');
+});
+
+test('the page reloads the player when it comes back, rather than leaving an error page', () => {
+  // Not expressible in the pure function - assert the wiring instead. A player that rendered a
+  // connection error while the server was down will sit on it forever unless the src is re-set.
+  assert.match(PAGE, /if \(!playerShown\)[\s\S]{0,220}frame\.src =/,
+    'entering the player state must (re)assign the iframe src');
+  assert.match(PAGE, /frame\.removeAttribute\('src'\)/,
+    'leaving it must blank the frame so a dead server is not hammered behind an invisible layer');
+});
+
+test('the player is a layer, never a navigation', () => {
+  // location.href = player would replace this document and kill the poller that implements
+  // requirement 2. This is the assertion that stops someone "simplifying" it back.
+  assert.doesNotMatch(PAGE, /location\.href\s*=/,
+    'navigating away would destroy the only thing able to notice the server failing');
+});


### PR DESCRIPTION
The BrightSign is now both server and player, so its screen has to be one or the other at any moment.

| state | screen |
|---|---|
| installing, down, or failed | diagnostics — the fault is visible |
| up, but no account yet | diagnostics **plus the address to create one** |
| up, and an account exists | the player, full screen |

A fresh install has nothing to play and nobody to play it for, so it stays on the configuration screen until someone has signed up. Hiding that address would leave the device unsetuppable — **it has no keyboard**.

### The player is an iframe layer, not a navigation

This is the design decision the second requirement forces. `location.href = playerUrl` would replace the document and take the poller with it — and that poller is the only thing able to notice the server failing *later*. As a layer, the diagnostics are one style change away from being back on screen, which is exactly what should happen when a box that has been playing for weeks throws at 3am.

A test asserts `location.href` is never assigned, so this cannot be quietly simplified back into a navigation.

Two details that follow from it:
- entering the player state **re-assigns** the iframe `src`. If the server had been down, whatever the player last rendered is an error page and it will not recover on its own.
- leaving it **blanks** the frame, so a dead server is not being hammered by a player retrying behind an invisible layer.

### Where `needsSetup` comes from

The wrapper asks, not the page. `/api/auth/config` is public, but the page is loaded from `file://` — origin `"null"` — and the server sets no CORS headers on its own API, while the wrapper process is already talking to it.

The answer is **three-valued**. `null` means the probe has not replied yet and is deliberately *not* treated as `false`: guessing would flip a fresh box to an empty player and take the sign-up address off the screen while someone was reading it.

### Verification

Against a real server, not by inspection — install, sign up, watch it flip:

```
BEFORE signup : needsSetup=null   -> diagnostics
POST /api/auth/register -> HTTP 201
AFTER  signup : needsSetup=false  -> player
```

The decision is a pure function in the page; the test lifts it out of `node-server.html` rather than restating it, so a change to the page is a change to what is tested.

```
brightsign-screen-state    8 pass 0 fail
```

Covers: healthy+account → player, healthy+no account → setup, unanswered probe → diagnostics, nothing listening → diagnostics, **a fatal after weeks of playing → diagnostics again**, and no status at all → diagnostics rather than a crash.

### Scope

`brightsign/` and one new test only. No change to any shared server code — the payload is untouched, so only `autorun.zip` needs redeploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)