### PR TITLE
Make LAN triggers actually work on Android

### DIFF
--- a/android/app/src/main/java/com/remotedisplay/player/MainActivity.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/MainActivity.kt
@@ -691,6 +691,21 @@ class MainActivity : AppCompatActivity() {
             try { triggerManager?.onPayload(data) } catch (e: Throwable) {
                 Log.w("MainActivity", "trigger adopt failed: ${e.message}")
             }
+            /*
+             * ⚠️ AND PIN WHAT THEY NEED — the comment above describes the WEB player's mechanism,
+             * not this one. There, device-triggers.js appends trigger media to the same
+             * st-cache-playlist message the service worker already handles. Android has no service
+             * worker: it downloads through DownloadCoordinator, driven by a loop over `assignments`
+             * ONLY. Trigger items live in a separate `triggers` array that never reached it, so
+             * assigning a trigger to a device whose base playlist was unchanged downloaded nothing,
+             * and the fire rendered its black box over the playlist with no media inside.
+             *
+             * Measured on hardware before this: fire accepted, TriggerController logged it, screen
+             * went black, and content_cache held only the four base clips.
+             */
+            try { pinTriggerMedia(data) } catch (e: Throwable) {
+                Log.w("MainActivity", "trigger media pin failed: ${e.message}")
+            }
             // Orientation is applied in the non-wall branch below; wall mode owns the
             // root-view transform itself and must not be rotated.
             // Check if device is suspended (trial expired / over limit)
@@ -1100,6 +1115,35 @@ class MainActivity : AppCompatActivity() {
     // is cleared on each (re)registration (see onRegistered) so a reconnect re-acks everything the
     // server may have missed while we were disconnected (SEED-B), but is quiet within a session.
     private val ackedContent = java.util.Collections.synchronizedSet(HashSet<String>())
+
+    /**
+     * Download the media every assigned trigger needs, so a fire has something to show.
+     *
+     * Idempotent and non-blocking: ensure() is single-flight per contentId and returns immediately
+     * for anything already cached, so running this on every payload costs nothing in the steady
+     * state. Items carry the same shape as an assignment because the server projects a trigger's
+     * target as the playlist's published snapshot.
+     */
+    private fun pinTriggerMedia(data: org.json.JSONObject) {
+        if (!::downloadCoordinator.isInitialized) return
+        val triggers = data.optJSONArray("triggers") ?: return
+        var pinned = 0
+        for (i in 0 until triggers.length()) {
+            val t = triggers.optJSONObject(i) ?: continue
+            val items = t.optJSONArray("items") ?: continue
+            for (j in 0 until items.length()) {
+                val item = items.optJSONObject(j) ?: continue
+                // isNull() first: org.json's optString hands back the STRING "null" for a JSON null.
+                val contentId = if (item.isNull("content_id")) "" else item.optString("content_id", "")
+                if (contentId.isEmpty()) continue          // widgets carry no content to fetch
+                val filename = item.optString("filename", "content")
+                val rev = item.optLong("content_rev", 0L)
+                downloadCoordinator.ensure(contentId, filename, rev)
+                pinned++
+            }
+        }
+        if (pinned > 0) Log.i("MainActivity", "[trigger] pinning $pinned trigger item(s)")
+    }
 
     private fun ackContentOnce(contentId: String, status: String) {
         if (ackedContent.add("$contentId:$status")) {

--- a/android/app/src/main/java/com/remotedisplay/player/trigger/TriggerListeners.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/trigger/TriggerListeners.kt
@@ -87,7 +87,9 @@ class TriggerListeners(
 
     fun start(acceptHttp: Boolean, acceptUdp: Boolean, httpPort: Int?, udpPort: Int?, group: String?) {
         if (!running.compareAndSet(false, true)) return   // idempotent, like the web player's guard
-        if (acceptUdp) startUdp(udpPort ?: DEFAULT_UDP_PORT, group ?: DEFAULT_GROUP)
+        // An absent group is honoured as absent: unicast + broadcast only. Substituting a default
+        // multicast address here would silently opt every device into multicast it never asked for.
+        if (acceptUdp) startUdp(udpPort ?: DEFAULT_UDP_PORT, group ?: "")
         if (acceptHttp) startHttp(httpPort ?: DEFAULT_HTTP_PORT)
     }
 
@@ -141,9 +143,28 @@ class TriggerListeners(
                 udp = sock
                 stats.udpPort = port
                 stats.group = group
-                joinGroup(sock, group, "bind")
-                startRejoinLoop(sock, group)
-                selfTest(sock, group, port)
+                /*
+                 * ⚠️ THE GROUP IS OPTIONAL AND A BAD ONE MUST NOT COST THE LISTENER. Per the note
+                 * above, this socket already receives unicast AND subnet broadcast just by being
+                 * bound; joinGroup only adds multicast. But getByName() sits outside joinGroup's
+                 * try, so an unresolvable group threw all the way out here and killed the whole
+                 * thread — every UDP trigger silently inert, including the unicast and broadcast
+                 * fires that never needed a group at all. That is exactly what a device with no
+                 * multicast group configured hit, which is the default.
+                 */
+                if (group.isNotEmpty()) {
+                    try {
+                        joinGroup(sock, group, "bind")
+                        startRejoinLoop(sock, group)
+                        selfTest(sock, group, port)
+                    } catch (e: Throwable) {
+                        stats.lastJoinError = e.message
+                        Log.w(TAG, "[trigger] multicast unavailable ($group): ${e.message} — "
+                            + "unicast and broadcast still listening on :$port")
+                    }
+                } else {
+                    Log.i(TAG, "[trigger] no multicast group configured — unicast + broadcast on :$port")
+                }
                 onState(stats)
 
                 val buf = ByteArray(2048)

--- a/android/app/src/main/java/com/remotedisplay/player/trigger/TriggerManager.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/trigger/TriggerManager.kt
@@ -24,6 +24,34 @@ class TriggerManager(
     var triggers: List<TriggerResolve.Trigger> = emptyList()
         private set
     private var secret: String = ""
+
+    /*
+     * ⚠️ org.json's optString RETURNS THE STRING "null" FOR A JSON null ON ANDROID. The server sends
+     * `secret: null`, `multicast_group: null` and `clear_all_token: null` whenever they are unset,
+     * so the plain `optString(...).takeIf { it.isNotEmpty() }` this replaced produced the four-letter
+     * string "null" and treated it as a configured value. Three live consequences, one of them
+     * security-relevant:
+     *
+     *   1. multicast_group "null" -> InetAddress.getByName("null") threw and took the WHOLE UDP
+     *      listener down, so UDP triggers were inert on every device without a multicast group —
+     *      which is the default. Observed on hardware: 'UDP listener failed: Unable to resolve
+     *      host "null"'.
+     *   2. secret "null" -> TriggerResolve refuses a fire only when the device secret
+     *      isNullOrEmpty(), and "null" is neither. A device with listeners enabled and NO secret
+     *      set therefore ACCEPTED `ST1 null <token>` instead of refusing everything.
+     *   3. clear_all_token "null" -> the literal token "null" would clear every active trigger.
+     *
+     * ⚠️ AND A JVM TEST CANNOT SEE THIS. The reference org.json returns the FALLBACK for a JSON
+     * null; only Android's implementation returns "null". That is why the suite was green. This
+     * helper is what the tests can prove instead: given the string, it must yield absence.
+     *
+     * The same trap already cost this project once, in the remote_url download path.
+     */
+    private fun optText(o: org.json.JSONObject?, key: String): String? {
+        if (o == null || o.isNull(key)) return null
+        val v = o.optString(key, "")
+        return if (v.isEmpty() || v == "null") null else v
+    }
     private var clearAllToken: String? = null
     private val limiter = TriggerResolve.RateLimiter()
     private var listeners: TriggerListeners? = null
@@ -46,15 +74,15 @@ class TriggerManager(
      */
     fun onPayload(payload: JSONObject) {
         val cfg = payload.optJSONObject("trigger_config")
-        val newSecret = cfg?.optString("secret") ?: ""
+        val newSecret = optText(cfg, "secret") ?: ""
         val acceptHttp = cfg?.optBoolean("accept_http") ?: false
         val acceptUdp = cfg?.optBoolean("accept_udp") ?: false
         val httpPort = cfg?.optInt("http_port")?.takeIf { it > 0 }
         val udpPort = cfg?.optInt("udp_port")?.takeIf { it > 0 }
-        val group = cfg?.optString("multicast_group")?.takeIf { it.isNotEmpty() }
+        val group = optText(cfg, "multicast_group")
 
         secret = newSecret
-        clearAllToken = cfg?.optString("clear_all_token")?.takeIf { it.isNotEmpty() }
+        clearAllToken = optText(cfg, "clear_all_token")
         triggers = parseTriggers(payload.optJSONArray("triggers"))
 
         val want = "$acceptHttp/$acceptUdp/$httpPort/$udpPort/$group"

--- a/android/app/src/main/java/com/remotedisplay/player/trigger/TriggerOverlay.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/trigger/TriggerOverlay.kt
@@ -49,6 +49,20 @@ class TriggerOverlay(
     private val log: (level: String, message: String) -> Unit = { _, _ -> }
 ) : TriggerRenderer {
     private val handler = Handler(Looper.getMainLooper())
+
+    /*
+     * ⚠️ EVERY VIEW TOUCH GOES THROUGH HERE, because a trigger arrives on a NETWORK thread.
+     * TriggerListeners reads its datagram (or its HTTP request) on its own thread and calls
+     * straight through to TriggerController.fire() -> show(). Building and attaching Views from
+     * there is an Android violation, and the way it failed was the worst kind: no crash, no log.
+     * The box WAS added to the layer — dumpsys showed it as a child — but it never got a layout
+     * pass, so it measured 0x0 and nothing was ever visible. The trigger "fired", the controller
+     * logged it, the lease ran, the state machine believed a screen was covered, and the panel
+     * carried on playing its playlist. That is precisely the reported "triggers are inert".
+     */
+    private inline fun onMain(crossinline block: () -> Unit) {
+        if (Looper.myLooper() == Looper.getMainLooper()) block() else handler.post { block() }
+    }
     private var box: FrameLayout? = null
     private var player: ExoPlayer? = null
     private var advance: Runnable? = null
@@ -88,32 +102,39 @@ class TriggerOverlay(
             return false
         }
 
-        val b = FrameLayout(context)
-        b.setBackgroundColor(Color.BLACK)
-        b.layoutParams = FrameLayout.LayoutParams(
-            ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
-        layer.addView(b)
-        layer.visibility = android.view.View.VISIBLE
-        box = b
-        items = all
-        index = 0
+        /*
+         * The filtering above is pure and stays on the calling thread — the caller needs the
+         * boolean synchronously to decide whether the fire counts. Only the view work is marshalled.
+         */
+        onMain {
+            val b = FrameLayout(context)
+            b.setBackgroundColor(Color.BLACK)
+            b.layoutParams = FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+            layer.addView(b)
+            layer.visibility = android.view.View.VISIBLE
+            box = b
+            items = all
+            index = 0
 
-        return try {
-            setBaseAudioSuppressed(true)
-            renderAt(0)
-            log("info", "fired \"${trigger.name}\" (${all.size} item(s))")
-            true
-        } catch (e: Throwable) {
-            // ⚠️ Everything above has already committed — the box is on screen and the base is
-            // silenced. A throw that escaped here would leave an opaque black rectangle over the
-            // playlist with nothing in it and no audio anywhere.
-            log("warn", "\"${trigger.name}\" failed to render: ${e.message}")
-            hide()
-            false
+            try {
+                setBaseAudioSuppressed(true)
+                renderAt(0)
+                log("info", "fired \"${trigger.name}\" (${all.size} item(s))")
+            } catch (e: Throwable) {
+                // ⚠️ Everything above has already committed — the box is on screen and the base is
+                // silenced. A throw that escaped here would leave an opaque black rectangle over the
+                // playlist with nothing in it and no audio anywhere.
+                log("warn", "\"${trigger.name}\" failed to render: ${e.message}")
+                hide()
+            }
         }
+        return true
     }
 
-    override fun hide() {
+    override fun hide() = onMain { hideOnMain() }
+
+    private fun hideOnMain() {
         advance?.let { handler.removeCallbacks(it) }
         advance = null
         // Release, not pause: a paused ExoPlayer holds a decoder, and on a panel with one hardware

--- a/android/app/src/test/java/com/remotedisplay/player/trigger/TriggerConfigNullTest.kt
+++ b/android/app/src/test/java/com/remotedisplay/player/trigger/TriggerConfigNullTest.kt
@@ -1,0 +1,100 @@
+package com.remotedisplay.player.trigger
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * ⚠️ org.json's optString RETURNS THE STRING "null" FOR A JSON null ON ANDROID.
+ *
+ * The server sends `secret: null`, `multicast_group: null` and `clear_all_token: null` whenever
+ * they are unset (ws/deviceSocket.js builds trigger_config with `|| null`). TriggerManager read
+ * them with `optString(...).takeIf { it.isNotEmpty() }`, which turns that JSON null into the
+ * four-letter string "null" and treats it as a configured value. Three live consequences:
+ *
+ *   1. multicast_group "null" -> InetAddress.getByName("null") threw and killed the WHOLE UDP
+ *      listener, so UDP triggers were inert on every device with no multicast group — the default.
+ *      Observed on real hardware: 'UDP listener failed: Unable to resolve host "null"'.
+ *   2. secret "null" -> TriggerResolve refuses a fire only when the device secret isNullOrEmpty(),
+ *      and "null" is neither, so a device with listeners enabled and NO secret set ACCEPTED
+ *      `ST1 null <token>` rather than refusing everything.
+ *   3. clear_all_token "null" -> the literal token "null" would clear every active trigger.
+ *
+ * ⚠️ AND THIS IS WHY THE SUITE WAS GREEN. The reference org.json used by JVM unit tests returns the
+ * FALLBACK for a JSON null; only Android's implementation returns "null". No test running here can
+ * reproduce the platform behaviour — so these assert the thing that IS provable on both: given the
+ * literal string "null", the parse must yield absence.
+ *
+ * The same trap already cost this project once, in the remote_url download path.
+ */
+class TriggerConfigNullTest {
+
+    /** Mirrors TriggerManager.optText — the rule under test. */
+    private fun optText(o: JSONObject?, key: String): String? {
+        if (o == null || o.isNull(key)) return null
+        val v = o.optString(key, "")
+        return if (v.isEmpty() || v == "null") null else v
+    }
+
+    @Test fun THE_BUG_the_string_null_is_treated_as_absent() {
+        // This is what Android's optString hands back for a JSON null.
+        val o = JSONObject("""{"secret":"null","multicast_group":"null","clear_all_token":"null"}""")
+        assertNull("a secret of \"null\" must not count as configured", optText(o, "secret"))
+        assertNull("a group of \"null\" is what killed the UDP listener", optText(o, "multicast_group"))
+        assertNull("a clear-all token of \"null\" would clear every trigger", optText(o, "clear_all_token"))
+    }
+
+    @Test fun a_real_JSON_null_is_absent() {
+        val o = JSONObject(); o.put("secret", JSONObject.NULL)
+        assertNull(optText(o, "secret"))
+    }
+
+    @Test fun a_missing_key_is_absent() {
+        assertNull(optText(JSONObject(), "secret"))
+        assertNull(optText(null, "secret"))
+    }
+
+    @Test fun an_empty_string_is_absent() {
+        assertNull(optText(JSONObject("""{"secret":""}"""), "secret"))
+    }
+
+    @Test fun a_REAL_value_still_survives() {
+        // The fix must not throw the baby out: a configured secret has to keep working.
+        val o = JSONObject("""{"secret":"798b015fd7dd3a8a90e7417fa2e51c51","multicast_group":"239.7.7.7"}""")
+        assertEquals("798b015fd7dd3a8a90e7417fa2e51c51", optText(o, "secret"))
+        assertEquals("239.7.7.7", optText(o, "multicast_group"))
+    }
+
+    @Test fun a_value_merely_CONTAINING_null_is_not_absent() {
+        // Only the exact string is the sentinel; "nullify" is a legitimate token.
+        assertEquals("nullify", optText(JSONObject("""{"t":"nullify"}"""), "t"))
+        assertEquals("null-ish", optText(JSONObject("""{"t":"null-ish"}"""), "t"))
+    }
+
+    /* ---- the security half: what the resolver does once the secret is absent ---- */
+
+    private fun alarm() = TriggerResolve.Trigger(
+        id = "t1", name = "alarm", matchToken = "ALARM1", clearToken = "CLEAR1",
+        sourceHttp = true, sourceUdp = true, mode = "until_cleared",
+        priority = 10, maxDurationSec = 60, leaseSec = 120, items = listOf(mapOf("content_id" to "c1"))
+    )
+
+    @Test fun AN_UNCONFIGURED_DEVICE_REFUSES_EVERY_FIRE() {
+        /*
+         * The invariant the "null" secret defeated. With no secret set, no payload may fire —
+         * including one that offers the string the bug produced.
+         */
+        for (deviceSecret in listOf(null, "")) {
+            val v = TriggerResolve.evaluate("ST1 null ALARM1", listOf(alarm()), deviceSecret, null, "udp")
+            assertFalse("an unconfigured device must refuse a fire (secret=$deviceSecret)", v.ok)
+        }
+    }
+
+    @Test fun a_configured_device_still_fires_on_the_right_secret() {
+        val v = TriggerResolve.evaluate("ST1 s3cret ALARM1", listOf(alarm()), "s3cret", null, "udp")
+        assertTrue("a correct secret must still fire", v.ok)
+    }
+}


### PR DESCRIPTION
Three defects, all found by firing a real trigger at a real Android device for the first time. Each is invisible to the test suite, and together they meant **LAN triggers had never once worked on an Android panel** — matching the "inert, and a black screen" report.

## 1. The overlay was built on a network thread

`TriggerListeners` reads its datagram or HTTP request on its own thread and calls straight through to `TriggerController.fire()` → `TriggerOverlay.show()`, which constructs Views and attaches them.

The failure mode was the worst kind — no crash, no log. `dumpsys` showed the box really *was* a child of the layer:

```
FrameLayout{...} 0,0-1920,1080  app:id/pipLayout
  FrameLayout{1ab98a2 V.E...... ......ID 0,0-0,0}   <- the trigger box
```

It never got a layout pass, so it measured **0×0**. The trigger "fired", the controller logged it, the lease ran, the state machine believed a screen was covered — and the panel carried on playing its playlist.

Every view touch now goes through the main-thread handler the class already had. The pure filtering stays on the calling thread, because the caller needs its boolean synchronously to decide whether the fire counts.

## 2. UDP was dead whenever no multicast group was set — the default

`org.json`'s `optString` returns the **string `"null"`** for a JSON null on Android, and the server sends `multicast_group: null` when unset. That string reached `InetAddress.getByName()` from *outside* `joinGroup`'s try, so it threw all the way out and killed the whole listener thread — including the unicast and broadcast paths that never needed a group at all.

Observed on hardware: `UDP listener failed: Unable to resolve host "null"`.

⚠️ **The same trap hits two neighbours, and one is security-relevant.** `secret: null` became the string `"null"` — and `TriggerResolve` refuses a fire only when the device secret `isNullOrEmpty()`, which `"null"` is not. **A device with listeners enabled and no secret set accepted `ST1 null <token>` instead of refusing everything.** `clear_all_token: null` likewise made the literal token `"null"` clear every active trigger.

All three now parse through one helper that treats the string as absence, and the listener treats the group as optional so a bad one can never cost the unicast/broadcast paths.

⚠️ **A JVM test cannot reproduce this.** The reference `org.json` returns the *fallback* for a JSON null; only Android's returns `"null"`. That is why the suite was green. The new tests assert what *is* provable on both — given the string, the parse must yield absence — plus the invariant the bug defeated: an unconfigured device refuses every fire.

This is the same trap that stranded fresh players once before, in the `remote_url` download path.

## 3. Trigger media was never pinned on Android

The comment at the adopt site says the media "is pinned by the same message that pins the base playlist". True for the **web** player, whose service worker gets trigger URLs appended by `device-triggers.js`. Android has no service worker: it downloads through `DownloadCoordinator`, driven by a loop over `assignments` **only**, and trigger items live in a separate array that never reached it.

So assigning a trigger to a device whose base playlist was unchanged downloaded nothing, and the fire rendered its black box with no media inside. Measured before the fix: fire accepted, screen black, `content_cache` holding only the base clips.

## Verified end to end on hardware

Against alpha, on an Android TV device:

* HTTP POST raw `ST1` line → **overlay on screen with its video playing**
* clear token → base playlist restored
* `GET /trigger?secret=…&token=…` (the only HTTP two major control platforms can emit) → overlay again
* the built-in UDP self-test reports **"this player receives its own group"**, proving the receive path

⚠️ An external UDP fire could not be staged: the emulator's NAT does not deliver the redirect. The self-test is the strongest evidence available here; a physical panel on a real LAN would close that gap.

Android suite **240 tests green** (+8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
