### PR TITLE
Let the server hold the LAN trigger door for players that cannot

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -23,6 +23,17 @@ function parseBillingRateTable(raw) {
 const { parseSize } = require('./lib/parse-size');
 
 module.exports = {
+  /*
+   * #trigger-ingress: let the SERVER hold the LAN trigger door open and forward what arrives to the
+   * addressed device. Off by default — opening an unauthenticated LAN port on the server is a
+   * different security posture from opening one on a panel, and must be a deliberate choice.
+   * Needed wherever a player cannot bind a socket itself (BrightSign's server-on-a-player widget
+   * has no Node), and useful where a control system can reach the server but not each screen.
+   */
+  triggerIngress: process.env.TRIGGER_INGRESS === '1' || process.env.TRIGGER_INGRESS === 'true',
+  /** UDP port for the server-side door. Only bound when triggerIngress is on. */
+  triggerIngressUdpPort: Number(process.env.TRIGGER_INGRESS_UDP_PORT || 7847),
+
   port: process.env.PORT || 3001,
   httpsPort: process.env.HTTPS_PORT || 3443,
   dataDir: DATA_DIR,

--- a/server/lib/trigger-ingress.js
+++ b/server/lib/trigger-ingress.js
@@ -1,0 +1,96 @@
+'use strict';
+
+/*
+ * Server-side LAN trigger ingress — the door for players that cannot open one themselves.
+ *
+ * ⚠️ WHY THIS EXISTS. Triggers are deliberately player-side: a datagram hits the panel directly, so
+ * an alarm works with the WAN down. That requires the player to bind a socket, which requires a
+ * Node context — and on BrightSign's server-on-a-player build the widget is created WITHOUT
+ * nodejs_enabled (brightsign/server/autorun.brs, and for good reasons documented there). The player
+ * runs in an iframe with no `require`, so `dgram` and raw `http` both throw and the listeners never
+ * start. Measured on an XT245: trigger ports closed, fires impossible, and nothing but an info-level
+ * log to say so. Enabling triggers on such a device did nothing at all.
+ *
+ * The server on that same box IS real Node. It can hold the door open and hand what arrives to the
+ * player over the socket they already share. On a server-on-a-player that keeps the offline
+ * guarantee completely intact — server and player are the same board, so there is no network
+ * between them to lose. It also helps any site where the control system can reach the server but
+ * not each panel.
+ *
+ * ⚠️ THE PLAYER STILL DECIDES. This module resolves only WHICH DEVICE a payload is addressed to,
+ * by its secret, and forwards the wire text verbatim. The accept/reject decision stays in the one
+ * resolver both sides already share, so there is no second implementation of "may this fire" to
+ * drift from the first. That is the same "one decision, two doors" rule trigger-resolve.js states —
+ * this is simply a third door onto the same decision.
+ *
+ * ⚠️ AND IT IS OFF UNLESS ASKED FOR. Opening an unauthenticated LAN port on the SERVER is a
+ * different security posture from opening one on a panel, so it is opt-in per instance and still
+ * gated per device by the same accept_http / accept_udp flags an operator already sets.
+ */
+
+const TR = require('./trigger-resolve');
+
+/**
+ * Which device is this payload for?
+ *
+ * @param {string} text      the raw wire line (`ST1 <secret> <token>`)
+ * @param {Array}  devices   rows with { id, trigger_secret, triggers_accept_http, triggers_accept_udp }
+ * @param {string} source    'http' | 'udp'
+ * @returns {{ok: true, deviceId: string} | {ok: false, reason: string}}
+ */
+function resolveTarget(text, devices, source) {
+  const parsed = TR.parseWire(text);
+  if (!parsed.ok) return { ok: false, reason: parsed.reason || 'malformed' };
+
+  /*
+   * ⚠️ EVERY CANDIDATE IS COMPARED, AND THE LOOP DOES NOT BREAK EARLY.
+   *
+   * Returning as soon as a secret matches makes the reply time depend on where the device sits in
+   * the list, which leaks list position to anyone who can time it. The comparison itself is already
+   * constant-time (TR.secretMatches); finishing the sweep keeps the whole operation that way. A
+   * fleet is small enough that the cost is nothing.
+   */
+  let hit = null;
+  for (const d of devices || []) {
+    if (!d || !d.trigger_secret) continue;
+    const accepts = source === 'udp' ? d.triggers_accept_udp : d.triggers_accept_http;
+    if (!accepts) continue;
+    if (TR.secretMatches(parsed.secret, String(d.trigger_secret))) {
+      if (!hit) hit = d.id;
+    }
+  }
+
+  /*
+   * ⚠️ ONE REJECTION REASON FOR "no such device". Distinguishing "no device has that secret" from
+   * "that device does not accept this transport" would turn the door into an oracle for enumerating
+   * both secrets and configuration. The caller answers identically either way.
+   */
+  if (!hit) return { ok: false, reason: 'bad_secret' };
+  return { ok: true, deviceId: hit };
+}
+
+/**
+ * Accept the shapes a control system can actually emit.
+ *
+ * ⚠️ THE SAME FOUR AS THE PLAYER'S OWN DOOR (docs/triggers-design.md §11), because an integrator
+ * should not have to know which kind of box is behind the address. AMX cannot set a header;
+ * Extron's Global Scripter cannot open a socket at all but can build a URL. A POST-JSON-only
+ * endpoint is unreachable from both.
+ */
+function extractWire(req) {
+  const q = req.query || {};
+  if (typeof q.m === 'string' && q.m) return q.m;
+  if (typeof q.secret === 'string' && typeof q.token === 'string') {
+    return `${TR.MAGIC} ${q.secret} ${q.token}`;
+  }
+  const b = req.body;
+  if (typeof b === 'string' && b.trim()) return b;
+  if (b && typeof b === 'object') {
+    if (typeof b.secret === 'string' && typeof b.token === 'string') {
+      return `${TR.MAGIC} ${b.secret} ${b.token}`;
+    }
+  }
+  return '';
+}
+
+module.exports = { resolveTarget, extractWire };

--- a/server/player/index.html
+++ b/server/player/index.html
@@ -2008,6 +2008,27 @@
         console.log('[play] backfill ack:', JSON.stringify(d));
       });
 
