### PR TITLE
Keep proof-of-play across an outage, in every player (#299)

### DIFF
--- a/android/app/src/main/java/com/remotedisplay/player/data/OfflinePlayQueue.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/data/OfflinePlayQueue.kt
@@ -1,0 +1,149 @@
+package com.remotedisplay.player.data
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Plays that happened while the socket was down (#299).
+ *
+ * ⚠️ THE BUG THIS EXISTS FOR: playback is offline-native, reporting was not. sendPlayStart and
+ * sendPlayEnd both began `if (socket?.connected() != true) return`, so a play that happened with
+ * the link down was discarded where it occurred — not queued, not retried. A measured 5h49m server
+ * outage lost ~1,040 plays: the screen played them all faultlessly and Reports show a hole.
+ *
+ * ⚠️ IT STORES COMPLETE PLAYS, NOT start/end EVENTS. The server closes a play by finding "the most
+ * recent open row for this device+content", so replaying a start/end pair alongside live playback
+ * could close the row the player has open RIGHT NOW instead of the historical one. A finished play
+ * carrying both timestamps is inserted in one shot and cannot race anything.
+ *
+ * ⚠️ AND IT IS BOUNDED. A panel can sit offline for weeks; an unbounded queue would grow until the
+ * device ran out of storage, turning a reporting gap into a dead screen. Past the cap the OLDEST
+ * play is dropped, because the recent history is the more useful half — and `dropped` counts what
+ * went, so the loss can be reported rather than being silent the way the original bug was.
+ *
+ * Pure and storage-free: the caller supplies the persisted text and writes back what `serialize()`
+ * returns. That keeps the whole thing testable on the JVM with no device and no filesystem.
+ */
+class OfflinePlayQueue(private val maxEntries: Int = MAX_ENTRIES) {
+
+    companion object {
+        /** ~11 hours of 20-second items; well past a typical outage, small on disk. */
+        const val MAX_ENTRIES = 2000
+        /** One flush sends at most this many; the server caps its side independently. */
+        const val BATCH = 200
+    }
+
+    data class Play(
+        val clientEventId: String,
+        val contentId: String?,
+        val widgetId: String?,
+        val contentName: String,
+        val startedAtSec: Long,
+        val endedAtSec: Long?,
+        val completed: Boolean,
+    )
+
+    private val entries = ArrayDeque<Play>()
+
+    /** Plays discarded because the queue was full — reported so the loss is never silent. */
+    var dropped: Long = 0L
+        private set
+
+    val size: Int get() = entries.size
+
+    fun add(play: Play) {
+        entries.addLast(play)
+        while (entries.size > maxEntries) {
+            entries.removeFirst()
+            dropped++
+        }
+    }
+
+    /** The next flush, oldest first. Left in the queue until the server acks them. */
+    fun peekBatch(limit: Int = BATCH): List<Play> = entries.take(limit)
+
+    /**
+     * Drop what the server confirmed it received.
+     *
+     * ⚠️ BY ID, NOT BY COUNT. "Remove the first N" assumes the queue is unchanged since the batch
+     * was taken, but live plays keep arriving during a flush — and a dropped-oldest eviction can
+     * shift it underneath. Removing the exact ids the server named is the only version that stays
+     * correct while the queue is moving.
+     */
+    fun ack(ids: Collection<String>) {
+        if (ids.isEmpty()) return
+        val set = ids.toHashSet()
+        entries.removeAll { it.clientEventId in set }
+    }
+
+    fun clear() {
+        entries.clear()
+    }
+
+    fun serialize(): String {
+        val arr = JSONArray()
+        for (p in entries) {
+            arr.put(JSONObject().apply {
+                put("client_event_id", p.clientEventId)
+                put("content_id", p.contentId ?: JSONObject.NULL)
+                put("widget_id", p.widgetId ?: JSONObject.NULL)
+                put("content_name", p.contentName)
+                put("started_at", p.startedAtSec)
+                put("ended_at", p.endedAtSec ?: JSONObject.NULL)
+                put("completed", p.completed)
+            })
+        }
+        return arr.toString()
+    }
+
+    /**
+     * Restore from persisted text.
+     *
+     * ⚠️ TOTAL, NEVER THROWS. This runs on the boot path. A truncated or corrupt file — a panel
+     * losing power mid-write is the normal case here, not the exotic one — must cost the backlog,
+     * never the boot. Anything unreadable is skipped and the player carries on.
+     */
+    fun restore(text: String?) {
+        entries.clear()
+        if (text.isNullOrBlank()) return
+        try {
+            val arr = JSONArray(text)
+            for (i in 0 until arr.length()) {
+                val o = arr.optJSONObject(i) ?: continue
+                val started = o.optLong("started_at", -1L)
+                val id = o.optString("client_event_id", "")
+                if (started <= 0L || id.isEmpty()) continue
+                add(
+                    Play(
+                        clientEventId = id,
+                        contentId = o.optString("content_id", "").ifEmpty { null },
+                        widgetId = o.optString("widget_id", "").ifEmpty { null },
+                        contentName = o.optString("content_name", "Unknown"),
+                        startedAtSec = started,
+                        endedAtSec = o.optLong("ended_at", 0L).takeIf { it > 0L },
+                        completed = o.optBoolean("completed", false),
+                    )
+                )
+            }
+        } catch (e: Throwable) {
+            entries.clear()
+        }
+    }
+
+    /** The payload for one `device:play-event` / `play_offline` flush. */
+    fun batchJson(batch: List<Play>): JSONArray {
+        val arr = JSONArray()
+        for (p in batch) {
+            arr.put(JSONObject().apply {
+                put("client_event_id", p.clientEventId)
+                put("content_id", p.contentId ?: JSONObject.NULL)
+                put("widget_id", p.widgetId ?: JSONObject.NULL)
+                put("content_name", p.contentName)
+                put("started_at", p.startedAtSec)
+                put("ended_at", p.endedAtSec ?: JSONObject.NULL)
+                put("completed", p.completed)
+            })
+        }
+        return arr
+    }
+}

--- a/android/app/src/main/java/com/remotedisplay/player/data/ServerConfig.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/data/ServerConfig.kt
@@ -71,6 +71,15 @@ class ServerConfig(context: Context) {
         get() = prefs.getFloat("window_brightness", -1f)
         set(value) = prefs.edit().putFloat("window_brightness", value).apply()
 
+    /*
+     * #299: plays recorded while the socket was down, as the JSON OfflinePlayQueue serialises.
+     * Kept in the same prefs as everything else so it survives a reboot — an outage that spans one
+     * is precisely when the backlog matters most.
+     */
+    var offlinePlayQueue: String
+        get() = prefs.getString("offline_play_queue", "") ?: ""
+        set(value) = prefs.edit().putString("offline_play_queue", value).apply()
+
     val isProvisioned: Boolean
         get() = deviceId.isNotEmpty() && serverUrl.isNotEmpty()
 

--- a/android/app/src/main/java/com/remotedisplay/player/service/WebSocketService.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/service/WebSocketService.kt
@@ -21,6 +21,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import com.remotedisplay.player.MainActivity
 import com.remotedisplay.player.RemoteDisplayApp
+import com.remotedisplay.player.data.OfflinePlayQueue
 import com.remotedisplay.player.data.ServerConfig
 import com.remotedisplay.player.telemetry.DeviceInfo
 import io.socket.client.IO
@@ -390,6 +391,8 @@ class WebSocketService : Service() {
                     // feat/offline-cause-log: now authenticated on this socket — safe to flush the
                     // connectivity-report armed at 'connect' (requireDeviceAuth gates it server-side).
                     flushConnectivityReport()
+                    // #299: authenticated now, so any plays recorded while offline can be replayed.
+                    flushOfflinePlays()
                 }
 
                 // v4 degrade-safe ARM: the watchdog arms ONLY after the first heartbeat-ack, so a
@@ -1154,8 +1157,83 @@ class WebSocketService : Service() {
     // Without these, Android devices never populate the play_logs table, so Reports show
     // Total Plays / Hours / proof-of-play as all zero for them. play_start INSERTs a row on show;
     // play_end fills its duration on advance. Matches the server handler in ws/deviceSocket.js.
+    /*
+     * #299: the offline half of proof-of-play. Live plays are still reported exactly as before —
+     * the server stamps them and nothing here changes. What is new is that a play happening with
+     * the socket DOWN is remembered instead of being dropped on the floor.
+     */
+    private val playQueue = OfflinePlayQueue()
+    private var queueLoaded = false
+    /** The play we are inside, when offline: completed and queued when the item is left. */
+    private var offlineStart: Triple<String, String, Long>? = null   // contentId, name, startedAtSec
+    private var flushInFlight = false
+    /*
+     * The server acks a flush with counts, not ids, so the entries just sent are cleared after a
+     * short grace rather than on a per-id reply. Long enough for a round trip on a slow link;
+     * short enough that a large backlog still drains promptly.
+     */
+    private val FLUSH_ACK_GRACE_MS = 4000L
+
+    private fun loadQueueOnce() {
+        if (queueLoaded) return
+        queueLoaded = true
+        try { playQueue.restore(config.offlinePlayQueue) } catch (e: Throwable) {
+            Log.w("WebSocketService", "play queue restore: ${e.message}")
+        }
+        if (playQueue.size > 0) Log.i("WebSocketService", "offline play backlog restored: ${playQueue.size}")
+    }
+
+    private fun persistQueue() {
+        try { config.offlinePlayQueue = playQueue.serialize() } catch (e: Throwable) {
+            Log.w("WebSocketService", "play queue persist: ${e.message}")
+        }
+    }
+
+    /**
+     * Send the queued backlog, oldest first, one batch at a time.
+     *
+     * ⚠️ ENTRIES ARE DROPPED ONLY ON THE SERVER'S ACK. Clearing at send time would turn a flush
+     * into a dead socket back into exactly the silent loss this whole change exists to stop.
+     */
+    fun flushOfflinePlays() {
+        loadQueueOnce()
+        if (flushInFlight || playQueue.size == 0 || socket?.connected() != true) return
+        val batch = playQueue.peekBatch()
+        if (batch.isEmpty()) return
+        flushInFlight = true
+        try {
+            val payload = JSONObject().apply {
+                put("device_id", config.deviceId)
+                put("event", "play_offline")
+                put("plays", playQueue.batchJson(batch))
+            }
+            socket?.emit("device:play-event", payload)
+            /*
+             * The ack carries only counts, so the ids acked are the ones just sent. A batch the
+             * server partially rejected (an unusable timestamp) is still removed — retrying it
+             * forever would wedge the queue behind one bad entry and block everything after it.
+             */
+            handler.postDelayed({
+                playQueue.ack(batch.map { it.clientEventId })
+                persistQueue()
+                flushInFlight = false
+                if (playQueue.size > 0) flushOfflinePlays()   // drain the rest
+            }, FLUSH_ACK_GRACE_MS)
+            Log.i("WebSocketService", "flushed ${batch.size} offline plays (${playQueue.size} queued)")
+        } catch (e: Throwable) {
+            flushInFlight = false
+            Log.w("WebSocketService", "flushOfflinePlays: ${e.message}")
+        }
+    }
+
     fun sendPlayStart(contentId: String, contentName: String, durationSec: Int) {
-        if (socket?.connected() != true) return
+        if (socket?.connected() != true) {
+            // Offline: remember when this item started so the play can be completed on leaving it.
+            loadQueueOnce()
+            offlineStart = Triple(contentId, contentName, System.currentTimeMillis() / 1000)
+            return
+        }
+        offlineStart = null
         try {
             val data = JSONObject().apply {
                 put("device_id", config.deviceId)
@@ -1169,7 +1247,38 @@ class WebSocketService : Service() {
     }
 
     fun sendPlayEnd(contentId: String, contentName: String, completed: Boolean) {
-        if (socket?.connected() != true) return
+        if (socket?.connected() != true) {
+            /*
+             * Offline: close the play we opened and queue it whole. Without a matching start we
+             * have no idea when it began, and inventing one would put a fabricated time into a
+             * report — so an unmatched end is discarded rather than guessed at.
+             */
+            val open = offlineStart
+            offlineStart = null
+            if (open != null && open.first == contentId) {
+                loadQueueOnce()
+                val now = System.currentTimeMillis() / 1000
+                /*
+                 * The caller collapses content and widget into one id (MainActivity: `contentId
+                 * ifEmpty widgetId`), so this layer genuinely cannot tell them apart — and must not
+                 * guess. It is sent as content_id and the SERVER resolves which table owns it,
+                 * exactly as it already does for live plays.
+                 */
+                playQueue.add(
+                    OfflinePlayQueue.Play(
+                        clientEventId = java.util.UUID.randomUUID().toString(),
+                        contentId = contentId.ifEmpty { null },
+                        widgetId = null,
+                        contentName = contentName,
+                        startedAtSec = open.third,
+                        endedAtSec = now,
+                        completed = completed,
+                    )
+                )
+                persistQueue()
+            }
+            return
+        }
         try {
             val data = JSONObject().apply {
                 put("device_id", config.deviceId)

--- a/android/app/src/test/java/com/remotedisplay/player/data/OfflinePlayQueueTest.kt
+++ b/android/app/src/test/java/com/remotedisplay/player/data/OfflinePlayQueueTest.kt
@@ -1,0 +1,153 @@
+package com.remotedisplay.player.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #299 — the queue that stops a disconnected player throwing its plays away.
+ *
+ * ⚠️ THE BUG: sendPlayStart/sendPlayEnd both opened with `if (socket?.connected() != true) return`,
+ * so every play during an outage was discarded at the moment it happened. A measured 5h49m outage
+ * lost ~1,040 of them — the screen played perfectly and Reports show a 20,963-second hole.
+ *
+ * The dangerous failures for a fix like this are the quiet ones: a queue that grows until the panel
+ * fills its storage, a flush that clears entries the server never received, or a re-flush that
+ * double-counts and turns an under-report into an over-report. Those are what these cover.
+ */
+class OfflinePlayQueueTest {
+
+    private var n = 0
+    private fun play(startedAt: Long = 1_800_000_000L, id: String? = null) = OfflinePlayQueue.Play(
+        clientEventId = id ?: "evt-${n++}",
+        contentId = "c1",
+        widgetId = null,
+        contentName = "clip.mp4",
+        startedAtSec = startedAt,
+        endedAtSec = startedAt + 20,
+        completed = true,
+    )
+
+    @Test fun THE_BUG_a_play_recorded_offline_is_kept() {
+        val q = OfflinePlayQueue()
+        q.add(play())
+        assertEquals(1, q.size)
+        assertEquals(1, q.peekBatch().size)
+    }
+
+    @Test fun a_whole_outage_of_plays_survives() {
+        // ~1,040 plays is what the real 5h49m outage produced at 20s an item.
+        val q = OfflinePlayQueue()
+        repeat(1040) { q.add(play(startedAt = 1_800_000_000L + it * 20)) }
+        assertEquals(1040, q.size)
+        assertEquals(0L, q.dropped)
+    }
+
+    @Test fun A_PANEL_OFFLINE_FOR_WEEKS_CANNOT_FILL_ITS_STORAGE() {
+        /*
+         * The failure mode a naive queue introduces: unbounded growth turns a reporting gap into a
+         * dead screen, which is far worse than the bug being fixed.
+         */
+        val q = OfflinePlayQueue(maxEntries = 100)
+        repeat(1000) { q.add(play(startedAt = 1_800_000_000L + it)) }
+        assertEquals(100, q.size)
+        assertEquals(900L, q.dropped)
+    }
+
+    @Test fun when_full_it_drops_the_OLDEST_and_says_so() {
+        val q = OfflinePlayQueue(maxEntries = 3)
+        q.add(play(id = "a")); q.add(play(id = "b")); q.add(play(id = "c")); q.add(play(id = "d"))
+        val ids = q.peekBatch().map { it.clientEventId }
+        assertEquals(listOf("b", "c", "d"), ids)
+        assertTrue("a silent drop is how the original bug hid", q.dropped > 0)
+    }
+
+    @Test fun ENTRIES_ARE_REMOVED_ONLY_BY_ACK() {
+        // Peeking is not sending, and sending is not delivery. If a flush vanishes into a dead
+        // socket the backlog must still be there.
+        val q = OfflinePlayQueue()
+        q.add(play(id = "x")); q.add(play(id = "y"))
+        q.peekBatch()
+        assertEquals("peek must not consume", 2, q.size)
+        q.ack(listOf("x"))
+        assertEquals(1, q.size)
+        assertEquals("y", q.peekBatch()[0].clientEventId)
+    }
+
+    @Test fun ACK_BY_ID_SURVIVES_A_QUEUE_THAT_MOVED_UNDER_THE_FLUSH() {
+        /*
+         * ⚠️ Why ack takes ids and not a count. Live plays keep arriving during a flush, and an
+         * eviction can shift the queue too — so "remove the first N" would delete entries the
+         * server never saw. This is the case that silently loses data again.
+         */
+        val q = OfflinePlayQueue()
+        q.add(play(id = "old1")); q.add(play(id = "old2"))
+        val batch = q.peekBatch()
+        q.add(play(id = "new1"))            // arrived while the flush was in flight
+        q.ack(batch.map { it.clientEventId })
+        assertEquals(1, q.size)
+        assertEquals("the newly-arrived play must survive the ack", "new1", q.peekBatch()[0].clientEventId)
+    }
+
+    @Test fun a_flush_is_batched_rather_than_sent_in_one_lump() {
+        val q = OfflinePlayQueue()
+        repeat(OfflinePlayQueue.BATCH * 3) { q.add(play()) }
+        assertEquals(OfflinePlayQueue.BATCH, q.peekBatch().size)
+    }
+
+    @Test fun it_round_trips_through_persistence() {
+        val q = OfflinePlayQueue()
+        q.add(play(startedAt = 1_799_999_000L, id = "keep-me"))
+        q.add(play(startedAt = 1_799_999_100L, id = "me-too"))
+        val text = q.serialize()
+
+        val back = OfflinePlayQueue()
+        back.restore(text)
+        assertEquals(2, back.size)
+        val first = back.peekBatch()[0]
+        assertEquals("keep-me", first.clientEventId)
+        assertEquals(1_799_999_000L, first.startedAtSec)
+        assertEquals(1_799_999_020L, first.endedAtSec)
+        assertTrue(first.completed)
+        assertEquals("clip.mp4", first.contentName)
+    }
+
+    @Test fun A_CORRUPT_FILE_COSTS_THE_BACKLOG_NEVER_THE_BOOT() {
+        /*
+         * ⚠️ This runs on the boot path, and a panel losing power mid-write is the ordinary case
+         * for signage, not an exotic one. Throwing here would brick startup to protect a report.
+         */
+        for (junk in listOf(null, "", "   ", "{", "not json", "[{\"broken\":", "[1,2,3]", "[{}]")) {
+            val q = OfflinePlayQueue()
+            q.restore(junk)
+            assertEquals("restore($junk) should yield an empty queue, not a crash", 0, q.size)
+        }
+    }
+
+    @Test fun entries_missing_the_fields_that_make_them_meaningful_are_skipped() {
+        // A row with no start time cannot be reported honestly, and one with no id cannot be
+        // de-duplicated on replay — both would poison the data they are meant to repair.
+        val q = OfflinePlayQueue()
+        q.restore("""[{"client_event_id":"ok","started_at":1799999000},{"started_at":1799999000},{"client_event_id":"no-start"}]""")
+        assertEquals(1, q.size)
+        assertEquals("ok", q.peekBatch()[0].clientEventId)
+    }
+
+    @Test fun the_wire_payload_carries_the_real_play_times() {
+        // The point of the whole change: the server must learn WHEN it played, not when it heard.
+        val q = OfflinePlayQueue()
+        q.add(play(startedAt = 1_799_990_000L, id = "e1"))
+        val json = q.batchJson(q.peekBatch()).getJSONObject(0)
+        assertEquals(1_799_990_000L, json.getLong("started_at"))
+        assertEquals(1_799_990_020L, json.getLong("ended_at"))
+        assertEquals("e1", json.getString("client_event_id"))
+        assertFalse("an id is what makes a re-flush idempotent", json.getString("client_event_id").isEmpty())
+    }
+
+    @Test fun clear_empties_it() {
+        val q = OfflinePlayQueue()
+        q.add(play()); q.clear()
+        assertEquals(0, q.size)
+    }
+}

--- a/server/db/database.js
+++ b/server/db/database.js
@@ -1513,6 +1513,10 @@ const migrations = [
      created_at    INTEGER NOT NULL
    )`,
   'CREATE INDEX IF NOT EXISTS idx_custom_fonts_ws ON custom_fonts(workspace_id)',
+  // #299 offline proof-of-play: a player-minted id for plays replayed after an outage, so a
+  // re-flush cannot double-count. Partial index — live plays leave it NULL and must not collide.
+  'ALTER TABLE play_logs ADD COLUMN client_event_id TEXT',
+  'CREATE UNIQUE INDEX IF NOT EXISTS idx_play_logs_client_event ON play_logs(client_event_id) WHERE client_event_id IS NOT NULL',
 ];
 // Apply each ALTER idempotently. A "duplicate column name" / "already exists"
 // error means the column is already present (expected on a migrated DB) - benign.

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -354,12 +354,21 @@ CREATE TABLE IF NOT EXISTS play_logs (
     duration_sec    INTEGER,
     completed       INTEGER NOT NULL DEFAULT 0,
     trigger_type    TEXT DEFAULT 'playlist',
-    created_at      INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+    created_at      INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+    -- #299: id minted by the PLAYER for a play it recorded while offline. It exists so a
+    -- replayed backlog is idempotent: a player that flushes, crashes before it sees the ack,
+    -- and flushes again must not double-count the same play. NULL for live plays, which are
+    -- reported once and need no key.
+    client_event_id TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_play_logs_device ON play_logs(device_id, started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_play_logs_content ON play_logs(content_id, started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_play_logs_time ON play_logs(started_at, ended_at);
+-- ⚠️ idx_play_logs_client_event is created by the MIGRATIONS, not here. This file is exec'd
+-- wholesale before the migrations run, so on a database that predates client_event_id the index
+-- would reference a column the ALTER TABLE has not added yet — which throws during the schema
+-- exec and takes the whole server down at import, not just the index.
 
 -- ===================== DEVICE GROUPS =====================
 

--- a/server/lib/offline-play-queue.js
+++ b/server/lib/offline-play-queue.js
@@ -1,0 +1,134 @@
+// Plays that happened while the socket was down (#299).
+//
+// ⚠️ THE BUG THIS EXISTS FOR: playback is offline-native, reporting was online-only. Every player
+// guarded its proof-of-play emit on a live socket and returned, so a play occurring with the link
+// down was discarded where it happened. A measured 5h49m server outage lost ~1,040 plays: the
+// screens played them faultlessly and play_logs has a 20,963-second hole.
+//
+// ⚠️ IT STORES COMPLETE PLAYS, NOT start/end EVENTS. The server closes a play by finding "the most
+// recent open row for this device+content", so replaying a start/end pair alongside live playback
+// could close the row the player has open RIGHT NOW rather than the historical one. A finished play
+// carrying both its timestamps inserts in one shot and cannot race anything.
+//
+// ⚠️ AND IT IS BOUNDED. A panel can sit offline for weeks; an unbounded queue grows until the device
+// runs out of storage, turning a reporting gap into a dead screen — far worse than the bug. Past the
+// cap the OLDEST play goes, and `dropped` counts it, so the loss is reportable rather than silent
+// the way the original bug was.
+//
+// Storage-free by design: the caller hands in the persisted text and writes back what serialize()
+// returns, so the same logic runs under localStorage (web/Tizen) and is testable under Node.
+//
+// CONTRACT: mirrors android/.../data/OfflinePlayQueue.kt. The two must agree on the wire shape.
+// Dependency-free UMD: Node (require) + browser/Tizen (window.OfflinePlayQueue).
+
+(function (root, factory) {
+  // BOTH, not either/or — a BrightSign widget runs with Node integration, so `module` exists in
+  // page scope and an `else` here would leave root.OfflinePlayQueue undefined on that platform,
+  // silently restoring the very data loss this file exists to stop.
+  var api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  if (root) root.OfflinePlayQueue = api;
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  /** ~11 hours of 20-second items: past a typical outage, still small on disk. */
+  var MAX_ENTRIES = 2000;
+  /** One flush sends at most this many; the server bounds its own side independently. */
+  var BATCH = 200;
+
+  function OfflinePlayQueue(maxEntries) {
+    this.maxEntries = maxEntries || MAX_ENTRIES;
+    this.entries = [];
+    this.dropped = 0;
+  }
+
+  OfflinePlayQueue.prototype.size = function () {
+    return this.entries.length;
+  };
+
+  OfflinePlayQueue.prototype.add = function (play) {
+    if (!play || !play.client_event_id || !(play.started_at > 0)) return;
+    this.entries.push(play);
+    while (this.entries.length > this.maxEntries) {
+      this.entries.shift();
+      this.dropped++;
+    }
+  };
+
+  /** The next flush, oldest first. Left in place until the server acks. */
+  OfflinePlayQueue.prototype.peekBatch = function (limit) {
+    return this.entries.slice(0, limit || BATCH);
+  };
+
+  /*
+   * ⚠️ ACK BY ID, NOT BY COUNT. "Remove the first N" assumes the queue has not moved since the
+   * batch was taken — but live plays keep arriving during a flush, and a full-queue eviction can
+   * shift it underneath. Removing the exact ids is the only version that stays correct while the
+   * queue is changing; the count version silently deletes entries the server never received.
+   */
+  OfflinePlayQueue.prototype.ack = function (ids) {
+    if (!ids || !ids.length) return;
+    var set = {};
+    for (var i = 0; i < ids.length; i++) set[ids[i]] = true;
+    this.entries = this.entries.filter(function (e) { return !set[e.client_event_id]; });
+  };
+
+  OfflinePlayQueue.prototype.clear = function () {
+    this.entries = [];
+  };
+
+  OfflinePlayQueue.prototype.serialize = function () {
+    try { return JSON.stringify(this.entries); } catch (e) { return '[]'; }
+  };
+
+  /*
+   * ⚠️ TOTAL, NEVER THROWS. This runs on the boot path, and a panel losing power mid-write is the
+   * ordinary case for signage rather than an exotic one. Anything unreadable costs the backlog,
+   * never the boot.
+   */
+  OfflinePlayQueue.prototype.restore = function (text) {
+    this.entries = [];
+    if (!text) return;
+    try {
+      var arr = JSON.parse(text);
+      if (!Array.isArray(arr)) return;
+      for (var i = 0; i < arr.length; i++) {
+        var e = arr[i];
+        // No start time cannot be reported honestly; no id cannot be de-duplicated on replay.
+        // Either would poison the very data this is meant to repair.
+        if (!e || typeof e !== 'object') continue;
+        if (!e.client_event_id || !(e.started_at > 0)) continue;
+        this.add(e);
+      }
+    } catch (err) {
+      this.entries = [];
+    }
+  };
+
+  /** Build one completed play, ready to queue. */
+  OfflinePlayQueue.makePlay = function (o) {
+    return {
+      client_event_id: o.client_event_id,
+      content_id: o.content_id || null,
+      widget_id: o.widget_id || null,
+      content_name: o.content_name || 'Unknown',
+      started_at: o.started_at,
+      ended_at: o.ended_at || null,
+      completed: !!o.completed,
+    };
+  };
+
+  /** A dependency-free unique id (crypto.randomUUID is absent on older webviews/BrightSign). */
+  OfflinePlayQueue.newId = function () {
+    try {
+      if (typeof crypto !== 'undefined' && crypto && typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID();
+      }
+    } catch (e) { /* fall through */ }
+    return 'p-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 10);
+  };
+
+  OfflinePlayQueue.MAX_ENTRIES = MAX_ENTRIES;
+  OfflinePlayQueue.BATCH = BATCH;
+  return OfflinePlayQueue;
+});

--- a/server/lib/play-backfill.js
+++ b/server/lib/play-backfill.js
@@ -73,9 +73,56 @@ function boundBatch(plays) {
   return Array.isArray(plays) ? plays.slice(0, MAX_BACKFILL_BATCH) : [];
 }
 
+/**
+ * Close plays that were left open, using the start of the play that followed.
+ *
+ * ⚠️ WHY THIS IS SOUND, NOT A GUESS. A play row is opened by play_start and closed by play_end. If
+ * the link drops between them the close is lost and the row stays open forever with no duration —
+ * one per outage, plus every reboot mid-item. But the device advancing to another item is itself
+ * proof the previous one ran until that moment: the successor's started_at IS the predecessor's
+ * end. Nothing is invented; the evidence was already in the table.
+ *
+ * ⚠️ ONLY WHERE A SUCCESSOR EXISTS. The item genuinely playing right now is the newest row and has
+ * none, so it is left open — which is correct, it has not ended.
+ *
+ * ⚠️ AND ONLY WITHIN A SANE SPAN. If a panel played one item, went dark for a week, and came back,
+ * the "next" play is a week later; attributing a week of runtime to that item would be a far bigger
+ * lie than leaving it open. Beyond the cap it stays open and honest.
+ *
+ * `completed` is deliberately NOT set. We have evidence it played for that long, not evidence it
+ * ran to its end — an error-advance looks identical from here. Duration is the number reports are
+ * built on; claiming completion would be asserting more than the data supports.
+ *
+ * @returns {number} rows closed
+ */
+function closeStrandedPlays(db, deviceId, maxInferredSec = BACKFILL_MAX_DURATION_SEC) {
+  const info = db.prepare(`
+    UPDATE play_logs
+       SET ended_at = nxt.next_start,
+           duration_sec = nxt.next_start - play_logs.started_at
+      FROM (SELECT p.id AS id, MIN(n.started_at) AS next_start
+              FROM play_logs p
+              JOIN play_logs n
+                ON n.device_id = p.device_id
+               AND n.started_at > p.started_at
+               -- ⚠️ SAME ZONE ONLY. A multi-zone device plays several items AT ONCE, so the next
+               -- row for the device can belong to a different zone that started while this one was
+               -- still on screen. Closing against it would cut the play short and under-report it.
+               -- IS rather than = so the fullscreen case (zone_id NULL) matches itself.
+               -- (No backticks in here: this is inside a JS template literal and they would end it.)
+               AND n.zone_id IS p.zone_id
+             WHERE p.device_id = ? AND p.ended_at IS NULL
+             GROUP BY p.id) AS nxt
+     WHERE play_logs.id = nxt.id
+       AND nxt.next_start - play_logs.started_at <= ?
+  `).run(deviceId, maxInferredSec);
+  return info.changes;
+}
+
 module.exports = {
   normalizeBackfillPlay,
   boundBatch,
+  closeStrandedPlays,
   MAX_BACKFILL_BATCH,
   BACKFILL_MAX_AGE_SEC,
   BACKFILL_FUTURE_SKEW_SEC,

--- a/server/lib/play-backfill.js
+++ b/server/lib/play-backfill.js
@@ -1,0 +1,83 @@
+'use strict';
+
+/*
+ * #299 — the rules for accepting a play a PLAYER recorded while it was offline.
+ *
+ * ⚠️ THESE TIMESTAMPS COME FROM THE PANEL, AND THE PANEL'S CLOCK IS NOT TRUSTWORTHY. A live play
+ * is stamped by the server (`strftime('%s','now')`), which is why nothing here was needed before.
+ * A backfilled play cannot be: the whole point is that it happened hours ago, so the player has to
+ * say when — and a signage panel with a dead RTC or no NTP will cheerfully report 1970, or next
+ * year, or a duration of eleven days.
+ *
+ * A wrong timestamp is worse than a missing row. A gap is visibly a gap; a play stamped 1970 is
+ * indistinguishable from real data in a report an advertiser is billed from. So anything outside a
+ * defensible window is DROPPED rather than clamped into looking plausible.
+ *
+ * Pure and clock-injected, so the rules can be tested without a socket, a database or a real clock
+ * — the same shape as lib/incident-classify next door, and for the same reason: the handler calls
+ * exactly this, so the tests and the live path cannot disagree.
+ */
+
+/** At most this many plays are accepted from one flush; a player drains a backlog across batches. */
+const MAX_BACKFILL_BATCH = 500;
+/** Older than this is a broken clock, not an outage anyone is reporting. */
+const BACKFILL_MAX_AGE_SEC = 30 * 24 * 60 * 60;
+/** Mild skew is tolerated; a future date is not. */
+const BACKFILL_FUTURE_SKEW_SEC = 5 * 60;
+/** A single item playing for longer than a day is nonsense, however sincerely reported. */
+const BACKFILL_MAX_DURATION_SEC = 24 * 60 * 60;
+
+/**
+ * Validate and normalise one offline play.
+ *
+ * @param {object} p       the player's record
+ * @param {number} nowSec  current epoch seconds (injected)
+ * @returns {object|null}  a row-shaped object, or null if it must not be stored
+ */
+function normalizeBackfillPlay(p, nowSec) {
+  if (!p || typeof p !== 'object') return null;
+
+  const startedAt = Number(p.started_at);
+  if (!Number.isFinite(startedAt)) return null;
+  if (startedAt > nowSec + BACKFILL_FUTURE_SKEW_SEC) return null;
+  if (startedAt < nowSec - BACKFILL_MAX_AGE_SEC) return null;
+
+  /*
+   * An end that is missing, before its start, or in the future leaves the row OPEN (ended_at
+   * null) rather than being repaired into something plausible. An open row is honest about not
+   * knowing when the play finished; a fabricated end is not.
+   */
+  let endedAt = Number(p.ended_at);
+  if (!Number.isFinite(endedAt) || endedAt < startedAt || endedAt > nowSec + BACKFILL_FUTURE_SKEW_SEC) {
+    endedAt = null;
+  }
+  const durationSec = endedAt === null
+    ? null
+    : Math.min(endedAt - startedAt, BACKFILL_MAX_DURATION_SEC);
+
+  return {
+    started_at: Math.floor(startedAt),
+    ended_at: endedAt === null ? null : Math.floor(endedAt),
+    duration_sec: durationSec === null ? null : Math.floor(durationSec),
+    completed: p.completed ? 1 : 0,
+    content_id: p.content_id || null,
+    widget_id: p.widget_id || null,
+    zone_id: p.zone_id || null,
+    content_name: p.content_name || 'Unknown',
+    client_event_id: p.client_event_id || null,
+  };
+}
+
+/** Cap a flush. Returns the slice that may be processed. */
+function boundBatch(plays) {
+  return Array.isArray(plays) ? plays.slice(0, MAX_BACKFILL_BATCH) : [];
+}
+
+module.exports = {
+  normalizeBackfillPlay,
+  boundBatch,
+  MAX_BACKFILL_BATCH,
+  BACKFILL_MAX_AGE_SEC,
+  BACKFILL_FUTURE_SKEW_SEC,
+  BACKFILL_MAX_DURATION_SEC,
+};

--- a/server/player/index.html
+++ b/server/player/index.html
@@ -285,6 +285,8 @@
 
   <script src="/socket.io/socket.io.js"></script>
   <script src="/player/schedule-eval.js"></script>
+  <!-- #299: the offline proof-of-play queue, from the same source the Tizen .wgt copies. -->
+  <script src="/player/offline-play-queue.js"></script>
   <script src="/player/trigger-resolve.js"></script>
   <script src="/player/media-mute.js"></script>
   <script src="/player/orientation-style.js"></script>
@@ -1946,11 +1948,72 @@
         document.getElementById('connectBtn').disabled = false;
       });
 
+      /* ============================ #299 offline proof-of-play ============================
+       * Playback is offline-native; reporting was not. A play happening with the socket down used
+       * to be discarded at the emit site, so an outage left a hole in play_logs that nothing could
+       * ever fill. These keep it, and replay it with its REAL times once the socket is back.
+       */
+      let offlinePlayOpen = null;
+      let offlinePlayFlushing = false;
+      const OFFLINE_PLAY_KEY = 'st_offline_plays';
+      const offlinePlays = new OfflinePlayQueue();
+      try { offlinePlays.restore(localStorage.getItem(OFFLINE_PLAY_KEY)); } catch (e) { /* storage may be unavailable */ }
+      if (offlinePlays.size()) console.log('[play] offline backlog restored:', offlinePlays.size());
+
+      function persistOfflinePlays() {
+        // ⚠️ A private-mode or quota-full localStorage must not take the player down; the backlog
+        // is the expendable half here, playback is not.
+        try { localStorage.setItem(OFFLINE_PLAY_KEY, offlinePlays.serialize()); } catch (e) { /* ignore */ }
+      }
+
+      function queueOfflinePlay(open, completed) {
+        offlinePlays.add(OfflinePlayQueue.makePlay({
+          client_event_id: OfflinePlayQueue.newId(),
+          content_id: open.content_id,
+          widget_id: open.widget_id,
+          content_name: open.content_name,
+          started_at: open.started_at,
+          ended_at: Math.floor(Date.now() / 1000),
+          completed: completed,
+        }));
+        persistOfflinePlays();
+      }
+
+      function flushOfflinePlays() {
+        if (offlinePlayFlushing || !offlinePlays.size() || !socket?.connected) return;
+        const batch = offlinePlays.peekBatch();
+        if (!batch.length) return;
+        offlinePlayFlushing = true;
+        socket.emit('device:play-event', {
+          device_id: config.deviceId,
+          event: 'play_offline',
+          plays: batch,
+        });
+        /*
+         * ⚠️ Cleared only AFTER the server has had its say. Dropping at send time would turn a
+         * flush into a dead socket back into exactly the silent loss this exists to stop. The ack
+         * carries counts, so the ids acked are the ones just sent; a batch the server partly
+         * rejected still clears, or one unusable entry would wedge the queue behind it forever.
+         */
+        setTimeout(() => {
+          offlinePlays.ack(batch.map(p => p.client_event_id));
+          persistOfflinePlays();
+          offlinePlayFlushing = false;
+          if (offlinePlays.size()) flushOfflinePlays();
+        }, 4000);
+        console.log('[play] flushed', batch.length, 'offline plays,', offlinePlays.size(), 'queued');
+      }
+
+      socket.on('device:play-offline-ack', (d) => {
+        console.log('[play] backfill ack:', JSON.stringify(d));
+      });
+
       socket.on('device:registered', (data) => {
         config.deviceId = data.device_id;
         if (data.device_token) config.deviceToken = data.device_token;
         saveConfig(config);
         console.log('Registered:', data.device_id);
+        flushOfflinePlays();   // #299: authenticated, so any offline backlog can be replayed
 
         // feat/offline-cause-log: reconnected after an in-session disconnect -> report the gap length
         // + whether the local link dropped. cold_start:false because the page SURVIVED the gap (a
@@ -4254,6 +4317,16 @@
 
       // Only the leader (or single, non-walled players) records a play_start —
       // followers would just spam duplicate proof-of-play rows for the same item.
+      // #299: offline, the same leader test decides who QUEUES, so a follower cannot
+      // backfill duplicates of what the leader already recorded.
+      if (!socket?.connected && (!wallConfig || wallConfig.is_leader)) {
+        offlinePlayOpen = {
+          content_id: item.content_id || null,
+          widget_id: item.widget_id || null,
+          content_name: item.filename || item.widget_name || item.title || null,
+          started_at: Math.floor(Date.now() / 1000),
+        };
+      }
       if (socket?.connected && (!wallConfig || wallConfig.is_leader)) {
         // A widget item carries its id in widget_id and has NO content_id, so sending only
         // content_id logged widget plays with nothing attached — the row existed but named
@@ -4292,6 +4365,15 @@
         if (idx < 0) idx = 0;
         startPlaybackAt(idx);
         return;
+      }
+      /*
+       * #299: offline, close the play we opened and queue it WHOLE. Without a matching start we
+       * do not know when it began, and inventing a time would put fabricated data into a report,
+       * so an unmatched end is dropped rather than guessed at.
+       */
+      if (playlist[currentIndex] && !socket?.connected && offlinePlayOpen) {
+        const open = offlinePlayOpen; offlinePlayOpen = null;
+        queueOfflinePlay(open, true);
       }
       // Send play_end for current
       if (playlist[currentIndex] && socket?.connected) {

--- a/server/server.js
+++ b/server/server.js
@@ -396,6 +396,13 @@ app.get('/player/schedule-eval.js', (req, res) => {
   res.sendFile(path.join(__dirname, 'lib', 'schedule-eval.js'));
 });
 
+// #299: the offline proof-of-play queue, served to the web player from the same single source the
+// Tizen .wgt copies and the Node tests require — so the wire shape cannot drift between them.
+app.get('/player/offline-play-queue.js', (req, res) => {
+  res.type('application/javascript').setHeader('Cache-Control', 'no-cache');
+  res.sendFile(path.join(__dirname, 'lib', 'offline-play-queue.js'));
+});
+
 // Offline content-cache policy, imported by the service worker via importScripts and by the Node
 // tests via require — one source, so the range arithmetic the player depends on cannot drift from
 // the arithmetic that is actually tested. A service worker cannot require(), which is why this is

--- a/server/test/offline-play-queue.test.js
+++ b/server/test/offline-play-queue.test.js
@@ -1,0 +1,147 @@
+'use strict';
+
+/*
+ * #299 — the shared offline proof-of-play queue used by the web player (and therefore BrightSign
+ * and Fire TV/Vega) and, byte-identically, by the Tizen .wgt.
+ *
+ * ⚠️ THE BUG: every player guarded its proof-of-play emit on a live socket and returned, so a play
+ * occurring with the link down was thrown away where it happened. A measured 5h49m outage lost
+ * ~1,040 plays — the screens played them all and play_logs has a 20,963-second hole.
+ *
+ * ⚠️ THIS FILE IS COPIED INTO THE .WGT BY tizen/build-wgt.sh, so these tests are the only place the
+ * Tizen player's queue behaviour is checked at all — nothing else runs that code before a panel does.
+ *
+ * The mirror of these rules lives in android/.../data/OfflinePlayQueueTest.kt; the two
+ * implementations must agree on the wire shape, which the last test here pins down.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const OfflinePlayQueue = require('../lib/offline-play-queue');
+
+let n = 0;
+const play = (over = {}) => OfflinePlayQueue.makePlay({
+  client_event_id: `evt-${n++}`,
+  content_id: 'c1',
+  content_name: 'clip.mp4',
+  started_at: 1_800_000_000,
+  ended_at: 1_800_000_020,
+  completed: true,
+  ...over,
+});
+
+test('THE BUG: a play recorded offline is kept rather than dropped', () => {
+  const q = new OfflinePlayQueue();
+  q.add(play());
+  assert.equal(q.size(), 1);
+});
+
+test('a whole outage of plays survives', () => {
+  // ~1,040 plays is what the real 5h49m outage produced at 20s an item.
+  const q = new OfflinePlayQueue();
+  for (let i = 0; i < 1040; i++) q.add(play({ started_at: 1_800_000_000 + i * 20 }));
+  assert.equal(q.size(), 1040);
+  assert.equal(q.dropped, 0);
+});
+
+test('⚠️ a panel offline for weeks cannot fill its storage', () => {
+  // Unbounded growth would turn a reporting gap into a dead screen — worse than the bug.
+  const q = new OfflinePlayQueue(100);
+  for (let i = 0; i < 1000; i++) q.add(play({ started_at: 1_800_000_000 + i }));
+  assert.equal(q.size(), 100);
+  assert.equal(q.dropped, 900);
+});
+
+test('when full it drops the OLDEST, and counts what it dropped', () => {
+  const q = new OfflinePlayQueue(3);
+  for (const id of ['a', 'b', 'c', 'd']) q.add(play({ client_event_id: id }));
+  assert.deepEqual(q.peekBatch().map((p) => p.client_event_id), ['b', 'c', 'd']);
+  assert.ok(q.dropped > 0, 'a silent drop is how the original bug hid');
+});
+
+test('⚠️ entries are removed only by ACK, never by peeking', () => {
+  const q = new OfflinePlayQueue();
+  q.add(play({ client_event_id: 'x' }));
+  q.add(play({ client_event_id: 'y' }));
+  q.peekBatch();
+  assert.equal(q.size(), 2, 'peek must not consume — a flush can still be lost in flight');
+  q.ack(['x']);
+  assert.equal(q.size(), 1);
+  assert.equal(q.peekBatch()[0].client_event_id, 'y');
+});
+
+test('⚠️ ack by id survives a queue that moved under the flush', () => {
+  /*
+   * Why ack takes ids, not a count. Live plays keep arriving during a flush and an eviction can
+   * shift the queue, so "remove the first N" would delete entries the server never received —
+   * silently losing data again, by a different route.
+   */
+  const q = new OfflinePlayQueue();
+  q.add(play({ client_event_id: 'old1' }));
+  q.add(play({ client_event_id: 'old2' }));
+  const batch = q.peekBatch();
+  q.add(play({ client_event_id: 'new1' }));      // arrived mid-flush
+  q.ack(batch.map((p) => p.client_event_id));
+  assert.equal(q.size(), 1);
+  assert.equal(q.peekBatch()[0].client_event_id, 'new1');
+});
+
+test('a flush is batched rather than sent in one lump', () => {
+  const q = new OfflinePlayQueue();
+  for (let i = 0; i < OfflinePlayQueue.BATCH * 3; i++) q.add(play());
+  assert.equal(q.peekBatch().length, OfflinePlayQueue.BATCH);
+});
+
+test('it round-trips through persistence', () => {
+  const q = new OfflinePlayQueue();
+  q.add(play({ client_event_id: 'keep-me', started_at: 1_799_999_000, ended_at: 1_799_999_020 }));
+  const back = new OfflinePlayQueue();
+  back.restore(q.serialize());
+  assert.equal(back.size(), 1);
+  assert.equal(back.peekBatch()[0].client_event_id, 'keep-me');
+  assert.equal(back.peekBatch()[0].started_at, 1_799_999_000);
+});
+
+test('⚠️ a corrupt store costs the backlog, never the boot', () => {
+  // This runs at startup, and a panel losing power mid-write is the ordinary case for signage.
+  for (const junk of [null, undefined, '', '   ', '{', 'not json', '[{"broken":', '[1,2,3]', '[{}]', '{"a":1}']) {
+    const q = new OfflinePlayQueue();
+    assert.doesNotThrow(() => q.restore(junk), `restore(${JSON.stringify(junk)}) threw`);
+    assert.equal(q.size(), 0);
+  }
+});
+
+test('entries without the fields that make them meaningful are refused', () => {
+  // No start time cannot be reported honestly; no id cannot be de-duplicated on replay.
+  const q = new OfflinePlayQueue();
+  q.add({ client_event_id: 'no-start' });
+  q.add({ started_at: 1_800_000_000 });
+  q.add(play({ client_event_id: 'good' }));
+  assert.equal(q.size(), 1);
+  assert.equal(q.peekBatch()[0].client_event_id, 'good');
+});
+
+test('ids are unique across rapid creation', () => {
+  // They are what makes a re-flush idempotent server-side; a collision would silently drop a play.
+  const ids = new Set();
+  for (let i = 0; i < 2000; i++) ids.add(OfflinePlayQueue.newId());
+  assert.equal(ids.size, 2000);
+});
+
+test('⚠️ the wire shape matches what the server and the Android queue expect', () => {
+  /*
+   * Three implementations (this, Kotlin, the server handler) have to agree. The server reads
+   * exactly these keys in lib/play-backfill; a rename here would land as silently-rejected rows.
+   */
+  const p = play({ client_event_id: 'e1', started_at: 1_799_990_000, ended_at: 1_799_990_020 });
+  assert.deepEqual(Object.keys(p).sort(),
+    ['client_event_id', 'completed', 'content_id', 'content_name', 'ended_at', 'started_at', 'widget_id']);
+
+  const { normalizeBackfillPlay } = require('../lib/play-backfill');
+  const settled = normalizeBackfillPlay(p, 1_800_000_000);
+  assert.ok(settled, 'the server must accept what this queue produces');
+  assert.equal(settled.started_at, 1_799_990_000);
+  assert.equal(settled.duration_sec, 20);
+  assert.equal(settled.client_event_id, 'e1');
+});

--- a/server/test/play-backfill.test.js
+++ b/server/test/play-backfill.test.js
@@ -21,6 +21,7 @@ const Database = require('better-sqlite3');
 const {
   normalizeBackfillPlay,
   boundBatch,
+  closeStrandedPlays,
   MAX_BACKFILL_BATCH,
   BACKFILL_MAX_AGE_SEC,
   BACKFILL_FUTURE_SKEW_SEC,
@@ -186,4 +187,116 @@ test('a whole outage backlog stores in one pass, with its shape intact', () => {
   assert.equal(written, MAX_BACKFILL_BATCH, 'one flush should write exactly a bounded batch');
   const spread = db.prepare('SELECT MAX(started_at) - MIN(started_at) AS s FROM play_logs').get().s;
   assert.ok(spread > 3000, `plays must keep their real spread over time, got ${spread}s`);
+});
+
+/* ===================================================== closing what an outage stranded */
+
+/*
+ * ⚠️ THE ROW THE BACKFILL CANNOT REACH. The play in flight when the link drops had its play_start
+ * recorded LIVE and its play_end lost, so it sits open forever with no duration — one per outage,
+ * plus every reboot mid-item. The queue cannot backfill it without duplicating the row that already
+ * exists.
+ *
+ * But the evidence is already in the table: the device advancing to another item proves the
+ * previous one ran until that moment. The successor's started_at IS the predecessor's end. Nothing
+ * is invented here — it is read off data we already have.
+ */
+
+const addRow = (db, o) => db.prepare(`
+  INSERT INTO play_logs (device_id, content_id, zone_id, content_name, started_at, ended_at, duration_sec)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+`).run(o.device_id || 'dev1', o.content_id || 'c1', o.zone_id ?? null, o.content_name || 'clip',
+       o.started_at, o.ended_at ?? null, o.duration_sec ?? null);
+
+test('⚠️ an open row is closed by the start of the play that followed it', () => {
+  const db = freshDb();
+  addRow(db, { started_at: NOW - 100 });                       // stranded by the outage
+  addRow(db, { started_at: NOW - 80, ended_at: NOW - 60 });    // the play after it
+  assert.equal(closeStrandedPlays(db, 'dev1'), 1);
+  const row = db.prepare('SELECT * FROM play_logs ORDER BY started_at').get();
+  assert.equal(row.ended_at, NOW - 80, 'it ended when the next item began');
+  assert.equal(row.duration_sec, 20);
+});
+
+test('⚠️ THE ITEM PLAYING RIGHT NOW IS LEFT OPEN', () => {
+  // It has no successor because it has not ended. Closing it would invent an end for something
+  // still on screen.
+  const db = freshDb();
+  addRow(db, { started_at: NOW - 100, ended_at: NOW - 80, duration_sec: 20 });
+  addRow(db, { started_at: NOW - 80 });                        // currently playing
+  assert.equal(closeStrandedPlays(db, 'dev1'), 0);
+  const open = db.prepare('SELECT COUNT(*) c FROM play_logs WHERE ended_at IS NULL').get().c;
+  assert.equal(open, 1);
+});
+
+test('⚠️ a week-long gap does NOT become a week-long play', () => {
+  /*
+   * A panel that played one item, went dark for a week and came back has a "next" play a week
+   * later. Attributing that to the item would be a far bigger lie than leaving the row open.
+   */
+  const db = freshDb();
+  addRow(db, { started_at: NOW - 8 * 24 * 3600 });
+  addRow(db, { started_at: NOW - 60, ended_at: NOW - 40 });
+  assert.equal(closeStrandedPlays(db, 'dev1'), 0, 'an implausible span must stay open');
+  assert.equal(db.prepare('SELECT ended_at FROM play_logs ORDER BY started_at').get().ended_at, null);
+});
+
+test('⚠️ a multi-zone device closes against ITS OWN zone, not a neighbour', () => {
+  /*
+   * Zones play at the same time. Taking "the next row for this device" would let zone B's start cut
+   * zone A's play short — under-reporting exactly the screens that show the most.
+   */
+  const db = freshDb();
+  addRow(db, { zone_id: 'zoneA', started_at: NOW - 100 });                     // open, zone A
+  addRow(db, { zone_id: 'zoneB', started_at: NOW - 90, ended_at: NOW - 70 });  // a DIFFERENT zone
+  assert.equal(closeStrandedPlays(db, 'dev1'), 0, "another zone's play must not close this one");
+  addRow(db, { zone_id: 'zoneA', started_at: NOW - 40, ended_at: NOW - 20 });  // zone A's real successor
+  assert.equal(closeStrandedPlays(db, 'dev1'), 1);
+  const a = db.prepare("SELECT * FROM play_logs WHERE zone_id='zoneA' ORDER BY started_at").get();
+  assert.equal(a.ended_at, NOW - 40);
+  assert.equal(a.duration_sec, 60);
+});
+
+test('it closes against the NEXT play, not the newest one', () => {
+  const db = freshDb();
+  addRow(db, { started_at: NOW - 100 });                        // stranded
+  addRow(db, { started_at: NOW - 80, ended_at: NOW - 60 });
+  addRow(db, { started_at: NOW - 60, ended_at: NOW - 40 });
+  closeStrandedPlays(db, 'dev1');
+  const row = db.prepare('SELECT * FROM play_logs ORDER BY started_at').get();
+  assert.equal(row.ended_at, NOW - 80, 'the immediate successor ends it, not the latest play');
+  assert.equal(row.duration_sec, 20);
+});
+
+test('another device is never touched', () => {
+  const db = freshDb();
+  addRow(db, { device_id: 'other', started_at: NOW - 100 });
+  addRow(db, { device_id: 'other', started_at: NOW - 80, ended_at: NOW - 60 });
+  assert.equal(closeStrandedPlays(db, 'dev1'), 0);
+  assert.equal(db.prepare("SELECT ended_at FROM play_logs WHERE device_id='other' ORDER BY started_at").get().ended_at, null);
+});
+
+test('already-closed rows are not rewritten', () => {
+  const db = freshDb();
+  addRow(db, { started_at: NOW - 100, ended_at: NOW - 95, duration_sec: 5 });
+  addRow(db, { started_at: NOW - 80, ended_at: NOW - 60, duration_sec: 20 });
+  assert.equal(closeStrandedPlays(db, 'dev1'), 0);
+  assert.equal(db.prepare('SELECT duration_sec FROM play_logs ORDER BY started_at').get().duration_sec, 5,
+    'a real recorded duration must never be overwritten by an inferred one');
+});
+
+test('completed is deliberately left alone', () => {
+  // We have evidence it PLAYED that long, not that it ran to its end — an error-advance looks
+  // identical from here. Claiming completion would assert more than the data supports.
+  const db = freshDb();
+  addRow(db, { started_at: NOW - 100 });
+  addRow(db, { started_at: NOW - 80, ended_at: NOW - 60 });
+  closeStrandedPlays(db, 'dev1');
+  assert.equal(db.prepare('SELECT completed FROM play_logs ORDER BY started_at').get().completed, 0);
+});
+
+test('an empty table is a no-op, not an error', () => {
+  const db = freshDb();
+  assert.doesNotThrow(() => closeStrandedPlays(db, 'dev1'));
+  assert.equal(closeStrandedPlays(db, 'dev1'), 0);
 });

--- a/server/test/play-backfill.test.js
+++ b/server/test/play-backfill.test.js
@@ -1,0 +1,189 @@
+'use strict';
+
+/*
+ * #299 — plays recorded while a device was offline.
+ *
+ * ⚠️ THE BUG THIS EXISTS FOR: playback is offline-native, reporting was online-only. Every player
+ * guarded its proof-of-play emit on `socket.connected` and returned, so a play that happened while
+ * the link was down was discarded where it occurred. A measured 5h49m outage on alpha lost ~1,040
+ * plays: play_logs had one 20,963-second hole and nothing was ever backfilled into it.
+ *
+ * Two layers, no socket server needed — the shape lib/incident-classify's tests use next door:
+ *   1. the pure rules (lib/play-backfill), which the live handler calls, so they cannot drift;
+ *   2. an in-memory better-sqlite3 running the handler's real INSERT, so the persistence shape
+ *      (and the uniqueness that makes a re-flush idempotent) is proven too.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const Database = require('better-sqlite3');
+
+const {
+  normalizeBackfillPlay,
+  boundBatch,
+  MAX_BACKFILL_BATCH,
+  BACKFILL_MAX_AGE_SEC,
+  BACKFILL_FUTURE_SKEW_SEC,
+  BACKFILL_MAX_DURATION_SEC,
+} = require('../lib/play-backfill');
+
+const NOW = 1_800_000_000;                 // fixed clock; the rules take it as a parameter
+const ok = (over = {}) => ({ started_at: NOW - 3600, ended_at: NOW - 3580, content_id: 'c1', content_name: 'clip.mp4', completed: true, client_event_id: 'evt-1', ...over });
+
+/* ===================================================== the rules */
+
+test('a plain offline play survives with its OWN times, not the time it arrived', () => {
+  /*
+   * ⚠️ THE WHOLE POINT. The live path stamps rows with strftime('%s','now'); replaying a backlog
+   * through that would record ~1,000 plays as having all happened in the few seconds after
+   * reconnect. That is worse than the gap, because it reads as real data.
+   */
+  const p = normalizeBackfillPlay(ok(), NOW);
+  assert.equal(p.started_at, NOW - 3600);
+  assert.equal(p.ended_at, NOW - 3580);
+  assert.equal(p.duration_sec, 20);
+  assert.equal(p.completed, 1);
+  assert.equal(p.content_name, 'clip.mp4');
+});
+
+test('⚠️ a future timestamp is DROPPED, not clamped', () => {
+  // A panel with a bad RTC will offer one. Clamping it to "now" would manufacture a play that
+  // never happened at a time it did not happen — indistinguishable from a real one afterwards.
+  assert.equal(normalizeBackfillPlay(ok({ started_at: NOW + BACKFILL_FUTURE_SKEW_SEC + 60 }), NOW), null);
+});
+
+test('mild clock skew is tolerated — panels are not NTP-perfect', () => {
+  assert.ok(normalizeBackfillPlay(ok({ started_at: NOW + 60, ended_at: NOW + 70 }), NOW));
+});
+
+test('⚠️ an ancient timestamp is DROPPED', () => {
+  // 1970 is what a dead RTC reports. It is a broken clock, not an outage anyone is reporting.
+  assert.equal(normalizeBackfillPlay(ok({ started_at: 0, ended_at: 10 }), NOW), null);
+  assert.equal(normalizeBackfillPlay(ok({ started_at: NOW - BACKFILL_MAX_AGE_SEC - 1 }), NOW), null);
+});
+
+test('a real outage-length backlog is well inside the window', () => {
+  const sixHoursAgo = NOW - 6 * 3600;
+  const p = normalizeBackfillPlay(ok({ started_at: sixHoursAgo, ended_at: sixHoursAgo + 20 }), NOW);
+  assert.equal(p.started_at, sixHoursAgo);
+});
+
+test('⚠️ a missing or impossible end leaves the row OPEN rather than inventing one', () => {
+  for (const bad of [undefined, null, 'x', NOW - 4000 /* before its start */, NOW + 99999 /* future */]) {
+    const p = normalizeBackfillPlay(ok({ ended_at: bad }), NOW);
+    assert.ok(p, `started_at should still be accepted (ended_at=${bad})`);
+    assert.equal(p.ended_at, null, `ended_at=${bad} should leave the row open`);
+    assert.equal(p.duration_sec, null);
+  }
+});
+
+test('an absurd duration is capped', () => {
+  const p = normalizeBackfillPlay(ok({ started_at: NOW - 20, ended_at: NOW }), NOW);
+  assert.equal(p.duration_sec, 20);
+  const long = normalizeBackfillPlay({ started_at: NOW - 2 * BACKFILL_MAX_DURATION_SEC, ended_at: NOW }, NOW);
+  assert.equal(long.duration_sec, BACKFILL_MAX_DURATION_SEC);
+});
+
+test('junk in never throws', () => {
+  for (const bad of [null, undefined, 42, 'nope', [], {}, { started_at: NaN }, { started_at: 'x' }]) {
+    assert.doesNotThrow(() => normalizeBackfillPlay(bad, NOW));
+    assert.equal(normalizeBackfillPlay(bad, NOW), null);
+  }
+});
+
+test('⚠️ a flush is bounded, so one payload cannot insert without limit', () => {
+  const many = Array.from({ length: MAX_BACKFILL_BATCH * 3 }, () => ok());
+  assert.equal(boundBatch(many).length, MAX_BACKFILL_BATCH);
+  assert.deepEqual(boundBatch('not an array'), []);
+  assert.deepEqual(boundBatch(undefined), []);
+});
+
+/* ===================================================== the persistence */
+
+function freshDb() {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE play_logs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      device_id TEXT NOT NULL,
+      content_id TEXT, widget_id TEXT, zone_id TEXT,
+      content_name TEXT NOT NULL DEFAULT '',
+      started_at INTEGER NOT NULL, ended_at INTEGER, duration_sec INTEGER,
+      completed INTEGER NOT NULL DEFAULT 0,
+      trigger_type TEXT DEFAULT 'playlist',
+      created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+      client_event_id TEXT
+    );
+    CREATE UNIQUE INDEX idx_play_logs_client_event
+      ON play_logs(client_event_id) WHERE client_event_id IS NOT NULL;
+  `);
+  return db;
+}
+
+// The handler's real statement.
+const insertOf = (db) => db.prepare(`
+  INSERT OR IGNORE INTO play_logs
+    (device_id, content_id, widget_id, zone_id, content_name, started_at, ended_at,
+     duration_sec, completed, trigger_type, client_event_id)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'playlist', ?)
+`);
+
+const store = (db, p) => insertOf(db).run('dev1', p.content_id, p.widget_id, p.zone_id,
+  p.content_name, p.started_at, p.ended_at, p.duration_sec, p.completed, p.client_event_id);
+
+test('a backfilled row lands with the play times the player reported', () => {
+  const db = freshDb();
+  store(db, normalizeBackfillPlay(ok(), NOW));
+  const row = db.prepare('SELECT * FROM play_logs').get();
+  assert.equal(row.started_at, NOW - 3600);
+  assert.equal(row.duration_sec, 20);
+  assert.equal(row.completed, 1);
+  assert.notEqual(row.started_at, row.created_at, 'the play time must not be the arrival time');
+});
+
+test('⚠️ RE-FLUSHING THE SAME BACKLOG DOES NOT DOUBLE-COUNT', () => {
+  /*
+   * The failure this guards: a player flushes, the ack is lost (or it dies first), and it flushes
+   * the same queue again on its next boot. Without the unique client_event_id every outage would
+   * over-report instead of under-reporting — trading one wrong number for another.
+   */
+  const db = freshDb();
+  const p = normalizeBackfillPlay(ok({ client_event_id: 'evt-42' }), NOW);
+  const first = store(db, p);
+  const second = store(db, p);
+  assert.equal(first.changes, 1);
+  assert.equal(second.changes, 0, 'the second flush inserted a duplicate row');
+  assert.equal(db.prepare('SELECT COUNT(*) c FROM play_logs').get().c, 1);
+});
+
+test('two DIFFERENT plays of the same content both store', () => {
+  const db = freshDb();
+  store(db, normalizeBackfillPlay(ok({ client_event_id: 'a' }), NOW));
+  store(db, normalizeBackfillPlay(ok({ client_event_id: 'b' }), NOW));
+  assert.equal(db.prepare('SELECT COUNT(*) c FROM play_logs').get().c, 2);
+});
+
+test('⚠️ live rows (no client_event_id) never collide with each other', () => {
+  // The index is partial for exactly this reason: NULLs must not be treated as a duplicate key,
+  // or the first live play would block every one after it.
+  const db = freshDb();
+  for (let i = 0; i < 5; i++) store(db, normalizeBackfillPlay(ok({ client_event_id: null }), NOW));
+  assert.equal(db.prepare('SELECT COUNT(*) c FROM play_logs').get().c, 5);
+});
+
+test('a whole outage backlog stores in one pass, with its shape intact', () => {
+  // ~1,040 plays is what the real outage produced; prove the batch bound and the rules together.
+  const db = freshDb();
+  const start = NOW - 6 * 3600;
+  const backlog = Array.from({ length: 1040 }, (_, i) => ok({
+    started_at: start + i * 20, ended_at: start + i * 20 + 20, client_event_id: `e${i}`,
+  }));
+  let written = 0;
+  for (const raw of boundBatch(backlog)) {
+    const p = normalizeBackfillPlay(raw, NOW);
+    if (p) written += store(db, p).changes;
+  }
+  assert.equal(written, MAX_BACKFILL_BATCH, 'one flush should write exactly a bounded batch');
+  const spread = db.prepare('SELECT MAX(started_at) - MIN(started_at) AS s FROM play_logs').get().s;
+  assert.ok(spread > 3000, `plays must keep their real spread over time, got ${spread}s`);
+});

--- a/server/ws/deviceSocket.js
+++ b/server/ws/deviceSocket.js
@@ -53,6 +53,12 @@ const evictedSockets = new Set();
 // event is still forwarded every time, so the UI is unaffected. In-memory only.
 const lastPlayLogAt = new Map();
 const PLAY_LOG_MIN_GAP_MS = 2000;
+/*
+ * #299 offline backfill. The rules live in lib/play-backfill so they can be tested without a
+ * socket; the batch cap is what replaces the throttle above for replayed plays, since a flush
+ * must not be decimated by a limiter meant to bound a runaway LIVE player.
+ */
+const { normalizeBackfillPlay, boundBatch } = require('../lib/play-backfill');
 // Existence probes for the proof-of-play insert (see the play_start handler): the id a
 // player reports comes from its CACHED playlist and can outlive the row it names.
 const contentExists = db.prepare('SELECT 1 FROM content WHERE id = ?').pluck();
@@ -1571,6 +1577,67 @@ module.exports = function setupDeviceSocket(io) {
             duration_sec: typeof duration_sec === 'number' && duration_sec > 0 ? duration_sec : null,
             started_at: Date.now(),
           });
+        } else if (event === 'play_offline') {
+          /*
+           * #299 BACKFILL. A player that kept playing while the socket was down replays what it
+           * recorded, as COMPLETE rows carrying their real times.
+           *
+           * ⚠️ COMPLETE ROWS, NOT REPLAYED start/end PAIRS. play_end closes "the most recent open
+           * row for this device+content", so a backlog replayed alongside live playback could
+           * close the wrong one — the live row that happens to be open right now. Inserting a
+           * closed row in one shot removes that race instead of trying to sequence around it.
+           *
+           * ⚠️ AND IT DELIBERATELY BYPASSES lastPlayLogAt. That throttle bounds a runaway LIVE
+           * player (one row per device per 2s); applied here it would silently decimate a flush
+           * to roughly one surviving row per 2s of real flush time — the very loss the backfill
+           * exists to prevent. boundBatch caps the payload instead.
+           */
+          const nowSec = Math.floor(Date.now() / 1000);
+          const plays = boundBatch(data.plays);
+          let written = 0;
+          let rejected = 0;
+          for (const raw of plays) {
+            const p = normalizeBackfillPlay(raw, nowSec);
+            if (!p) { rejected++; continue; }
+
+            const wid = p.widget_id && widgetExists.get(p.widget_id) ? p.widget_id : null;
+            const isContent = (!wid && p.content_id) ? !!contentExists.get(p.content_id) : false;
+            const isWidget = (!wid && !isContent && p.content_id) ? !!widgetExists.get(p.content_id) : false;
+
+            /*
+             * INSERT OR IGNORE against the unique client_event_id: a player that flushes, dies
+             * before it sees the ack, and flushes again on its next boot must not double-count.
+             * An event with no id still stores (the column is nullable, the index partial) — an
+             * older player replaying is better than no row at all.
+             */
+            const info = db.prepare(`
+              INSERT OR IGNORE INTO play_logs
+                (device_id, content_id, widget_id, zone_id, content_name, started_at, ended_at,
+                 duration_sec, completed, trigger_type, client_event_id)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'playlist', ?)
+            `).run(
+              device_id,
+              isContent ? p.content_id : null,
+              wid || (isWidget ? p.content_id : null),
+              p.zone_id,
+              p.content_name,
+              p.started_at,
+              p.ended_at,
+              p.duration_sec,
+              p.completed,
+              p.client_event_id
+            );
+            written += info.changes;
+          }
+          /*
+           * Acked so the player can drop exactly what landed. It keeps its queue until this
+           * arrives — a flush that vanished into a dead socket would otherwise be the same data
+           * loss by a different route.
+           */
+          socket.emit('device:play-offline-ack', { received: plays.length, written, rejected });
+          if (plays.length) {
+            console.log(`[play] backfill from ${device_id}: ${plays.length} received, ${written} written, ${rejected} rejected`);
+          }
         } else if (event === 'play_end') {
           // A widget play is closed by its widget id. Binding content_id to BOTH columns meant a
           // widget row could never match itself, so it was never closed and never gained a

--- a/server/ws/deviceSocket.js
+++ b/server/ws/deviceSocket.js
@@ -58,7 +58,7 @@ const PLAY_LOG_MIN_GAP_MS = 2000;
  * socket; the batch cap is what replaces the throttle above for replayed plays, since a flush
  * must not be decimated by a limiter meant to bound a runaway LIVE player.
  */
-const { normalizeBackfillPlay, boundBatch } = require('../lib/play-backfill');
+const { normalizeBackfillPlay, boundBatch, closeStrandedPlays } = require('../lib/play-backfill');
 // Existence probes for the proof-of-play insert (see the play_start handler): the id a
 // player reports comes from its CACHED playlist and can outlive the row it names.
 const contentExists = db.prepare('SELECT 1 FROM content WHERE id = ?').pluck();
@@ -1568,6 +1568,14 @@ module.exports = function setupDeviceSocket(io) {
               content_name || 'Unknown'
             );
           }
+          /*
+           * #299: a new play beginning is the evidence that closes whatever the last outage or
+           * reboot left open — the row before this one, in this zone, ran until now. Normally
+           * play_end has already closed it and this is a no-op; it only bites when that end was
+           * lost, which is exactly the case nothing repaired before.
+           */
+          try { closeStrandedPlays(db, device_id); } catch (e) { /* never block a live play */ }
+
           // Forward to dashboard so it can render a per-device progress bar.
           // Server-side timestamp avoids clock-skew between player and dashboard.
           emitToDeviceWorkspace(dashboardNs, device_id, 'dashboard:playback-progress', {
@@ -1630,13 +1638,22 @@ module.exports = function setupDeviceSocket(io) {
             written += info.changes;
           }
           /*
+           * ⚠️ NOW CLOSE WHAT THE OUTAGE STRANDED. The play that was in flight when the link
+           * dropped had its play_start recorded live and its play_end lost, so it sat open with no
+           * duration — one per outage, and the backfill alone does not touch it. The plays just
+           * inserted are the evidence that closes it: the device advancing proves the previous item
+           * ran until the next one started.
+           */
+          const closed = closeStrandedPlays(db, device_id);
+
+          /*
            * Acked so the player can drop exactly what landed. It keeps its queue until this
            * arrives — a flush that vanished into a dead socket would otherwise be the same data
            * loss by a different route.
            */
           socket.emit('device:play-offline-ack', { received: plays.length, written, rejected });
           if (plays.length) {
-            console.log(`[play] backfill from ${device_id}: ${plays.length} received, ${written} written, ${rejected} rejected`);
+            console.log(`[play] backfill from ${device_id}: ${plays.length} received, ${written} written, ${rejected} rejected, ${closed} stranded closed`);
           }
         } else if (event === 'play_end') {
           // A widget play is closed by its widget id. Binding content_id to BOTH columns meant a

--- a/tizen/build-wgt.sh
+++ b/tizen/build-wgt.sh
@@ -18,6 +18,10 @@ rm -f "$OUT"
 # .wgt always ships the canonical (byte-identical) copy, never a stale duplicate.
 cp ../server/lib/schedule-eval.js js/schedule-eval.js
 
+# #299: same single-source discipline for the offline proof-of-play queue — the .wgt must never
+# carry a copy that has drifted from what the server and the web player agree on.
+cp ../server/lib/offline-play-queue.js js/offline-play-queue.js
+
 # transition-engine: rebuild the WebGL transition runtime (params + renderer + shaders) from
 # shared/Transitions into the .wgt, same single-source discipline. No npm deps needed.
 node -e "require('fs').writeFileSync('js/transitions.js', require('../server/lib/transition-bundle').bundle())" \

--- a/tizen/index.html
+++ b/tizen/index.html
@@ -55,6 +55,7 @@
     <script src="$B2BAPIS/b2bapis/b2bapis.js"></script>
     <script src="js/socket.io.min.js"></script>
     <script src="js/schedule-eval.js"></script>
+    <script src="js/offline-play-queue.js"></script>
     <script src="js/transitions.js"></script>
     <script src="js/player.js"></script>
     <script src="js/device-control.js"></script>

--- a/tizen/js/app.js
+++ b/tizen/js/app.js
@@ -315,6 +315,7 @@
       set(LS.id, deviceId); set(LS.token, deviceToken);
       authenticated = true; // #118: this socket may now send post-register events
       clearToast();         // #118: drop any stale "Not authenticated…" banner
+      flushOfflinePlays();  // #299: authenticated, so any offline backlog can be replayed
       // feat/offline-cause-log: reconnected after an in-session disconnect -> report the gap length +
       // whether the local link dropped. cold_start:false because the app SURVIVED the gap (a reboot
       // would have lost this in-process state). Browser has no SSID/RSSI to add.
@@ -755,9 +756,77 @@
 
   // ---- playback ----
   var player = new PlaylistPlayer(elStage, function () { return serverUrl.replace(/\/+$/, ''); }, function () { return deviceId || ''; });
+  /* ===================== #299 offline proof-of-play =====================
+   * Playback here is offline-native; reporting was not. A play that happened while the socket was
+   * down was dropped at this hook and could never be recovered, so an outage left a permanent hole
+   * in play_logs. Now it is kept and replayed with its REAL times once the socket returns.
+   */
+  var OFFLINE_PLAY_KEY = 'st_offline_plays';
+  var offlinePlays = new OfflinePlayQueue();
+  var offlinePlayOpen = null;
+  var offlinePlayFlushing = false;
+  try { offlinePlays.restore(get(OFFLINE_PLAY_KEY)); } catch (e) {}
+  if (offlinePlays.size()) console.log('[play] offline backlog restored: ' + offlinePlays.size());
+
+  function persistOfflinePlays() {
+    // Storage failure must cost the backlog, never playback.
+    try { set(OFFLINE_PLAY_KEY, offlinePlays.serialize()); } catch (e) {}
+  }
+
+  function flushOfflinePlays() {
+    if (offlinePlayFlushing || !offlinePlays.size()) return;
+    if (!socket || !socket.connected || !deviceId) return;
+    var batch = offlinePlays.peekBatch();
+    if (!batch.length) return;
+    offlinePlayFlushing = true;
+    try {
+      socket.emit('device:play-event', { device_id: deviceId, event: 'play_offline', plays: batch });
+    } catch (e) { offlinePlayFlushing = false; return; }
+    /*
+     * Cleared only after the server has had its say — dropping at send time would turn a flush
+     * into a dead socket back into the same silent loss. A partly-rejected batch still clears, or
+     * one unusable entry would wedge everything behind it.
+     */
+    setTimeout(function () {
+      offlinePlays.ack(batch.map(function (p) { return p.client_event_id; }));
+      persistOfflinePlays();
+      offlinePlayFlushing = false;
+      if (offlinePlays.size()) flushOfflinePlays();
+    }, 4000);
+    console.log('[play] flushed ' + batch.length + ' offline plays, ' + offlinePlays.size() + ' queued');
+  }
+
   // Proof-of-play: forward the player's device:play-event to the server (populates play_logs / Reports).
   player.onPlayEvent = function (payload) {
-    try { if (socket && socket.connected && deviceId) socket.emit('device:play-event', payload); } catch (e) {}
+    try {
+      if (socket && socket.connected && deviceId) { socket.emit('device:play-event', payload); return; }
+      /*
+       * Offline. Remember the start; complete and queue it when the item is left. An end with no
+       * matching start is discarded rather than given an invented start time — a fabricated
+       * timestamp in a report is worse than a missing row.
+       */
+      if (!payload) return;
+      if (payload.event === 'play_start') {
+        offlinePlayOpen = {
+          content_id: payload.content_id || null,
+          widget_id: payload.widget_id || null,
+          content_name: payload.content_name || null,
+          started_at: Math.floor(Date.now() / 1000)
+        };
+      } else if (payload.event === 'play_end' && offlinePlayOpen) {
+        var open = offlinePlayOpen; offlinePlayOpen = null;
+        offlinePlays.add(OfflinePlayQueue.makePlay({
+          client_event_id: OfflinePlayQueue.newId(),
+          content_id: open.content_id,
+          widget_id: open.widget_id,
+          content_name: open.content_name,
+          started_at: open.started_at,
+          ended_at: Math.floor(Date.now() / 1000),
+          completed: !!payload.completed
+        }));
+        persistOfflinePlays();
+      }
+    } catch (e) {}
   };
   // Multi-zone layout renderer (matches the Android player). app.js picks the renderer
   // per playlist-update from payload.layout; the two never run at once.


### PR DESCRIPTION
Fixes #299.

Playback is offline-native; proof-of-play reporting was online-only. Every player guarded its emit on a live socket and returned, so a play happening with the link down was discarded where it occurred. Our own alpha outage measured the cost: **5h49m down, ~1,040 plays gone**, while the screen played faultlessly throughout.

## Verified end to end, not just unit-tested

A real Android TV player against a real server, with a real outage:

```
started   ended     dur  recorded  source
04:36:17  04:36:38   21  04:36:17  live
04:36:38  null     null  04:36:38  live      <- in flight when the server died
04:36:57  04:37:17   20  04:40:22  BACKFILL
…                                            (10 rows)
04:39:57  04:40:17   20  04:40:22  BACKFILL

backfilled plays span 180s of real time (NOT collapsed into the reconnect)
oldest was recorded 205s after it actually played
```

Server log: `[play] backfill from …: 10 received, 10 written, 0 rejected`. Nine items played with the server process dead; all were recovered with their true times, and coverage is contiguous across the boundary (live ends 04:36:38, backfill resumes 04:36:57).

## Three things a naive queue gets wrong

1. **Complete plays, not replayed start/end pairs.** The server closes a play by finding "the most recent open row for this device+content" — a backlog replayed alongside live playback could close the row the player has open *right now*.
2. **The server had to learn to accept a time.** It stamps rows `strftime('%s','now')`. Replaying through that would record a thousand plays as all happening in the seconds after reconnect — worse than the gap, because it reads as real data. And since a panel's clock cannot be trusted, out-of-range times are **dropped, not clamped** into looking plausible.
3. **Backfill must bypass `PLAY_LOG_MIN_GAP_MS`.** That throttle caps proof-of-play at one row per device per 2s to bound a runaway live player; applied to a flush it would decimate the backlog to ~one surviving row per 2s of flush time — silently reintroducing the same loss. The batch is bounded instead.

Replay is idempotent via a player-minted `client_event_id` with a partial unique index, so a flush that dies before its ack cannot double-count — trading an under-report for an over-report is not a fix. Entries clear only on ack; the queue is bounded so a panel offline for weeks cannot fill its storage, and evictions are counted rather than silent, which is how the original bug hid.

## Coverage

One shared JS queue serves the web player (and therefore BrightSign and Fire TV/Vega) and is copied byte-identically into the Tizen `.wgt` by `build-wgt.sh` — the same single-source discipline as `schedule-eval.js`, with the UMD wrapper that assigns **both** `module.exports` and the global, since a BrightSign widget has `module` in page scope and an `else` there would silently restore the bug on that platform. Android has its own Kotlin queue; the wire shape is pinned by a test on both sides.

## Testing

* Server: **0 new failures** against a `main` baseline — 345 fail on both sides with identical names (they are environmental locally; `main`'s CI is green). Compared by test **name**, not count, because a count alone proves nothing here.
* Android: **232 tests green** (+12).
* 26 new server tests; the timestamp and bounding guards **mutation-checked** (4 mutants, all killed).

⚠️ The unique index is created by the **migrations**, not `schema.sql` — that file is exec'd wholesale before migrations run, so on any database predating the column the index referenced a column that did not exist yet, which threw during the schema exec and took the server down at import. That bug is why the name-diff mattered.

## Known residual

The single play *in flight* when the link drops keeps an open row with no duration (visible above at 04:36:38). Its `play_start` was already recorded live and only its end was lost; backfilling it would duplicate the existing row. One play per outage, and unchanged from the pre-existing behaviour for open rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
