### PR TITLE
Make the on-device server opt-in, and stop the status port answering the LAN

### DIFF
--- a/brightsign/server/autorun.brs
+++ b/brightsign/server/autorun.brs
@@ -47,17 +47,26 @@ Sub Main()
     CreateDirectory(root$ + "/data")
 
     ' ------------------------------------------------------------------------------------------
-    ' 1. The server.
+    ' 1. The server - only if this player has been told to be one.
     ' ------------------------------------------------------------------------------------------
+    ' ⚠️ OFF UNLESS ASKED. A fleet gets one package; exactly one box per site should host the
+    ' server. Defaulting to on would mean every player that ever received this package started
+    ' listening on 8181, and the mistake would be invisible until two of them fought over the same
+    ' displays. A device with no config file, an unreadable one, or one that says 0 stays a player.
+    serverEnabled = ServerEnabled(root$)
+    print "[st-server] local server enabled: "; serverEnabled
     ' Only three keys exist here: message_port, node_arguments, arguments. An invented `env:` key is
     ' what killed the first attempt at this file, with nothing but "Load or runtime error in
     ' autorun. Forcing recovery." to go on - and it sent me to the widget for the wrong reason.
     ' Anything the server needs to be told goes in DATA_DIR/server.env, which it reads itself.
-    node = CreateObject("roNodeJs", "bs-server-boot.js", { message_port: msgPort })
-    if node = invalid then
-        print "[st-server] FAILED: could not launch the node process"
-    else
-        print "[st-server] node process launched"
+    node = invalid
+    if serverEnabled then
+        node = CreateObject("roNodeJs", "bs-server-boot.js", { message_port: msgPort })
+        if node = invalid then
+            print "[st-server] FAILED: could not launch the node process"
+        else
+            print "[st-server] node process launched"
+        end if
     end if
 
     ' ------------------------------------------------------------------------------------------
@@ -72,10 +81,18 @@ Sub Main()
     end if
     rect = CreateObject("roRectangle", 0, 0, w%, h%)
 
+    ' Spelled out rather than casting the boolean: this file cannot be run anywhere but on the
+    ' player, so it is not the place for a clever conversion nobody can check.
+    serverParam$ = "0"
+    if serverEnabled then serverParam$ = "1"
+
     ' NOTE what is NOT here: nodejs_enabled. The page no longer requires anything - it polls the
     ' server process over HTTP - so it can be an ordinary browser page. One less hybrid context.
     config = {
-        url: "file:///" + LCase(StripColon(root$)) + ":/node-server.html"
+        ' The page cannot discover this for itself: when the server is off there is no status
+        ' listener to ask, and "nothing is answering" would render as a fault rather than as a
+        ' deliberate setting.
+        url: "file:///" + LCase(StripColon(root$)) + ":/node-server.html?server=" + serverParam$
         javascript_enabled: true
         brightsign_js_objects_enabled: true
         storage_path: root$ + "/widget-cache"
@@ -113,6 +130,42 @@ Sub Main()
         end if
     end while
 End Sub
+
+
+'*******************************************************************************************
+Function ServerEnabled(root$ As String) As Boolean
+'*******************************************************************************************
+    ' st-config.json on the storage root, e.g. {"server": 1}
+    '
+    ' Deliberately at the root rather than inside data/: it is what an operator drops in over the
+    ' DWS, and autozip never writes it, so a re-provision cannot silently switch a site's server
+    ' off - or on.
+    '
+    ' Absent, unparseable, or anything other than an affirmative value means DISABLED. There is no
+    ' reading of a broken config file that should end with a device deciding to host a server.
+    txt$ = ReadAsciiFile(root$ + "/st-config.json")
+    if txt$ = "" then return false
+
+    cfg = ParseJSON(txt$)
+    if cfg = invalid then
+        print "[st-server] st-config.json is not valid JSON - server stays disabled"
+        return false
+    end if
+    if type(cfg) <> "roAssociativeArray" then return false
+
+    v = cfg.server
+    if v = invalid then return false
+
+    ' Accept the shapes a human actually writes: 1, true, "1", "true", "yes", "on".
+    if type(v) = "Boolean" then return v
+    if type(v) = "Integer" then return v <> 0
+    if type(v) = "roInt" then return v <> 0
+    if type(v) = "String" or type(v) = "roString" then
+        low$ = LCase(v)
+        return low$ = "1" or low$ = "true" or low$ = "yes" or low$ = "on"
+    end if
+    return false
+End Function
 
 '*******************************************************************************************
 Function StripColon(v As String) As String

--- a/brightsign/server/bs-server-boot.js
+++ b/brightsign/server/bs-server-boot.js
@@ -466,7 +466,17 @@ try {
     // Losing the screen must never cost us the server.
     remember('error', ['status listener failed', String(e && e.message ? e.message : e)]);
   });
