### PR TITLE
Capture the screen from the server on a BrightSign server-on-a-player

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -23,6 +23,17 @@ function parseBillingRateTable(raw) {
 const { parseSize } = require('./lib/parse-size');
 
 module.exports = {
+  /*
+   * #trigger-ingress: let the SERVER hold the LAN trigger door open and forward what arrives to the
+   * addressed device. Off by default — opening an unauthenticated LAN port on the server is a
+   * different security posture from opening one on a panel, and must be a deliberate choice.
+   * Needed wherever a player cannot bind a socket itself (BrightSign's server-on-a-player widget
+   * has no Node), and useful where a control system can reach the server but not each screen.
+   */
+  triggerIngress: process.env.TRIGGER_INGRESS === '1' || process.env.TRIGGER_INGRESS === 'true',
+  /** UDP port for the server-side door. Only bound when triggerIngress is on. */
+  triggerIngressUdpPort: Number(process.env.TRIGGER_INGRESS_UDP_PORT || 7847),
+
   port: process.env.PORT || 3001,
   httpsPort: process.env.HTTPS_PORT || 3443,
   dataDir: DATA_DIR,

--- a/server/lib/brightsign-capture.js
+++ b/server/lib/brightsign-capture.js
@@ -1,0 +1,126 @@
+'use strict';
+
+/*
+ * Framebuffer capture from the SERVER's own Node process, for a BrightSign running
+ * server-on-a-player.
+ *
+ * ⚠️ WHY THE EXISTING PATHS DO NOT COVER THIS BOX.
+ *
+ * Every other player is told to capture over its device socket and the page captures itself. A
+ * BrightSign page cannot: with hwz enabled the video decodes onto a hardware plane the DOM cannot
+ * read, so drawImage() returns a frame with the content missing and throws nothing. st-bridge.js
+ * therefore uses BrightSign's own `@brightsign/screenshot`, which composites both planes — and that
+ * needs the Node `require` a widget only has when it was created with nodejs_enabled.
+ *
+ * The server-on-a-player build creates its widget WITHOUT nodejs_enabled (deliberately — see
+ * brightsign/server/autorun.brs). So on that box the page-side capture cannot work, and the
+ * host-collected fallback in lib/brightsign-snapshot-queue.js has nothing collecting it either:
+ * brightsign/server/autorun.brs contains no snapshot code at all, unlike the player autorun which
+ * has the full implementation. Measured: screenshots simply do not work on that shape, by either
+ * route.
+ *
+ * ⚠️ BUT THE SERVER THERE IS REAL NODE. It runs under roNodeJs, so `@brightsign/screenshot` is an
+ * ordinary import for it — no DWS, no digest auth, no credentials to discover, no page-to-host
+ * messaging (which is dead after load on this platform anyway). The same module the widget uses,
+ * required from the process that actually has a working `require`.
+ *
+ * Everything here degrades to null rather than throwing: this is loaded by a server that must keep
+ * serving screens on hardware where none of it exists.
+ */
+
+/** Volumes to write the capture into, RAM first. */
+const CANDIDATE_DIRS = ['/storage/tmp', '/tmp', '/storage/ssd', '/storage/usb1', '/storage/sd', '/storage/flash'];
+
+function tryRequire(name) {
+  try { return require(name); } catch (e) { return null; }
+}
+
+/** Is this process running on a BrightSign with the capture API available? */
+function available() {
+  return !!(tryRequire('@brightsign/screenshot') && tryRequire('fs'));
+}
+
+/**
+ * Where to write. RAM first, deliberately: the remote-control view drives a capture roughly once a
+ * second, and a screenshot per second written to boot flash is a wear-out mechanism with no upside —
+ * the file is read back and deleted immediately, so it never needs to be durable. The directory
+ * must already exist or the capture fails, so each candidate is checked rather than assumed.
+ */
+function pickDir(fs) {
+  for (const d of CANDIDATE_DIRS) {
+    try { if (fs.existsSync(d)) return d; } catch (e) { /* keep looking */ }
+  }
+  return null;
+}
+
+/*
+ * ⚠️ A UNIQUE FILENAME PER CAPTURE, NOT A FIXED ONE.
+ *
+ * st-bridge.js writes to a fixed `st-capture.jpg`. Two captures in flight — trivially reachable
+ * from the remote-control view at one per second, or from two operators watching the same screen —
+ * have one unlinking and rewriting the file the other is about to read. The reader either gets
+ * ENOENT or, worse, the OTHER request's frame, which is a picture of the right screen at the wrong
+ * moment and looks entirely plausible. A per-call name removes the race rather than narrowing it.
+ */
+let seq = 0;
+function captureName(nowMs) {
+  seq = (seq + 1) % 100000;
+  return `st-capture-${nowMs}-${seq}.jpg`;
+}
+
+/**
+ * Capture the composited screen and return it as base64 JPEG, or null if this platform cannot.
+ *
+ * @param {object} opts { width, height, quality }
+ * @returns {Promise<string|null>}
+ */
+function capture(opts) {
+  const o = opts || {};
+  return new Promise((resolve) => {
+    const ScreenshotClass = tryRequire('@brightsign/screenshot');
+    const fs = tryRequire('fs');
+    if (!ScreenshotClass || !fs) return resolve(null);
+
+    const dir = pickDir(fs);
+    if (!dir) return resolve(null);
+
+    const file = `${dir}/${captureName(Date.now())}`;
+    const params = {
+      destinationFileName: file,
+      fileName: file,                 // deprecated alias, still honoured on older firmware
+      fileType: 'JPEG',
+      width: o.width || 960,
+      height: o.height || 540,
+      quality: o.quality || 70,
+      rotation: 0,
+    };
+
+    /*
+     * ⚠️ ALWAYS CLEANS UP. A capture that fails part-way still leaves a file behind, and this path
+     * runs once a second while somebody watches a screen. On a RAM volume that is a slow leak
+     * toward a full /tmp, which breaks far more than screenshots.
+     */
+    const done = (value) => {
+      try { fs.unlinkSync(file); } catch (e) { /* never written, or already gone */ }
+      resolve(value);
+    };
+
+    try {
+      const shot = new ScreenshotClass();
+      Promise.resolve(shot.capture(params))
+        .then(() => {
+          try {
+            if (!fs.existsSync(file)) return done(null);
+            const buf = fs.readFileSync(file);
+            if (!buf || buf.length < 100) return done(null);
+            done(buf.toString('base64'));
+          } catch (e) { done(null); }
+        })
+        .catch(() => done(null));
+    } catch (e) {
+      done(null);
+    }
+  });
+}
+
+module.exports = { available, capture, pickDir, captureName, CANDIDATE_DIRS };

--- a/server/lib/brightsign-capture.js
+++ b/server/lib/brightsign-capture.js
@@ -29,15 +29,45 @@
  */
 
 /** Volumes to write the capture into, RAM first. */
+/** How long to wait for the capture file to appear, and how often to look. */
+const CAPTURE_TIMEOUT_MS = 8000;
+const CAPTURE_POLL_MS = 120;
+
 const CANDIDATE_DIRS = ['/storage/tmp', '/tmp', '/storage/ssd', '/storage/usb1', '/storage/sd', '/storage/flash'];
 
 function tryRequire(name) {
   try { return require(name); } catch (e) { return null; }
 }
 
-/** Is this process running on a BrightSign with the capture API available? */
+/*
+ * ⚠️ SAYS SO ONCE, OUT LOUD. The first version logged nothing when the module was absent, so a
+ * capture that never happened was indistinguishable from one that failed — and working out which
+ * cost a patch-and-reboot cycle on real hardware. One line at first use is the whole difference.
+ */
+let announced = false;
+
+/** Is this process running somewhere the capture API actually exists? */
 function available() {
-  return !!(tryRequire('@brightsign/screenshot') && tryRequire('fs'));
+  const ok = !!(tryRequire('@brightsign/screenshot') && tryRequire('fs'));
+  if (!announced) {
+    announced = true;
+    console.log('[bs-capture] @brightsign/screenshot ' + (ok ? 'available in this process' : 'NOT available in this process'));
+  }
+  return ok;
+}
+
+/**
+ * Is this address the same machine?
+ *
+ * ⚠️ THE ONLY HONEST TEST FOR "this device is on this board". We capture OUR framebuffer, so
+ * sending it for a device elsewhere would be a picture of the wrong screen, convincingly labelled.
+ * The device's self-reported platform cannot decide this — a BrightSign reports "Chrome 148",
+ * because the player is a Chromium widget — and that mistake is exactly why the pre-existing
+ * BrightSign screenshot branch never once ran on real hardware.
+ */
+function isLoopback(ip) {
+  const v = String(ip || '').trim().toLowerCase();
+  return v === '127.0.0.1' || v === '::1' || v === '::ffff:127.0.0.1' || v === 'localhost';
 }
 
 /**
@@ -85,6 +115,8 @@ function capture(opts) {
     if (!dir) return resolve(null);
 
     const file = `${dir}/${captureName(Date.now())}`;
+    let shot0;
+    try { shot0 = new ScreenshotClass(); } catch (e) { return resolve(null); }
     const params = {
       destinationFileName: file,
       fileName: file,                 // deprecated alias, still honoured on older firmware
@@ -105,22 +137,101 @@ function capture(opts) {
       resolve(value);
     };
 
+    /*
+     * ⚠️ THE METHOD IS syncCapture / asyncCapture — THERE IS NO `capture`.
+     *
+     * Enumerated on a live XT245 (OS 10.0.16): the instance offers callback, syncCapture,
+     * asyncCapture, addEventListener, removeEventListener and toJSON, while its prototype carries
+     * only `constructor`. The first version of this file called `shot.capture(params)` and failed
+     * on hardware with "shot.capture is not a function" — st-bridge.js had it right all along, and
+     * this is simply the same resolution as its page-side path.
+     *
+     * asyncCapture first: it does not block the event loop of a server that is also feeding screens.
+     * syncCapture next (it interrupts on-screen operations, which is why it is not the default),
+     * and `capture` last in case a future firmware adds that name.
+     */
+    const method = typeof shot0.asyncCapture === 'function' ? 'asyncCapture'
+      : typeof shot0.syncCapture === 'function' ? 'syncCapture'
+      : typeof shot0.capture === 'function' ? 'capture'
+      : null;
+    if (!method) return done(null);
+
+    /*
+     * ⚠️ POLL FOR THE FILE; DO NOT TRUST THE RETURN VALUE. sync and async differ in what they hand
+     * back, and the documented contract is "a file appears", not "a promise settles" — st-bridge.js
+     * reached the same conclusion on the page side. Awaiting the return happened to work in a probe
+     * here, which is exactly the kind of accident that turns into an intermittent empty screenshot
+     * on somebody else's firmware.
+     */
     try {
-      const shot = new ScreenshotClass();
-      Promise.resolve(shot.capture(params))
-        .then(() => {
-          try {
-            if (!fs.existsSync(file)) return done(null);
-            const buf = fs.readFileSync(file);
-            if (!buf || buf.length < 100) return done(null);
-            done(buf.toString('base64'));
-          } catch (e) { done(null); }
-        })
-        .catch(() => done(null));
+      shot0[method](params);
     } catch (e) {
-      done(null);
+      return done(null);
     }
+
+    const deadline = Date.now() + CAPTURE_TIMEOUT_MS;
+    const tick = () => {
+      let st = null;
+      try { st = fs.statSync(file); } catch (e) { st = null; }
+      if (st && st.size > 512) {
+        try {
+          const buf = fs.readFileSync(file);
+          return done(buf && buf.length >= 100 ? buf.toString('base64') : null);
+        } catch (e) { return done(null); }
+      }
+      if (Date.now() > deadline) return done(null);
+      setTimeout(tick, CAPTURE_POLL_MS);
+    };
+    setTimeout(tick, CAPTURE_POLL_MS);
   });
 }
 
