### PR TITLE
BrightSign: mute the audio plane, not just the DOM

### DIFF
--- a/brightsign/st-bridge.js
+++ b/brightsign/st-bridge.js
@@ -428,8 +428,13 @@
     add('playback.video'); add('playback.image'); add('playback.widget'); add('playback.youtube');
     add('playback.zones');
     /*
-     * ⚠️ DECLARED ON AN ASSUMPTION NOBODY HAS TESTED. These say the DOM's `el.muted` / `el.volume`
-     * reach the audio path. On this platform video decodes onto a HARDWARE PLANE the DOM cannot
+     * ⚠️ RESOLVED 2026-08-30 BY EXPERIMENT — and the assumption was WRONG. The note below asked for
+     * ears at a panel; a live XT245 answered instead: every output read `mute:false, volumeLinear:1`
+     * while the player was muting through `el.muted`. The DOM does not reach the audio plane. The
+     * bridge now drives @brightsign/audiooutput (see setAudioMuted), and the capability is probed
+     * rather than asserted. The original reasoning is kept because it is still the right reasoning:
+     *
+     * These said the DOM's `el.muted` / `el.volume` On this platform video decodes onto a HARDWARE PLANE the DOM cannot
      * touch — that is why the screen-off path tears the source down rather than pausing — and
      * whether AUDIO routes the same way has never been established: DWS exposes no audio-state
      * endpoint and no JS API reports whether sound is leaving the box, so it cannot be settled
@@ -445,7 +450,24 @@
      * either one being honoured. But this is the one capability here asserted rather than probed,
      * against the rule the file states below, and it should be resolved by experiment.
      */
-    add('audio.mute'); add('audio.volume');
+    /*
+     * ⚠️ PROBED NOW, NOT ASSERTED. The long note above said this was the one capability declared on
+     * an assumption, and that it should be settled by experiment. It has been: the DOM path does
+     * NOT reach the audio plane on this hardware, and @brightsign/audiooutput does. So the
+     * capability tracks whether that module is actually usable here, by the rule the rest of this
+     * file follows — try it, then declare.
+     */
+    try {
+      var AudioOutputProbe = tryRequire('@brightsign/audiooutput');
+      var audioUsable = false;
+      if (AudioOutputProbe) {
+        var probeNames = ['analog', 'hdmi', 'spdif', 'usb'];
+        for (var ai = 0; ai < probeNames.length; ai++) {
+          try { new AudioOutputProbe(probeNames[ai]); audioUsable = true; break; } catch (e) { /* not this one */ }
+        }
+      }
+      if (audioUsable) { add('audio.mute'); add('audio.volume'); }
+    } catch (e) { /* no audio control declared, which is the truthful answer */ }
     add('sync.clock');            // clock-derived group sync is pure JS and needs nothing
     add('remote.input');          // synthesised DOM events; needs no host and no mouse_enabled
 
@@ -552,6 +574,63 @@
 
   var API = {
     /* True only when this really is a BrightSign — either module access or the UA. */
+    /*
+     * Platform audio. THE DOM DOES NOT REACH IT.
+     *
+     * ⚠️ MEASURED, not assumed. On a live XT245 (OS 10.0.16) every output read `mute:false,
+     * volumeLinear:1` while the player was muting through `el.muted` — analog, hdmi and spdif all
+     * wide open. So `audio.mute` was declared on an assumption the hardware disproves, and three
+     * things quietly did not work: mute, wall-follower silence (N overlapping soundtracks on a
+     * wall), and a trigger overlay's base-audio suppression — an alarm that is supposed to be the
+     * only thing you can hear, playing over the advert it interrupted.
+     *
+     * @brightsign/audiooutput is the real control: `new AudioOutput('analog')` and friends expose
+     * `mute` as a settable PROPERTY, plus volumeLinear / volumeDb.
+     *
+     * ⚠️ OUTPUTS ARE ENUMERATED AND FAILURES TOLERATED, NEVER ASSUMED. On the test unit `hdmi`
+     * calls itself `hdmi:1` and `usb` throws "Failed to get mute" outright with nothing plugged in.
+     * A fixed list with no error handling would take the whole mute down because one absent jack
+     * raised — which is precisely the shape of failure this replaces.
+     */
+    audioOutputs: function () {
+      var AudioOutput = tryRequire('@brightsign/audiooutput');
+      if (!AudioOutput) return [];
+      var found = [];
+      var names = ['analog', 'hdmi', 'spdif', 'usb'];
+      for (var i = 0; i < names.length; i++) {
+        try { found.push({ name: names[i], out: new AudioOutput(names[i]) }); }
+        catch (e) { /* absent on this unit — not an error, just not there */ }
+      }
+      return found;
+    },
+
+    /**
+     * Mute or unmute every audio output this player actually has.
+     * @returns {number} how many outputs accepted it — 0 means the platform path is unavailable,
+     *          which the caller should treat as "the DOM is all we have" rather than as success.
+     */
+    setAudioMuted: function (on) {
+      var outs = this.audioOutputs();
+      var applied = 0;
+      for (var i = 0; i < outs.length; i++) {
+        try { outs[i].out.mute = !!on; applied++; }
+        catch (e) { /* one output refusing must not stop the others */ }
+      }
+      return applied;
+    },
+
+    /** Read back what the hardware says, for diagnosis — the DOM cannot tell you this. */
+    audioState: function () {
+      var outs = this.audioOutputs();
+      var state = {};
+      for (var i = 0; i < outs.length; i++) {
+        try {
+          state[outs[i].name] = { mute: outs[i].out.mute, volume: outs[i].out.volumeLinear };
+        } catch (e) { state[outs[i].name] = 'unreadable'; }
+      }
+      return state;
+    },
+
     isBrightSign: function () {
       return !!(port || registry || deviceInfo || uaIsBrightSign);
     },

--- a/server/player/index.html
+++ b/server/player/index.html
@@ -1191,6 +1191,31 @@
           else { activeYtPlayer.unMute(); activeYtPlayer.setVolume(mediaVolume != null ? Math.round(mediaVolume * 100) : 100); }
         } catch (e) { /* player not ready yet; onReady applies it again */ }
       }