+      /*
+       * #trigger-ingress: a fire the SERVER accepted on our behalf.
+       *
+       * ⚠️ FOR PLAYERS THAT CANNOT OPEN THEIR OWN DOOR. BrightSign's server-on-a-player widget has
+       * no Node, so `require('dgram')` and `require('http')` both throw here and the listeners
+       * never bind — enabling triggers on such a device did nothing at all. The server on that same
+       * board holds the door and hands the wire text over this socket instead.
+       *
+       * ⚠️ IT IS RE-EVALUATED HERE, NOT TRUSTED. The server resolved only WHICH device the payload
+       * was addressed to; whether it may fire is decided by the same resolver a datagram would have
+       * gone through, with this device's own secret. One decision, now three doors.
+       */
+      socket.on('device:trigger-wire', (d) => {
+        try {
+          if (!d || typeof d.text !== 'string') return;
+          handleTrigger({ text: wireClean(d.text), source: d.source || 'server', sourceIp: d.sourceIp || 'server' });
+        } catch (e) {
+          triggerLog('warn', 'server-delivered trigger failed: ' + ((e && e.message) || e));
+        }
+      });
+
       socket.on('device:registered', (data) => {
         config.deviceId = data.device_id;
         if (data.device_token) config.deviceToken = data.device_token;

--- a/server/server.js
+++ b/server/server.js
@@ -589,6 +589,112 @@ app.get('/player/trigger-resolve.js', (req, res) => {
   res.sendFile(path.join(__dirname, 'lib', 'trigger-resolve.js'));
 });
 
+/*
+ * #trigger-ingress: the SERVER-side LAN trigger door.
+ *
+ * ⚠️ THIS EXISTS BECAUSE SOME PLAYERS CANNOT OPEN ONE. BrightSign's server-on-a-player build creates
+ * its widget without nodejs_enabled (deliberately — see brightsign/server/autorun.brs), so the
+ * player has no `require`, `dgram` and raw `http` both throw, and the trigger listeners never bind.
+ * Measured on an XT245: every trigger port closed, so enabling triggers did precisely nothing. The
+ * server on that same board is real Node and can hold the door instead.
+ *
+ * ⚠️ THE PLAYER STILL DECIDES. This resolves only WHICH device the payload is addressed to (by its
+ * secret) and forwards the wire text verbatim, so accept/reject stays in the single shared resolver
+ * rather than being reimplemented here and drifting.
+ *
+ * Unauthenticated by design, exactly like the player's own door: the wire carries no URL, no
+ * duration and no position, so the worst an attacker with a guessed token can do is show content an
+ * operator already configured for that screen. It is off unless TRIGGER_INGRESS is set.
+ */
+if (config.triggerIngress) {
+  const triggerIngress = require('./lib/trigger-ingress');
+  const TRcore = require('./lib/trigger-resolve');
+  // ⚠️ Required here, not assumed. server.js has no module-level `db`; every other consumer pulls
+  // it in locally, and referencing a bare `db` threw a ReferenceError inside the UDP message
+  // handler — where an uncaught throw takes the process with it.
+  const { db: triggerDb } = require('./db/database');
+  // Same shape as the player's: per source IP, so one noisy controller cannot drown the others.
+  const ingressLimiter = TRcore.createRateLimiter ? TRcore.createRateLimiter() : null;
+
+  const handleIngress = (req, res, source) => {
+    const ip = req.ip || (req.socket && req.socket.remoteAddress) || 'unknown';
+    if (ingressLimiter && !ingressLimiter.allow(ip, Date.now())) {
+      // Newline-terminated: Extron reads until a known suffix and otherwise blocks until timeout.
+      return res.status(429).type('text/plain').send('rate_limited\n');
+    }
+    const text = triggerIngress.extractWire(req);
+    const devices = triggerDb.prepare(
+      'SELECT id, trigger_secret, triggers_accept_http, triggers_accept_udp FROM devices WHERE trigger_secret IS NOT NULL'
+    ).all();
+    const target = triggerIngress.resolveTarget(text, devices, source);
+    if (!target.ok) {
+      return res.status(403).type('text/plain').send(target.reason + '\n');
+    }
+    const deviceNs = app.get('io') && app.get('io').of('/device');
+    const room = deviceNs && deviceNs.adapter.rooms.get(target.deviceId);
+    if (!room || room.size === 0) {
+      return res.status(503).type('text/plain').send('device_offline\n');
+    }
+    deviceNs.to(target.deviceId).emit('device:trigger-wire', { text, source, sourceIp: ip });
+    return res.type('text/plain').send('ok\n');
+  };
+
+  // The same four shapes the player's door accepts (docs/triggers-design.md §11) — a control system
+  // should not have to know which kind of box is behind the address.
+  app.post('/api/trigger', express.text({ type: '*/*', limit: '2kb' }), (req, res) => handleIngress(req, res, 'http'));
+  app.get('/api/trigger', (req, res) => handleIngress(req, res, 'http'));
+
+  /*
+   * The UDP half. A datagram is what most AV control systems actually emit — Extron's ControlScript
+   * truncates at 1024 bytes and delivers at most that per receive event, which is where the cap
+   * below comes from (it is their limit, not ours).
+   *
+   * ⚠️ A FAILURE TO BIND MUST NOT TAKE THE SERVER DOWN. This runs at boot on a signage box whose
+   * only job is showing content; a port already in use is a reason for triggers not to work, never
+   * a reason for the screens to go dark.
+   */
+  try {
+    const dgram = require('dgram');
+    const sock = dgram.createSocket({ type: 'udp4', reuseAddr: true });
+    sock.on('error', (err) => {
+      console.warn('[trigger-ingress] UDP listener error:', err.message);
+      try { sock.close(); } catch (e) { /* already gone */ }
+    });
+    sock.on('message', (buf, rinfo) => {
+     /*
+      * ⚠️ WRAPPED. This is a socket callback: an uncaught throw here is an uncaughtException that
+      * takes the whole server down, and a signage server dying means every screen it feeds stops.
+      * A malformed datagram from the LAN must never be able to do that.
+      */
+     try {
+      const ip = (rinfo && rinfo.address) || 'unknown';
+      if (ingressLimiter && !ingressLimiter.allow(ip, Date.now())) return;
+      const text = buf.toString('utf8', 0, Math.min(buf.length, 1024));
+      const devices = triggerDb.prepare(
+        'SELECT id, trigger_secret, triggers_accept_http, triggers_accept_udp FROM devices WHERE trigger_secret IS NOT NULL'
+      ).all();
+      const target = triggerIngress.resolveTarget(text, devices, 'udp');
+      // ⚠️ Silent on rejection. A datagram door on a LAN sees every stray broadcast; answering
+      // would both amplify traffic and tell a prober which guesses were closer.
+      if (!target.ok) return;
+      const deviceNs = app.get('io') && app.get('io').of('/device');
+      const room = deviceNs && deviceNs.adapter.rooms.get(target.deviceId);
+      if (!room || room.size === 0) return;
+      deviceNs.to(target.deviceId).emit('device:trigger-wire', { text, source: 'udp', sourceIp: ip });
+      console.log('[trigger-ingress] udp fire -> ' + target.deviceId + ' from ' + ip);
+     } catch (e) {
+      console.warn('[trigger-ingress] udp handler:', e.message);
+     }
+    });
+    sock.bind(config.triggerIngressUdpPort, () => {
+      console.log('[trigger-ingress] UDP door on :' + config.triggerIngressUdpPort);
+      try { sock.unref(); } catch (e) { /* keep going */ }
+    });
+  } catch (e) {
+    console.warn('[trigger-ingress] UDP unavailable:', e.message);
+  }
+}
+
 app.get('/player/media-mute.js', (req, res) => {
   res.type('application/javascript').setHeader('Cache-Control', 'no-cache');
   res.sendFile(path.join(__dirname, 'lib', 'media-mute.js'));

--- a/server/test/trigger-ingress.test.js
+++ b/server/test/trigger-ingress.test.js
@@ -1,0 +1,128 @@
+'use strict';
+
+/*
+ * The SERVER-side LAN trigger door.
+ *
+ * ⚠️ WHY IT EXISTS. Triggers are player-side by design so an alarm survives the WAN being down —
+ * but that needs the player to bind a socket, which needs a Node context. BrightSign's
+ * server-on-a-player build creates its widget WITHOUT nodejs_enabled (deliberately: a Node-enabled
+ * widget "is NOT Node" and hosting the server there cost four boot failures), so the player runs in
+ * an iframe with no `require`. `dgram` and raw `http` both throw and the listeners never start.
+ * Measured on a real XT245: trigger ports 7847/8079/8099 all closed, so enabling triggers on that
+ * box did nothing whatsoever. The server on the same board is real Node and can hold the door.
+ *
+ * ⚠️ THIS MODULE DECIDES ONLY *WHICH DEVICE*, never whether a fire is allowed. That stays in the one
+ * resolver both sides already share, so there is no second copy of "may this fire" to drift from
+ * the first — the "one decision, N doors" rule trigger-resolve.js states.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { resolveTarget, extractWire } = require('../lib/trigger-ingress');
+
+const SECRET_A = 'a'.repeat(32);
+const SECRET_B = 'b'.repeat(32);
+
+const devices = [
+  { id: 'dev-a', trigger_secret: SECRET_A, triggers_accept_http: 1, triggers_accept_udp: 1 },
+  { id: 'dev-b', trigger_secret: SECRET_B, triggers_accept_http: 1, triggers_accept_udp: 0 },
+  { id: 'dev-none', trigger_secret: null, triggers_accept_http: 1, triggers_accept_udp: 1 },
+];
+
+const wire = (secret, token = 'ALARM1') => `ST1 ${secret} ${token}`;
+
+/* ============================================================ addressing */
+
+test('THE POINT: a payload is routed to the device whose secret it carries', () => {
+  const r = resolveTarget(wire(SECRET_A), devices, 'udp');
+  assert.equal(r.ok, true);
+  assert.equal(r.deviceId, 'dev-a');
+});
+
+test('a different secret reaches a different device', () => {
+  const r = resolveTarget(wire(SECRET_B), devices, 'http');
+  assert.equal(r.deviceId, 'dev-b');
+});
+
+test('⚠️ the per-device transport flag still gates it', () => {
+  // dev-b accepts http but NOT udp. The server door must not become a way around a setting an
+  // operator deliberately turned off on the panel.
+  assert.equal(resolveTarget(wire(SECRET_B), devices, 'http').ok, true);
+  assert.equal(resolveTarget(wire(SECRET_B), devices, 'udp').ok, false);
+});
+
+test('a device with no secret can never be addressed', () => {
+  // The unconfigured-device invariant: no secret means no fire, by any door.
+  assert.equal(resolveTarget(wire(''), devices, 'udp').ok, false);
+  assert.equal(resolveTarget('ST1 null ALARM1', devices, 'udp').ok, false);
+});
+
+test('an unknown secret is refused', () => {
+  assert.equal(resolveTarget(wire('z'.repeat(32)), devices, 'udp').ok, false);
+});
+
+test('⚠️ "no such device" and "wrong transport" answer identically', () => {
+  /*
+   * Distinguishing them would turn the door into an oracle for enumerating both secrets and
+   * per-device configuration — from an unauthenticated LAN port.
+   */
+  const unknown = resolveTarget(wire('z'.repeat(32)), devices, 'udp');
+  const wrongTransport = resolveTarget(wire(SECRET_B), devices, 'udp');
+  assert.equal(unknown.reason, wrongTransport.reason);
+});
+
+test('junk in never throws', () => {
+  for (const bad of [null, undefined, '', 'nonsense', 'ST1', 'ST1 only-two', 'X1 a b', 42, {}]) {
+    assert.doesNotThrow(() => resolveTarget(bad, devices, 'udp'));
+    assert.equal(resolveTarget(bad, devices, 'udp').ok, false);
+  }
+  assert.doesNotThrow(() => resolveTarget(wire(SECRET_A), null, 'udp'));
+  assert.doesNotThrow(() => resolveTarget(wire(SECRET_A), [null, {}, { id: 'x' }], 'udp'));
+});
+
+test('a malformed wire is refused before any secret is compared', () => {
+  const r = resolveTarget('GARBAGE', devices, 'udp');
+  assert.equal(r.ok, false);
+  assert.notEqual(r.reason, undefined);
+});
+
+test('⚠️ the sweep does not stop at the first match', () => {
+  /*
+   * Returning early makes the reply time depend on the device's position in the list, which leaks
+   * that position to anyone who can time it. This asserts the property structurally — the source
+   * must not break out of the loop — because timing cannot be asserted reliably in a unit test.
+   */
+  const src = require('fs').readFileSync(require.resolve('../lib/trigger-ingress.js'), 'utf8');
+  const loop = src.slice(src.indexOf('for (const d of devices'), src.indexOf('if (!hit) return'));
+  assert.ok(!/\bbreak\b/.test(loop), 'the candidate sweep must not break early');
+  assert.ok(/secretMatches/.test(loop), 'the compare must go through the constant-time helper');
+});
+
+/* ============================================================ the four wire shapes */
+
+test('⚠️ all four shapes a control system can actually emit are accepted', () => {
+  /*
+   * AMX has no HTTP client and hand-builds requests; Extron's Global Scripter forbids the socket
+   * and http modules outright but can build a URL. A POST-JSON-only door is unreachable from both,
+   * which is why the player's door takes all of these — and why this one must match it.
+   */
+  const expected = `ST1 ${SECRET_A} ALARM1`;
+  assert.equal(extractWire({ body: expected }), expected, 'raw text/plain line');
+  assert.equal(extractWire({ body: { secret: SECRET_A, token: 'ALARM1' } }), expected, 'JSON envelope');
+  assert.equal(extractWire({ query: { secret: SECRET_A, token: 'ALARM1' } }), expected, 'GET query params');
+  assert.equal(extractWire({ query: { m: expected } }), expected, 'GET whole raw line');
+});
+
+test('a request carrying nothing usable yields an empty wire, not a throw', () => {
+  for (const req of [{}, { body: undefined }, { body: {} }, { query: {} }, { body: 42 }, { query: { secret: 'x' } }]) {
+    assert.doesNotThrow(() => extractWire(req));
+    assert.equal(resolveTarget(extractWire(req), devices, 'http').ok, false);
+  }
+});
+
+test('the query form round-trips into a real addressing decision', () => {
+  // End to end through both halves: what a URL-only control system sends must reach the right device.
+  const text = extractWire({ query: { secret: SECRET_A, token: 'ALARM1' } });
+  assert.equal(resolveTarget(text, devices, 'http').deviceId, 'dev-a');
+});


### PR DESCRIPTION
Triggers are player-side by design, so an alarm survives the WAN going down. That requires the player to **bind a socket**, which requires a Node context — and some players simply do not have one.

## The gap, measured on real hardware

BrightSign's server-on-a-player build creates its widget **without** `nodejs_enabled`. That is deliberate and well argued in `brightsign/server/autorun.brs`: a Node-enabled widget "is NOT Node", and hosting the server there cost four boot failures and risked an open SQLite WAL on every teardown. But the consequence was never followed through — the player runs in an iframe with no `require`, so `require('dgram')` and `require('http')` both throw and the trigger listeners never bind.

Confirmed on an XT245 running beta5:

```
tcp 8079: closed      tcp 7847: closed      tcp 8099: closed
```

Enabling triggers on that box did **nothing at all**, and said so only at info level.

Tizen is worse off for the same reason, and `capabilities.js` already says so honestly: a Tizen web app has no raw socket and no way to accept an inbound connection, so it refuses to declare `trigger.http`/`trigger.udp`.

## The fix

The server on that same board **is** real Node. It holds the door and hands what arrives to the player over the socket they already share. On a server-on-a-player this keeps the offline guarantee completely intact — server and player are the same hardware, so there is no network between them to lose. It also helps any site where the control system can reach the server but not each panel.

* ⚠️ **The player still decides.** This resolves only *which device* a payload is addressed to, by its secret, and forwards the wire text verbatim. Accept/reject stays in the one resolver both sides already share — the "one decision, N doors" rule `trigger-resolve.js` states.
* ⚠️ **The secret sweep does not break early.** Returning at the first match makes reply time depend on the device's position in the list, leaking it to anyone who can time it. The compare is already constant-time; finishing the sweep keeps the whole operation that way.
* ⚠️ **"No such device" and "wrong transport" answer identically**, so an unauthenticated LAN port cannot be used to enumerate secrets *or* per-device configuration.
* **Off unless `TRIGGER_INGRESS=1`** — opening an unauthenticated LAN port on the *server* is a different security posture from opening one on a panel — and still gated per device by the same `accept_http`/`accept_udp` flags an operator already sets.
* The UDP handler is wrapped: a socket callback that throws is an `uncaughtException`, and a signage server dying takes every screen it feeds with it.

All four wire shapes the player's own door accepts are accepted here too, because an integrator should not have to know which kind of box is behind the address (AMX cannot set a header; Extron's Global Scripter cannot open a socket at all but can build a URL).

## Verified end to end

Against a web player with **no listeners of its own** — the BrightSign topology exactly:

| | result |
|---|---|
| UDP datagram → server `:7848` | overlay on screen, video playing |
| UDP clear | overlay gone (`triggerBox: false`) |
| `GET /api/trigger?secret=…&token=…` | `ok` |
| raw `ST1` POST | `ok` |
| bad secret | `bad_secret` |

Server suite **2764 tests**, only the 3 known multicast/IGMP failures that need a real network interface — they pass 12/12 unsandboxed and fail identically on `main`. 12 new tests.

## Still open, deliberately not in this PR

Tizen has no trigger **rendering** at all, so the ingress alone will not help it — that needs a renderer, scoped separately. And this is not yet proven on the XT245 itself, because the box runs beta5 and this code is newer; that comes with the next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