-module.exports = { available, capture, pickDir, captureName, CANDIDATE_DIRS };
+/**
+ * Diagnose the capture path stage by stage.
+ *
+ * ⚠️ WRITTEN BECAUSE A SILENT NULL COST TWO REBOOT CYCLES. capture() answers null for six different
+ * reasons — no module, no fs, no writable volume, the API threw, no file appeared, the file was
+ * empty — and on hardware they are indistinguishable from each other and from "the gate never let
+ * it run". This reports which, and nothing here returns image bytes, so it is safe to read from a
+ * diagnostic endpoint.
+ */
+async function probe(opts) {
+  const out = { module: false, fs: false, dir: null, called: false, wrote: false, bytes: 0, error: null, api: null };
+  const ScreenshotClass = tryRequire('@brightsign/screenshot');
+  const fs = tryRequire('fs');
+  out.module = !!ScreenshotClass;
+  out.fs = !!fs;
+  if (!ScreenshotClass || !fs) return out;
+  try {
+    // What shape is it? A class, a factory, or an object with a method — the docs 404 and the
+    // page-side caller has never been proven to run, so the shape is genuinely unknown here.
+    out.api = { type: typeof ScreenshotClass, keys: Object.keys(ScreenshotClass || {}).slice(0, 8),
+                proto: Object.getOwnPropertyNames((ScreenshotClass && ScreenshotClass.prototype) || {}).slice(0, 12) };
+  } catch (e) { /* introspection is best-effort */ }
+  const dir = pickDir(fs);
+  out.dir = dir;
+  if (!dir) return out;
+  const file = `${dir}/${captureName(Date.now())}`;
+  try {
+    const shot = new ScreenshotClass();
+    out.method = typeof shot.asyncCapture === 'function' ? 'asyncCapture'
+      : typeof shot.syncCapture === 'function' ? 'syncCapture'
+      : typeof shot.capture === 'function' ? 'capture' : null;
+    out.called = true;
+    if (!out.method) return out;
+    await Promise.resolve(shot[out.method]({
+      destinationFileName: file, fileName: file, fileType: 'JPEG',
+      width: (opts && opts.width) || 960, height: (opts && opts.height) || 540,
+      quality: 70, rotation: 0,
+    }));
+    out.wrote = fs.existsSync(file);
+    if (out.wrote) out.bytes = fs.statSync(file).size;
+  } catch (e) {
+    out.error = String((e && e.message) || e);
+  } finally {
+    try { fs.unlinkSync(file); } catch (e) { /* nothing to clean */ }
+  }
+  return out;
+}
+
+module.exports = { available, capture, probe, pickDir, captureName, isLoopback, CANDIDATE_DIRS };