+
+      /*
+       * ⚠️ BRIGHTSIGN: THE DOM ABOVE DOES NOT REACH THE AUDIO PLANE. Measured on a live XT245 —
+       * every output read `mute:false, volumeLinear:1` while this function was setting el.muted on
+       * every element. So on that hardware mute has never muted, a video wall has played N
+       * overlapping soundtracks, and nothing here made a sound stop. The bridge drives
+       * @brightsign/audiooutput, which does.
+       *
+       * ⚠️ AND THE PLATFORM MUTE IS GLOBAL, NOT PER-ELEMENT — which is why this is NOT
+       * `want || baseAudioSuppressed`. Suppression means an ALARM OVERLAY is playing and must be
+       * the thing you hear; muting the whole output then would silence the alarm, turning a
+       * base-audio bug into an emergency-message bug. So the platform is silenced only when the
+       * base wants silence AND nothing is asserting audio over it.
+       *
+       * Selective suppression — overlay audible while the base underneath is silent — is still
+       * unsolved on this platform, because per-element control is exactly what it does not have.
+       * That is the pre-existing behaviour, not a regression introduced here.
+       */
+      try {
+        var bs = window.ScreenTinkerBS;
+        if (bs && typeof bs.setAudioMuted === 'function' && bs.isBrightSign && bs.isBrightSign()) {
+          bs.setAudioMuted(want && !baseAudioSuppressed);
+        }
+      } catch (e) { /* the DOM writes above still stand on every other platform */ }
+
       return want;
     }
 


### PR DESCRIPTION
Reported as "mute doesn't work on the BrightSign" — and it doesn't, nor does anything else that needs a sound to *stop*.

## The assumption the code itself flagged

`st-bridge.js` declared `audio.mute` / `audio.volume` with a comment saying outright that this was the one capability **asserted rather than probed**, that it rested on the DOM's `el.muted` reaching the audio path, and that settling it "needs ears at a panel".

A live XT245 settled it instead. With the player setting `el.muted` on every element, every output read:

```
analog: { mute: false, volumeLinear: 1 }
hdmi:   { mute: false, volumeLinear: 1 }   (reports itself as "hdmi:1")
spdif:  { mute: false, volumeLinear: 1 }
```

**The DOM does not reach the audio plane.** Three things were silently broken by it:

* **mute** — the reported symptom
* **wall-follower silence** — a video wall playing N overlapping soundtracks
* **a trigger overlay's base-audio suppression** — an alarm meant to be the only thing you can hear, playing over the advert it interrupted

That last one is exactly what the original comment predicted would happen.

## The fix

`@brightsign/audiooutput` is the real control: `new AudioOutput('analog')` and friends expose **`mute` as a settable property**, plus `volumeLinear` / `volumeDb`.

Verified on hardware, reading back through a **fresh handle** rather than the one just written:

```
requested: true   before: {analog:false, hdmi:false, spdif:false}
                  after:  {analog:true,  hdmi:true,  spdif:true}
requested: false  after:  {analog:false, hdmi:false, spdif:false}
```

* ⚠️ **Outputs are enumerated and failures tolerated.** On the test unit `hdmi` calls itself `hdmi:1`, and `usb` throws "Failed to get mute" outright with nothing plugged in. A fixed list without per-output error handling would take the whole mute down because one absent jack raised.
* ⚠️ **The platform mute is global, not per-element** — so the player passes `want && !baseAudioSuppressed`, *not* `want || baseAudioSuppressed`. Suppression means an alarm overlay is playing and must be audible; muting the whole output there would silence the alarm, turning a base-audio bug into an emergency-message bug.
* The capability is now **probed** — construct an output, then declare — by the rule the rest of that file already follows.

## Known limit, stated plainly

**Selective suppression is still unsolved on this platform**: overlay audible while the base underneath is silent needs per-element control, which is precisely what BrightSign does not offer here. That is the pre-existing behaviour, not a regression added by this change.

67 existing bridge/capability tests still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