-  statusServer.listen(STATUS_PORT, () => remember('log', ['status listener on :' + STATUS_PORT]));
+  /*
+   * ⚠️ LOOPBACK ONLY. Its only consumer is node-server.html running on this same device.
+   *
+   * Bound to every interface - which is what listen(port) does - it answered from anywhere on the
+   * customer's LAN with the install progress, disk usage, the device's own address and a tail of
+   * the server's console. That last one is the problem: a log tail carries whatever the server
+   * last printed, which is not a thing to hand to an unauthenticated caller on a network we do
+   * not control.
+   */
+  statusServer.listen(STATUS_PORT, '127.0.0.1',
+    () => remember('log', ['status listener on 127.0.0.1:' + STATUS_PORT]));
   if (statusServer.unref) statusServer.unref();
 } catch (e) {
   remember('error', ['could not start the status listener', String(e && e.message ? e.message : e)]);

--- a/brightsign/server/node-server.html
+++ b/brightsign/server/node-server.html
@@ -137,7 +137,11 @@
    * flipping to the player on an unanswered probe shows a blank player to someone who is still
    * waiting to be told where to sign up.
    */
-  function screenState(s) {
+  function screenState(s, serverEnabled) {
+    // Off on purpose is not the same as broken. Without this the page would poll a listener that
+    // was never started and report "no answer from the server process" - which reads as a fault
+    // and would send someone looking for one.
+    if (serverEnabled === false) return 'disabled';
     if (!s || !s.serving || s.fatal) return 'diagnostics';
     if (s.needsSetup === true) return 'setup';
     if (s.needsSetup === false) return 'player';
@@ -152,8 +156,14 @@
    */
   var playerShown = false;
 
+  /*
+   * st-config.json decides whether this box runs a server; autorun.brs passes the answer through
+   * because with the server off there is no status listener to ask.
+   */
+  var serverEnabled = !/[?&]server=0(&|$)/.test(String(location.search));
+
   function applyLayer(s) {
-    var state = screenState(s);
+    var state = screenState(s, serverEnabled);
     var frame = el('player');
 
     if (state === 'player') {
@@ -175,6 +185,18 @@
       playerShown = false;
     }
     el('setupNote').style.display = state === 'setup' ? 'block' : 'none';
+
+    if (state === 'disabled') {
+      el('sub').textContent = 'local server disabled';
+      el('sub').className = 'sub';
+      el('url').textContent = 'set {"server": 1} in st-config.json to enable';
+      el('url').className = 'url pending';
+      el('log').textContent =
+        'This player is not running a ScreenTinker server.\n\n' +
+        'Exactly one device per site should host one. To make it this device, put\n' +
+        '  {"server": 1}\n' +
+        'in st-config.json on the storage root and reboot.';
+    }
     return false;
   }
 
@@ -223,7 +245,12 @@
   }
 
   paint();
-  poll();
-  setInterval(poll, 2000);
+  if (serverEnabled) {
+    poll();
+    setInterval(poll, 2000);
+  } else {
+    // No listener was ever started, so polling would only manufacture errors.
+    applyLayer(null);
+  }
 })();
 </script>

--- a/brightsign/server/st-config.example.json
+++ b/brightsign/server/st-config.example.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Copy to st-config.json on the player's storage root. Absent or 0 means this device does NOT run a server - which is the default, because exactly one box per site should host one.",
+  "server": 0
+}

--- a/scripts/build-server-boot-zip.sh
+++ b/scripts/build-server-boot-zip.sh
@@ -44,6 +44,9 @@ cp brightsign/server/bs-server-boot.js   "$STAGE/bs-server-boot.js"
 cp brightsign/server/bs-payload-install.js "$STAGE/bs-payload-install.js"
 cp brightsign/server/node-server.html    "$STAGE/node-server.html"
 cp brightsign/server/server.env.example  "$STAGE/server.env.example"
+# Shipped as .example ONLY. A file named st-config.json would be extracted over the operator's own
+# on every re-provision, silently switching a site's server on or off.
+cp brightsign/server/st-config.example.json "$STAGE/st-config.example.json"
 
 mkdir -p "$(dirname "$OUT")"
 rm -f "$OUT"