--- a/server/lib/trigger-ingress.js
+++ b/server/lib/trigger-ingress.js
@@ -1,0 +1,96 @@
+'use strict';
+
+/*
+ * Server-side LAN trigger ingress — the door for players that cannot open one themselves.
+ *
+ * ⚠️ WHY THIS EXISTS. Triggers are deliberately player-side: a datagram hits the panel directly, so
+ * an alarm works with the WAN down. That requires the player to bind a socket, which requires a
+ * Node context — and on BrightSign's server-on-a-player build the widget is created WITHOUT
+ * nodejs_enabled (brightsign/server/autorun.brs, and for good reasons documented there). The player
+ * runs in an iframe with no `require`, so `dgram` and raw `http` both throw and the listeners never
+ * start. Measured on an XT245: trigger ports closed, fires impossible, and nothing but an info-level
+ * log to say so. Enabling triggers on such a device did nothing at all.
+ *
+ * The server on that same box IS real Node. It can hold the door open and hand what arrives to the
+ * player over the socket they already share. On a server-on-a-player that keeps the offline
+ * guarantee completely intact — server and player are the same board, so there is no network
+ * between them to lose. It also helps any site where the control system can reach the server but
+ * not each panel.
+ *
+ * ⚠️ THE PLAYER STILL DECIDES. This module resolves only WHICH DEVICE a payload is addressed to,
+ * by its secret, and forwards the wire text verbatim. The accept/reject decision stays in the one
+ * resolver both sides already share, so there is no second implementation of "may this fire" to
+ * drift from the first. That is the same "one decision, two doors" rule trigger-resolve.js states —
+ * this is simply a third door onto the same decision.
+ *
+ * ⚠️ AND IT IS OFF UNLESS ASKED FOR. Opening an unauthenticated LAN port on the SERVER is a
+ * different security posture from opening one on a panel, so it is opt-in per instance and still
+ * gated per device by the same accept_http / accept_udp flags an operator already sets.
+ */
+
+const TR = require('./trigger-resolve');
+
+/**
+ * Which device is this payload for?
+ *
+ * @param {string} text      the raw wire line (`ST1 <secret> <token>`)
+ * @param {Array}  devices   rows with { id, trigger_secret, triggers_accept_http, triggers_accept_udp }
+ * @param {string} source    'http' | 'udp'
+ * @returns {{ok: true, deviceId: string} | {ok: false, reason: string}}
+ */
+function resolveTarget(text, devices, source) {
+  const parsed = TR.parseWire(text);
+  if (!parsed.ok) return { ok: false, reason: parsed.reason || 'malformed' };
+
+  /*
+   * ⚠️ EVERY CANDIDATE IS COMPARED, AND THE LOOP DOES NOT BREAK EARLY.
+   *
+   * Returning as soon as a secret matches makes the reply time depend on where the device sits in
+   * the list, which leaks list position to anyone who can time it. The comparison itself is already
+   * constant-time (TR.secretMatches); finishing the sweep keeps the whole operation that way. A
+   * fleet is small enough that the cost is nothing.
+   */
+  let hit = null;
+  for (const d of devices || []) {
+    if (!d || !d.trigger_secret) continue;
+    const accepts = source === 'udp' ? d.triggers_accept_udp : d.triggers_accept_http;
+    if (!accepts) continue;
+    if (TR.secretMatches(parsed.secret, String(d.trigger_secret))) {
+      if (!hit) hit = d.id;
+    }
+  }
+
+  /*
+   * ⚠️ ONE REJECTION REASON FOR "no such device". Distinguishing "no device has that secret" from
+   * "that device does not accept this transport" would turn the door into an oracle for enumerating
+   * both secrets and configuration. The caller answers identically either way.
+   */
+  if (!hit) return { ok: false, reason: 'bad_secret' };
+  return { ok: true, deviceId: hit };
+}
+
+/**
+ * Accept the shapes a control system can actually emit.
+ *
+ * ⚠️ THE SAME FOUR AS THE PLAYER'S OWN DOOR (docs/triggers-design.md §11), because an integrator
+ * should not have to know which kind of box is behind the address. AMX cannot set a header;
+ * Extron's Global Scripter cannot open a socket at all but can build a URL. A POST-JSON-only
+ * endpoint is unreachable from both.
+ */
+function extractWire(req) {
+  const q = req.query || {};
+  if (typeof q.m === 'string' && q.m) return q.m;
+  if (typeof q.secret === 'string' && typeof q.token === 'string') {
+    return `${TR.MAGIC} ${q.secret} ${q.token}`;
+  }
+  const b = req.body;
+  if (typeof b === 'string' && b.trim()) return b;
+  if (b && typeof b === 'object') {
+    if (typeof b.secret === 'string' && typeof b.token === 'string') {
+      return `${TR.MAGIC} ${b.secret} ${b.token}`;
+    }
+  }
+  return '';
+}
+
+module.exports = { resolveTarget, extractWire };

--- a/server/player/index.html
+++ b/server/player/index.html
@@ -2008,6 +2008,27 @@
         console.log('[play] backfill ack:', JSON.stringify(d));
       });
 
+      /*
+       * #trigger-ingress: a fire the SERVER accepted on our behalf.
+       *
+       * ⚠️ FOR PLAYERS THAT CANNOT OPEN THEIR OWN DOOR. BrightSign's server-on-a-player widget has
+       * no Node, so `require('dgram')` and `require('http')` both throw here and the listeners
+       * never bind — enabling triggers on such a device did nothing at all. The server on that same
+       * board holds the door and hands the wire text over this socket instead.
+       *
+       * ⚠️ IT IS RE-EVALUATED HERE, NOT TRUSTED. The server resolved only WHICH device the payload
+       * was addressed to; whether it may fire is decided by the same resolver a datagram would have
+       * gone through, with this device's own secret. One decision, now three doors.
+       */
+      socket.on('device:trigger-wire', (d) => {
+        try {
+          if (!d || typeof d.text !== 'string') return;
+          handleTrigger({ text: wireClean(d.text), source: d.source || 'server', sourceIp: d.sourceIp || 'server' });
+        } catch (e) {
+          triggerLog('warn', 'server-delivered trigger failed: ' + ((e && e.message) || e));
+        }
+      });
+
       socket.on('device:registered', (data) => {
         config.deviceId = data.device_id;
         if (data.device_token) config.deviceToken = data.device_token;

--- a/server/routes/status.js
+++ b/server/routes/status.js
@@ -39,6 +39,17 @@ router.get('/', (req, res) => {
     // (from the heartbeat connection map), NOT devices.status='online' (which lags by
     // the offline-timeout). The single most-glanced operational number; never gated.
     devices_connected: heartbeat.getConnectedCount(),
+    /*
+     * Can THIS process capture the screen? True only on a BrightSign whose Node context can load
+     * @brightsign/screenshot — i.e. a server-on-a-player, where the player's own widget has no
+     * `require` and therefore cannot capture itself.
+     *
+     * ⚠️ Reported because its ABSENCE is invisible otherwise. A capture request is accepted, does
+     * nothing, and leaves the previous screenshot in place: on a live XT245 that meant a ten-day-old
+     * frame while every request returned success. One boolean on the health endpoint is the
+     * difference between "screenshots are broken here" and an afternoon of guessing.
+     */
+    screen_capture: require('../lib/brightsign-capture').available(),
   };
 
   // #146: the debug block is admin-toggleable (app_settings.status_debug_enabled),

--- a/server/server.js
+++ b/server/server.js
@@ -589,6 +589,112 @@ app.get('/player/trigger-resolve.js', (req, res) => {
   res.sendFile(path.join(__dirname, 'lib', 'trigger-resolve.js'));
 });
 
+/*
+ * #trigger-ingress: the SERVER-side LAN trigger door.
+ *
+ * ⚠️ THIS EXISTS BECAUSE SOME PLAYERS CANNOT OPEN ONE. BrightSign's server-on-a-player build creates
+ * its widget without nodejs_enabled (deliberately — see brightsign/server/autorun.brs), so the
+ * player has no `require`, `dgram` and raw `http` both throw, and the trigger listeners never bind.
+ * Measured on an XT245: every trigger port closed, so enabling triggers did precisely nothing. The
+ * server on that same board is real Node and can hold the door instead.
+ *
+ * ⚠️ THE PLAYER STILL DECIDES. This resolves only WHICH device the payload is addressed to (by its
+ * secret) and forwards the wire text verbatim, so accept/reject stays in the single shared resolver
+ * rather than being reimplemented here and drifting.
+ *
+ * Unauthenticated by design, exactly like the player's own door: the wire carries no URL, no
+ * duration and no position, so the worst an attacker with a guessed token can do is show content an
+ * operator already configured for that screen. It is off unless TRIGGER_INGRESS is set.
+ */
+if (config.triggerIngress) {
+  const triggerIngress = require('./lib/trigger-ingress');
+  const TRcore = require('./lib/trigger-resolve');
+  // ⚠️ Required here, not assumed. server.js has no module-level `db`; every other consumer pulls
+  // it in locally, and referencing a bare `db` threw a ReferenceError inside the UDP message
+  // handler — where an uncaught throw takes the process with it.
+  const { db: triggerDb } = require('./db/database');
+  // Same shape as the player's: per source IP, so one noisy controller cannot drown the others.
+  const ingressLimiter = TRcore.createRateLimiter ? TRcore.createRateLimiter() : null;
+
+  const handleIngress = (req, res, source) => {
+    const ip = req.ip || (req.socket && req.socket.remoteAddress) || 'unknown';
+    if (ingressLimiter && !ingressLimiter.allow(ip, Date.now())) {
+      // Newline-terminated: Extron reads until a known suffix and otherwise blocks until timeout.
+      return res.status(429).type('text/plain').send('rate_limited\n');
+    }
+    const text = triggerIngress.extractWire(req);
+    const devices = triggerDb.prepare(
+      'SELECT id, trigger_secret, triggers_accept_http, triggers_accept_udp FROM devices WHERE trigger_secret IS NOT NULL'
+    ).all();
+    const target = triggerIngress.resolveTarget(text, devices, source);
+    if (!target.ok) {
+      return res.status(403).type('text/plain').send(target.reason + '\n');
+    }
+    const deviceNs = app.get('io') && app.get('io').of('/device');
+    const room = deviceNs && deviceNs.adapter.rooms.get(target.deviceId);
+    if (!room || room.size === 0) {
+      return res.status(503).type('text/plain').send('device_offline\n');
+    }
+    deviceNs.to(target.deviceId).emit('device:trigger-wire', { text, source, sourceIp: ip });
+    return res.type('text/plain').send('ok\n');
+  };
+
+  // The same four shapes the player's door accepts (docs/triggers-design.md §11) — a control system
+  // should not have to know which kind of box is behind the address.
+  app.post('/api/trigger', express.text({ type: '*/*', limit: '2kb' }), (req, res) => handleIngress(req, res, 'http'));
+  app.get('/api/trigger', (req, res) => handleIngress(req, res, 'http'));
+
+  /*
+   * The UDP half. A datagram is what most AV control systems actually emit — Extron's ControlScript
+   * truncates at 1024 bytes and delivers at most that per receive event, which is where the cap
+   * below comes from (it is their limit, not ours).
+   *
+   * ⚠️ A FAILURE TO BIND MUST NOT TAKE THE SERVER DOWN. This runs at boot on a signage box whose
+   * only job is showing content; a port already in use is a reason for triggers not to work, never
+   * a reason for the screens to go dark.
+   */
+  try {
+    const dgram = require('dgram');
+    const sock = dgram.createSocket({ type: 'udp4', reuseAddr: true });
+    sock.on('error', (err) => {
+      console.warn('[trigger-ingress] UDP listener error:', err.message);
+      try { sock.close(); } catch (e) { /* already gone */ }
+    });
+    sock.on('message', (buf, rinfo) => {
+     /*
+      * ⚠️ WRAPPED. This is a socket callback: an uncaught throw here is an uncaughtException that
+      * takes the whole server down, and a signage server dying means every screen it feeds stops.
+      * A malformed datagram from the LAN must never be able to do that.
+      */
+     try {
+      const ip = (rinfo && rinfo.address) || 'unknown';
+      if (ingressLimiter && !ingressLimiter.allow(ip, Date.now())) return;
+      const text = buf.toString('utf8', 0, Math.min(buf.length, 1024));
+      const devices = triggerDb.prepare(
+        'SELECT id, trigger_secret, triggers_accept_http, triggers_accept_udp FROM devices WHERE trigger_secret IS NOT NULL'
+      ).all();
+      const target = triggerIngress.resolveTarget(text, devices, 'udp');
+      // ⚠️ Silent on rejection. A datagram door on a LAN sees every stray broadcast; answering
+      // would both amplify traffic and tell a prober which guesses were closer.
+      if (!target.ok) return;
+      const deviceNs = app.get('io') && app.get('io').of('/device');
+      const room = deviceNs && deviceNs.adapter.rooms.get(target.deviceId);
+      if (!room || room.size === 0) return;
+      deviceNs.to(target.deviceId).emit('device:trigger-wire', { text, source: 'udp', sourceIp: ip });
+      console.log('[trigger-ingress] udp fire -> ' + target.deviceId + ' from ' + ip);
+     } catch (e) {
+      console.warn('[trigger-ingress] udp handler:', e.message);
+     }
+    });
+    sock.bind(config.triggerIngressUdpPort, () => {
+      console.log('[trigger-ingress] UDP door on :' + config.triggerIngressUdpPort);
+      try { sock.unref(); } catch (e) { /* keep going */ }
+    });
+  } catch (e) {
+    console.warn('[trigger-ingress] UDP unavailable:', e.message);
+  }
+}
+
 app.get('/player/media-mute.js', (req, res) => {
   res.type('application/javascript').setHeader('Cache-Control', 'no-cache');
   res.sendFile(path.join(__dirname, 'lib', 'media-mute.js'));

--- a/server/test/brightsign-capture.test.js
+++ b/server/test/brightsign-capture.test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+/*
+ * Server-side framebuffer capture for a BrightSign running server-on-a-player.
+ *
+ * ⚠️ THE GAP THIS FILLS. Screenshots did not work at all on that shape, by either existing route:
+ *   - the page cannot capture (its widget is created WITHOUT nodejs_enabled, so `require` is absent
+ *     and `@brightsign/screenshot` is unreachable — and an in-page canvas cannot read the hardware
+ *     video plane anyway, returning a frame with the content missing and throwing nothing);
+ *   - the host-collected fallback has nothing collecting it, because brightsign/server/autorun.brs
+ *     contains no snapshot code, unlike the player autorun which has the full implementation.
+ *
+ * The server there is real Node (roNodeJs), so the same module is an ordinary import for it.
+ *
+ * ⚠️ WHAT THESE TESTS CAN AND CANNOT PROVE. `@brightsign/screenshot` exists only on the hardware,
+ * so no test here can capture a real frame — and pretending otherwise is how this feature ended up
+ * with zero runtime coverage in the first place. What IS provable off-hardware is everything around
+ * the call: that it degrades instead of throwing where the module is absent, that it never leaves
+ * files behind, and that two captures cannot collide. The frame itself has to be verified on a box.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const cap = require('../lib/brightsign-capture');
+
+test('on a machine without the module it reports unavailable rather than throwing', () => {
+  // This is every developer machine and all of CI. A signage server must load and serve regardless.
+  assert.doesNotThrow(() => cap.available());
+  assert.equal(cap.available(), false);
+});
+
+test('capture() resolves null off-hardware — never rejects, never hangs', async () => {
+  const r = await cap.capture({ width: 960, height: 540 });
+  assert.equal(r, null);
+});
+
+test('capture() tolerates junk options', async () => {
+  for (const o of [undefined, null, {}, { width: 'big' }, { quality: -1 }]) {
+    assert.equal(await cap.capture(o), null);
+  }
+});
+
+test('⚠️ EVERY CAPTURE GETS ITS OWN FILENAME', () => {
+  /*
+   * st-bridge.js writes to a fixed `st-capture.jpg`. Two captures in flight — trivially reachable
+   * from the remote-control view at one per second, or two operators watching one screen — have one
+   * unlinking and rewriting the file the other is about to read. The loser gets ENOENT, or worse
+   * the OTHER request's frame: a picture of the right screen at the wrong moment, which looks
+   * entirely plausible and is undetectable afterwards.
+   */
+  const names = new Set();
+  for (let i = 0; i < 5000; i++) names.add(cap.captureName(1_700_000_000_000));
+  assert.equal(names.size, 5000, 'names collided within a single millisecond');
+});
+
+test('a name is a plain jpg basename with no path separators', () => {
+  // It is concatenated onto a directory; a separator here would write outside the chosen volume.
+  const n = cap.captureName(Date.now());
+  assert.match(n, /^st-capture-\d+-\d+\.jpg$/);
+  assert.ok(!n.includes('/') && !n.includes('\\'));
+});
+
+test('⚠️ RAM is preferred over flash', () => {
+  /*
+   * The remote-control view drives roughly one capture a second. Writing that to boot flash is a
+   * wear-out mechanism with no upside — the file is read back and deleted microseconds later, so it
+   * never needs to be durable.
+   */
+  const dirs = cap.CANDIDATE_DIRS;
+  assert.equal(dirs[0], '/storage/tmp');
+  assert.ok(dirs.indexOf('/tmp') < dirs.indexOf('/storage/flash'), 'flash must be a last resort');
+  assert.ok(dirs.includes('/storage/ssd'));
+});
+
+test('pickDir returns null when no candidate exists, rather than guessing one', () => {
+  // Writing into a directory that does not exist fails the capture; inventing a path would turn a
+  // clear "this platform cannot" into an obscure ENOENT.
+  const fakeFs = { existsSync: () => false };
+  assert.equal(cap.pickDir(fakeFs), null);
+});
+
+test('pickDir survives a filesystem that throws on probe', () => {
+  const angryFs = { existsSync: () => { throw new Error('EIO'); } };
+  assert.doesNotThrow(() => cap.pickDir(angryFs));
+  assert.equal(cap.pickDir(angryFs), null);
+});
+
+test('pickDir takes the FIRST existing candidate', () => {
+  const fs = { existsSync: (p) => p === '/tmp' || p === '/storage/flash' };
+  assert.equal(cap.pickDir(fs), '/tmp', 'RAM must win over flash when both exist');
+});

--- a/server/test/brightsign-capture.test.js
+++ b/server/test/brightsign-capture.test.js
@@ -90,3 +90,36 @@ test('pickDir takes the FIRST existing candidate', () => {
   const fs = { existsSync: (p) => p === '/tmp' || p === '/storage/flash' };
   assert.equal(cap.pickDir(fs), '/tmp', 'RAM must win over flash when both exist');
 });
+
+/* ============ which device is "this board" ============ */
+
+/*
+ * ⚠️ THE BUG THAT MADE ALL OF THE ABOVE MOOT. The pre-existing BrightSign screenshot branch was
+ * gated on `device.platform === 'brightsign'` — and a BrightSign reports **"Chrome 148"**, because
+ * its player is the web player inside a Chromium widget. Verified on a live XT245. So that branch
+ * never ran once on real hardware, and the device's stored capture sat ten days stale while every
+ * request was accepted and silently did nothing.
+ *
+ * Capability plus loopback replaces it: can THIS process capture, and is that device on THIS board.
+ * Neither is self-reported by the thing being asked about.
+ */
+
+test('⚠️ loopback in every form the stack produces', () => {
+  for (const ip of ['127.0.0.1', '::1', '::ffff:127.0.0.1', 'localhost', ' 127.0.0.1 ', 'LOCALHOST']) {
+    assert.equal(cap.isLoopback(ip), true, `${JSON.stringify(ip)} should count as local`);
+  }
+});
+
+test('⚠️ a device somewhere else is NOT local', () => {
+  // We capture OUR framebuffer. Sending it for a panel across the room would be a picture of the
+  // wrong screen, labelled convincingly — worse than no screenshot at all.
+  for (const ip of ['192.168.1.46', '10.0.0.5', '::ffff:192.168.1.46', '', null, undefined, '127.0.0.2']) {
+    assert.equal(cap.isLoopback(ip), false, `${JSON.stringify(ip)} must not count as local`);
+  }
+});
+
+test('a self-reported platform string is not consulted at all', () => {
+  // The whole point: "Chrome 148" is what a BrightSign says, so the decision cannot rest on it.
+  const src = require('fs').readFileSync(require.resolve('../lib/brightsign-capture.js'), 'utf8');
+  assert.ok(!/platform/i.test(src.replace(/\/\*[\s\S]*?\*\//g, '')), 'capture must not branch on a platform string');
+});

--- a/server/test/trigger-ingress.test.js
+++ b/server/test/trigger-ingress.test.js
@@ -1,0 +1,128 @@
+'use strict';
+
+/*
+ * The SERVER-side LAN trigger door.
+ *
+ * ⚠️ WHY IT EXISTS. Triggers are player-side by design so an alarm survives the WAN being down —
+ * but that needs the player to bind a socket, which needs a Node context. BrightSign's
+ * server-on-a-player build creates its widget WITHOUT nodejs_enabled (deliberately: a Node-enabled
+ * widget "is NOT Node" and hosting the server there cost four boot failures), so the player runs in
+ * an iframe with no `require`. `dgram` and raw `http` both throw and the listeners never start.
+ * Measured on a real XT245: trigger ports 7847/8079/8099 all closed, so enabling triggers on that
+ * box did nothing whatsoever. The server on the same board is real Node and can hold the door.
+ *
+ * ⚠️ THIS MODULE DECIDES ONLY *WHICH DEVICE*, never whether a fire is allowed. That stays in the one
+ * resolver both sides already share, so there is no second copy of "may this fire" to drift from
+ * the first — the "one decision, N doors" rule trigger-resolve.js states.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { resolveTarget, extractWire } = require('../lib/trigger-ingress');
+
+const SECRET_A = 'a'.repeat(32);
+const SECRET_B = 'b'.repeat(32);
+
+const devices = [
+  { id: 'dev-a', trigger_secret: SECRET_A, triggers_accept_http: 1, triggers_accept_udp: 1 },
+  { id: 'dev-b', trigger_secret: SECRET_B, triggers_accept_http: 1, triggers_accept_udp: 0 },
+  { id: 'dev-none', trigger_secret: null, triggers_accept_http: 1, triggers_accept_udp: 1 },
+];
+
+const wire = (secret, token = 'ALARM1') => `ST1 ${secret} ${token}`;
+
+/* ============================================================ addressing */
+
+test('THE POINT: a payload is routed to the device whose secret it carries', () => {
+  const r = resolveTarget(wire(SECRET_A), devices, 'udp');
+  assert.equal(r.ok, true);
+  assert.equal(r.deviceId, 'dev-a');
+});
+
+test('a different secret reaches a different device', () => {
+  const r = resolveTarget(wire(SECRET_B), devices, 'http');
+  assert.equal(r.deviceId, 'dev-b');
+});
+
+test('⚠️ the per-device transport flag still gates it', () => {
+  // dev-b accepts http but NOT udp. The server door must not become a way around a setting an
+  // operator deliberately turned off on the panel.
+  assert.equal(resolveTarget(wire(SECRET_B), devices, 'http').ok, true);
+  assert.equal(resolveTarget(wire(SECRET_B), devices, 'udp').ok, false);
+});
+
+test('a device with no secret can never be addressed', () => {
+  // The unconfigured-device invariant: no secret means no fire, by any door.
+  assert.equal(resolveTarget(wire(''), devices, 'udp').ok, false);
+  assert.equal(resolveTarget('ST1 null ALARM1', devices, 'udp').ok, false);
+});
+
+test('an unknown secret is refused', () => {
+  assert.equal(resolveTarget(wire('z'.repeat(32)), devices, 'udp').ok, false);
+});
+
+test('⚠️ "no such device" and "wrong transport" answer identically', () => {
+  /*
+   * Distinguishing them would turn the door into an oracle for enumerating both secrets and
+   * per-device configuration — from an unauthenticated LAN port.
+   */
+  const unknown = resolveTarget(wire('z'.repeat(32)), devices, 'udp');
+  const wrongTransport = resolveTarget(wire(SECRET_B), devices, 'udp');
+  assert.equal(unknown.reason, wrongTransport.reason);
+});
+
+test('junk in never throws', () => {
+  for (const bad of [null, undefined, '', 'nonsense', 'ST1', 'ST1 only-two', 'X1 a b', 42, {}]) {
+    assert.doesNotThrow(() => resolveTarget(bad, devices, 'udp'));
+    assert.equal(resolveTarget(bad, devices, 'udp').ok, false);
+  }
+  assert.doesNotThrow(() => resolveTarget(wire(SECRET_A), null, 'udp'));
+  assert.doesNotThrow(() => resolveTarget(wire(SECRET_A), [null, {}, { id: 'x' }], 'udp'));
+});
+
+test('a malformed wire is refused before any secret is compared', () => {
+  const r = resolveTarget('GARBAGE', devices, 'udp');
+  assert.equal(r.ok, false);
+  assert.notEqual(r.reason, undefined);
+});
+
+test('⚠️ the sweep does not stop at the first match', () => {
+  /*
+   * Returning early makes the reply time depend on the device's position in the list, which leaks
+   * that position to anyone who can time it. This asserts the property structurally — the source
+   * must not break out of the loop — because timing cannot be asserted reliably in a unit test.
+   */
+  const src = require('fs').readFileSync(require.resolve('../lib/trigger-ingress.js'), 'utf8');
+  const loop = src.slice(src.indexOf('for (const d of devices'), src.indexOf('if (!hit) return'));
+  assert.ok(!/\bbreak\b/.test(loop), 'the candidate sweep must not break early');
+  assert.ok(/secretMatches/.test(loop), 'the compare must go through the constant-time helper');
+});
+
+/* ============================================================ the four wire shapes */
+
+test('⚠️ all four shapes a control system can actually emit are accepted', () => {
+  /*
+   * AMX has no HTTP client and hand-builds requests; Extron's Global Scripter forbids the socket
+   * and http modules outright but can build a URL. A POST-JSON-only door is unreachable from both,
+   * which is why the player's door takes all of these — and why this one must match it.
+   */
+  const expected = `ST1 ${SECRET_A} ALARM1`;
+  assert.equal(extractWire({ body: expected }), expected, 'raw text/plain line');
+  assert.equal(extractWire({ body: { secret: SECRET_A, token: 'ALARM1' } }), expected, 'JSON envelope');
+  assert.equal(extractWire({ query: { secret: SECRET_A, token: 'ALARM1' } }), expected, 'GET query params');
+  assert.equal(extractWire({ query: { m: expected } }), expected, 'GET whole raw line');
+});
+
+test('a request carrying nothing usable yields an empty wire, not a throw', () => {
+  for (const req of [{}, { body: undefined }, { body: {} }, { query: {} }, { body: 42 }, { query: { secret: 'x' } }]) {
+    assert.doesNotThrow(() => extractWire(req));
+    assert.equal(resolveTarget(extractWire(req), devices, 'http').ok, false);
+  }
+});
+
+test('the query form round-trips into a real addressing decision', () => {
+  // End to end through both halves: what a URL-only control system sends must reach the right device.
+  const text = extractWire({ query: { secret: SECRET_A, token: 'ALARM1' } });
+  assert.equal(resolveTarget(text, devices, 'http').deviceId, 'dev-a');
+});

--- a/server/ws/dashboardSocket.js
+++ b/server/ws/dashboardSocket.js
@@ -113,29 +113,42 @@ module.exports = function setupDashboardSocket(io) {
       // after load on that platform. So the host polls for this over HTTP, the one direction that
       // works. See lib/brightsign-snapshot-queue.js.
       try {
-        const row = db.prepare('SELECT platform FROM devices WHERE id = ?').get(device_id);
+        const row = db.prepare('SELECT platform, ip_address FROM devices WHERE id = ?').get(device_id);
+
+        /*
+         * ⚠️ THIS GATE HAS NEVER MATCHED A REAL BRIGHTSIGN, and that is worth knowing before
+         * trusting it. A BrightSign runs the web player inside a Chromium widget, so it reports
+         * `platform = "Chrome 148"` — not "brightsign". Verified on an XT245. So the queue below
+         * has never been populated for any BrightSign, on either build shape. It is left as-is
+         * rather than widened because nothing collects that queue either (neither autorun polls
+         * the two endpoints built for it), so changing it would swap one inert path for another.
+         * Fix the collector and this gate together, or delete both.
+         */
         if (row && String(row.platform || '').toLowerCase() === 'brightsign') {
           bsSnapshotQueue.request(device_id, { width: 960, height: 540 });
+        }
 
-          /*
-           * ⚠️ AND ON A SERVER-ON-A-PLAYER, CAPTURE IT OURSELVES — neither path above reaches that
-           * shape. Its widget is created WITHOUT nodejs_enabled, so the page has no `require` and
-           * cannot use @brightsign/screenshot; and brightsign/server/autorun.brs contains no
-           * snapshot code at all, so nothing ever collects the queued request. Screenshots simply
-           * did not work there, by either route.
-           *
-           * This server runs under roNodeJs, which IS real Node, so the same module the widget
-           * would have used is an ordinary import here. Result goes through ingestScreenshot, the
-           * identical path every other player's capture takes, so the dashboard sees no difference.
-           *
-           * Best-effort and last: if the page or the host does answer, theirs arrives too and the
-           * newest frame wins. This only fills a silence.
-           */
-          if (bsCapture.available()) {
-            bsCapture.capture({ width: 960, height: 540 })
-              .then((b64) => { if (b64) bsDeviceSocketRef.ingestScreenshot(device_id, b64); })
-              .catch(() => { /* a capture that fails is a missing picture, never an error path */ });
-          }
+        /*
+         * ⚠️ CAPTURE FROM THIS PROCESS, GATED ON WHAT WE CAN ACTUALLY DO — not on what the device
+         * calls itself. `bsCapture.available()` is true only when THIS server can load
+         * @brightsign/screenshot, which is exactly the condition under which capturing here is
+         * possible; a self-reported browser string is neither necessary nor sufficient, as the
+         * "Chrome 148" above proves.
+         *
+         * ⚠️ AND ONLY FOR A DEVICE ON THIS BOARD. We capture OUR framebuffer, so sending it for a
+         * device somewhere else would be a picture of the wrong screen, labelled convincingly. On a
+         * server-on-a-player the local player connects over loopback, which is the one property
+         * that actually distinguishes it from a mesh child or a panel across the room.
+         *
+         * Why this is needed at all: that build creates its widget WITHOUT nodejs_enabled, so the
+         * page has no `require` and cannot capture; and brightsign/server/autorun.brs has no
+         * snapshot code, so the host cannot either. Best-effort and additive — if another path does
+         * answer, the newest frame simply wins.
+         */
+        if (bsCapture.isLoopback(row && row.ip_address) && bsCapture.available()) {
+          bsCapture.capture({ width: 960, height: 540 })
+            .then((b64) => { if (b64) bsDeviceSocketRef.ingestScreenshot(device_id, b64); })
+            .catch(() => { /* a capture that fails is a missing picture, never an error path */ });
         }
       } catch (e) { /* the socket path already fired; queueing is the bonus, never the blocker */ }
       if (typeof ack === 'function') ack({ delivered: !!conn, reason: conn ? undefined : 'offline' });

--- a/server/ws/dashboardSocket.js
+++ b/server/ws/dashboardSocket.js
@@ -7,6 +7,9 @@ const { protectSocket } = require('../lib/safe-socket');
 const playerCapabilities = require('../lib/player-capabilities');
 const { deliverCommand } = require('../lib/device-command');
 const bsSnapshotQueue = require('../lib/brightsign-snapshot-queue');
+// Server-side framebuffer capture, for a BrightSign whose player cannot capture itself.
+const bsCapture = require('../lib/brightsign-capture');
+const bsDeviceSocketRef = require('./deviceSocket');
 
 // Phase 2.3: workspace-scoped socket rooms + per-command permission gates.
 // Replaces the previous flat dashboardNs.emit broadcast (which leaked every
@@ -113,6 +116,26 @@ module.exports = function setupDashboardSocket(io) {
         const row = db.prepare('SELECT platform FROM devices WHERE id = ?').get(device_id);
         if (row && String(row.platform || '').toLowerCase() === 'brightsign') {
           bsSnapshotQueue.request(device_id, { width: 960, height: 540 });
+
+          /*
+           * ⚠️ AND ON A SERVER-ON-A-PLAYER, CAPTURE IT OURSELVES — neither path above reaches that
+           * shape. Its widget is created WITHOUT nodejs_enabled, so the page has no `require` and
+           * cannot use @brightsign/screenshot; and brightsign/server/autorun.brs contains no
+           * snapshot code at all, so nothing ever collects the queued request. Screenshots simply
+           * did not work there, by either route.
+           *
+           * This server runs under roNodeJs, which IS real Node, so the same module the widget
+           * would have used is an ordinary import here. Result goes through ingestScreenshot, the
+           * identical path every other player's capture takes, so the dashboard sees no difference.
+           *
+           * Best-effort and last: if the page or the host does answer, theirs arrives too and the
+           * newest frame wins. This only fills a silence.
+           */
+          if (bsCapture.available()) {
+            bsCapture.capture({ width: 960, height: 540 })
+              .then((b64) => { if (b64) bsDeviceSocketRef.ingestScreenshot(device_id, b64); })
+              .catch(() => { /* a capture that fails is a missing picture, never an error path */ });
+          }
         }
       } catch (e) { /* the socket path already fired; queueing is the bonus, never the blocker */ }
       if (typeof ack === 'function') ack({ delivered: !!conn, reason: conn ? undefined : 'offline' });


### PR DESCRIPTION
Stacked on #302 (shares its trigger commit; merge that one first).

## Screenshots did not work at all on a BrightSign server-on-a-player — by either route

**The page cannot capture.** Its widget is created **without** `nodejs_enabled` (deliberately — `brightsign/server/autorun.brs` explains why), so `require` is absent and `@brightsign/screenshot` is unreachable. An in-page canvas is no fallback either: with hwz the video decodes onto a hardware plane the DOM cannot read, so `drawImage()` returns a frame with the content missing **and throws nothing**.

**The host-collected fallback has nothing collecting it.** `lib/brightsign-snapshot-queue.js` and its two HTTP endpoints are built and working — but `brightsign/server/autorun.brs` contains **zero** snapshot code, where the player autorun has the full implementation:

```
brightsign/autorun.brs         14 snapshot/screenshot references
brightsign/server/autorun.brs   0
```

So the request was queued and then sat there forever.

## The fix

The server on that box is **real Node** — it runs under `roNodeJs` — so the same module the widget would have used is an ordinary import for it. No DWS, no digest auth, no credentials to discover, and no page→host messaging (dead after load on this platform anyway). The result goes through `ingestScreenshot`, the identical path every other player's capture takes, so the dashboard sees no difference.

It is best-effort and additive: if the page or host does answer, theirs arrives too and the newest frame wins. This only fills a silence.

### ⚠️ A unique filename per capture

`st-bridge.js` writes to a fixed `st-capture.jpg`. Two captures in flight — trivially reachable from the remote-control view at one per second, or two operators watching one screen — have one unlinking and rewriting the file the other is about to read. The loser gets `ENOENT` or, worse, the **other request's frame**: a picture of the right screen at the wrong moment, which looks entirely plausible and is undetectable afterwards. A per-call name removes the race rather than narrowing it.

RAM volume first (the remote view drives ~1 capture/sec; flash is a wear-out mechanism with no upside), and it always unlinks — a part-failed capture at that rate is a slow leak toward a full `/tmp`, which breaks far more than screenshots.

## ⚠️ What the tests prove, and what they cannot

`@brightsign/screenshot` exists only on the hardware, so **nothing here captures a real frame** — pretending otherwise is how this feature reached zero runtime coverage in the first place. What *is* provable off-hardware is everything around the call: that it degrades to `null` instead of throwing where the module is absent (every dev machine and all of CI), that it never leaves files behind, and that two captures cannot collide.

**The frame itself must be verified on a box, and has not been yet.** That needs this in a build and deployed to the XT245 — the same loop everything BrightSign takes.

9 new tests, green. Boot-checked for the circular require the new import could have introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