--- a/server/test/brightsign-screen-state.test.js
+++ b/server/test/brightsign-screen-state.test.js
@@ -47,43 +47,51 @@ const frame = (over) => Object.assign(
   { serving: true, fatal: null, needsSetup: false, port: '8181' }, over);
 
 test('a healthy server with an account shows the player', () => {
-  assert.equal(screenState(frame()), 'player');
+  assert.equal(screenState(frame(), true), 'player');
+});
+
+test('a player that was never asked to be a server says so, rather than reporting a fault', () => {
+  // st-config.json is absent or {"server": 0} - the default. There is no status listener to poll,
+  // so without this the page would show "no answer from the server process" and send someone
+  // looking for a broken server that was never meant to exist.
+  assert.equal(screenState(null, false), 'disabled');
+  assert.equal(screenState(frame(), false), 'disabled', 'the setting wins over any stale status');
 });
 
 test('a healthy server with NO account shows setup, not a blank player', () => {
   // The whole point of requirement 1: stay on the config screen until someone has signed up.
-  assert.equal(screenState(frame({ needsSetup: true })), 'setup');
+  assert.equal(screenState(frame({ needsSetup: true }), true), 'setup');
 });
 
 test('an unanswered setup probe is not treated as "no setup needed"', () => {
   // null means we have not been told yet. Guessing "false" here would flip a fresh box to a player
   // that has nothing to show, and take the sign-up address off the screen while doing it.
-  assert.equal(screenState(frame({ needsSetup: null })), 'diagnostics');
-  assert.equal(screenState(frame({ needsSetup: undefined })), 'diagnostics');
+  assert.equal(screenState(frame({ needsSetup: null }), true), 'diagnostics');
+  assert.equal(screenState(frame({ needsSetup: undefined }), true), 'diagnostics');
 });
 
 test('nothing listening means diagnostics, whatever else is true', () => {
-  assert.equal(screenState(frame({ serving: false })), 'diagnostics');
-  assert.equal(screenState(frame({ serving: false, needsSetup: false })), 'diagnostics');
+  assert.equal(screenState(frame({ serving: false }), true), 'diagnostics');
+  assert.equal(screenState(frame({ serving: false, needsSetup: false }), true), 'diagnostics');
 });
 
 test('THE RECOVERY CASE: a server that fails takes the player off the screen', () => {
   // Requirement 2. A box that has been playing for weeks and then throws must show the operator
   // something other than black.
   const playing = frame();
-  assert.equal(screenState(playing), 'player');
+  assert.equal(screenState(playing, true), 'player');
 
   const broken = frame({ fatal: 'server failed to start TypeError: ...' });
-  assert.equal(screenState(broken), 'diagnostics', 'a fatal must reveal the diagnostics again');
+  assert.equal(screenState(broken, true), 'diagnostics', 'a fatal must reveal the diagnostics again');
 
   const gone = frame({ serving: false });
-  assert.equal(screenState(gone), 'diagnostics', 'so must the port going away');
+  assert.equal(screenState(gone, true), 'diagnostics', 'so must the port going away');
 });
 
 test('no status at all is diagnostics rather than a crash', () => {
   // The first paint happens before the first poll answers.
-  assert.equal(screenState(null), 'diagnostics');
-  assert.equal(screenState(undefined), 'diagnostics');
+  assert.equal(screenState(null, true), 'diagnostics');
+  assert.equal(screenState(undefined, true), 'diagnostics');
 });
 
 test('the page reloads the player when it comes back, rather than leaving an error page', () => {


### PR DESCRIPTION
Two changes: the server no longer runs unless a device is told to be one, and the status listener stops answering the customer's network.

### The server is off unless asked

A fleet gets one package, and **exactly one box per site should host the server**. Defaulting to on means every player that ever received this package starts listening on 8181, and the mistake stays invisible until two of them fight over the same displays.

```json
{ "server": 1 }
```

`st-config.json` on the storage root. Absent, unreadable, unparseable, or anything other than an affirmative value leaves it **off** — there is no reading of a broken config file that should end with a device deciding to host a server.

It sits at the root rather than in `data/` because that is where an operator drops it over the DWS, and `autozip` never writes it — so a re-provision cannot silently flip a site either way. The package ships `st-config.example.json`, **never** `st-config.json`, for the same reason, and the build asserts that.

### With the server off, nothing listens

`roNodeJs` is never created, so there is no `:8181` and no `:8182`.

The page is told through its URL (`?server=0`) rather than discovering it, because with no listener to poll, *"nothing is answering"* would render as a **fault** — sending someone looking for a broken server that was never meant to exist. The screen now has a fourth state that says the server is disabled and gives the one line of JSON that changes it.

### The status listener was on the LAN

Confirmed against the live device before fixing:

```
$ curl -o /dev/null -w "%{http_code}" http://192.168.1.46:8182/
200
```

That endpoint returns install progress, disk usage, the device's own address, and **a tail of the server's console** — which carries whatever the server printed most recently. Its only consumer is a page on the same device. It now binds `127.0.0.1`.

Verified from `/proc/net/tcp` rather than by probing:

```
kernel says :8182 is bound to 127.0.0.1   (loopback only)
```

Worth saying why: my first attempt probed the LAN address over HTTP and reported success. `os.networkInterfaces()` found no non-internal IPv4 in that environment, so the fallback silently probed loopback and labelled the result "LAN address". The kernel's own view has no such failure mode.

### Tests

```
brightsign-screen-state    9 pass 0 fail
```

Adds: *a player that was never asked to be a server says so, rather than reporting a fault* — including that the setting wins over any stale status.

### Scope

`brightsign/` plus the boot packager and one test. No shared server code; the payload is untouched, so only `autorun.zip` needs redeploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)