### PR TITLE
Move the designer's clock, date, countdown and QR into slides

### DIFF
--- a/frontend/js/i18n/en.js
+++ b/frontend/js/i18n/en.js
@@ -115,7 +115,13 @@ export default {
   'nav.reports': 'Reports',
   'nav.servers': 'Servers',
   'nav.kiosk': 'Kiosk',
-  'nav.designer': 'Designer',
+  /*
+   * Marked deprecating in the nav rather than removed. Existing designer-made widgets still PLAY
+   * and are still re-editable here — their config carries the design source precisely so they can
+   * be reopened — so pulling the entry would strand them in the raw HTML editor. The label is the
+   * cheapest honest signal that new work belongs in Slides.
+   */
+  'nav.designer': 'Designer (deprecating)',
   'nav.activity': 'Activity',
   'nav.teams': 'Teams',
   'nav.help': 'Help',

--- a/frontend/js/views/slides.js
+++ b/frontend/js/views/slides.js
@@ -35,8 +35,33 @@ const KINDS = {
   image: { icon: '▣', label: 'Photo', size: 0, weight: 400 },
   rule: { icon: '▬', label: 'Rule', size: 0, weight: 400 },
   box: { icon: '◻', label: 'Panel', size: 0, weight: 400 },
+  clock: { icon: '◷', label: 'Clock', size: 9, weight: 700 },
+  date: { icon: '▤', label: 'Date', size: 4, weight: 400 },
+  countdown: { icon: '◔', label: 'Countdown', size: 9, weight: 700 },
+  qr: { icon: '▦', label: 'QR code', size: 0, weight: 400 },
 };
-const TEXT_KINDS = ['head', 'body', 'stat'];
+
+/*
+ * ⚠️ THE SAME TWO-FLAG SPLIT THE RENDERER MAKES, and it has to stay in step with it.
+ *
+ * TEXT_KINDS = reads `fields[slot]`, so the Content tab offers an input for it. A QR's payload and
+ * a countdown's expiry message are fields for the same reason a headline is: changing the URL
+ * behind a poster should not mean rebuilding the layout.
+ *
+ * GLYPH_KINDS = puts characters on screen, so it gets the font and size controls. A clock shows
+ * characters and reads no field; a QR reads a field and shows none. Driving both from one list is
+ * the bug the renderer's KINDS comment describes, and it looks correct in this editor either way —
+ * the machine authoring the slide has the fonts installed.
+ */
+const TEXT_KINDS = ['head', 'body', 'stat', 'countdown', 'qr'];
+const GLYPH_KINDS = ['head', 'body', 'stat', 'clock', 'date', 'countdown'];
+const LIVE_KINDS = ['clock', 'date', 'countdown'];
+
+/* The allowlists the server validates against; an option not in these is silently dropped there. */
+const CLOCK_FORMATS = [['24', '13:45'], ['24s', '13:45:09'], ['12', '1:45 PM'], ['12s', '1:45:09 PM']];
+const DATE_FORMATS = [['long', 'Monday, 5 January 2026'], ['weekday', 'Monday, 5 January'],
+  ['short', '5 Jan 2026'], ['numeric', '05/01/2026']];
+const QR_LEVELS = [['L', 'L — smallest'], ['M', 'M — normal'], ['Q', 'Q — tolerant'], ['H', 'H — most tolerant']];
 
 const state = {
   decks: [], deck: null, si: 0, ei: 0, tab: 'content',
@@ -129,10 +154,25 @@ function newElement(kind) {
   const k = KINDS[kind];
   return {
     slot: uid('f'), kind,
-    box: { x: 10, y: 40, w: 50, ...(kind === 'rule' ? { h: 0.7 } : {}), ...(kind === 'image' || kind === 'box' ? { h: 30 } : {}) },
+    box: {
+      x: 10, y: 40, w: kind === 'qr' ? 18 : 50,
+      ...(kind === 'rule' ? { h: 0.7 } : {}),
+      // A QR must stay square or it does not scan; the renderer letterboxes the SVG inside the box,
+      // so an equal-ish w/h is what makes the code as large as the space allows.
+      ...(kind === 'qr' ? { h: 32 } : {}),
+      ...(kind === 'image' || kind === 'box' ? { h: 30 } : {}),
+    },
     style: { color: '#FFFFFF', font: 'sans', size_cqw: k.size || 3, weight: k.weight, align: 'left', opacity: 1, radius_cqw: 0 },
     motion: { animation: 'slideU', delay: 0.2, duration: 0.55, easing: 'ease-out' },
     content_id: null,
+    ...(kind === 'clock' ? { clock_format: '24', tz: '', locale: '' } : {}),
+    ...(kind === 'date' ? { date_format: 'long', tz: '', locale: '' } : {}),
+    // Default target a week out: a countdown to "now" reads as expired the moment it is added, and
+    // the operator cannot tell whether it works.
+    ...(kind === 'countdown' ? { target: Date.now() + 7 * 86400000 } : {}),
+    // ⚠️ Black modules, NOT style.color — a QR that inherits the usual white text colour is a
+    // white square on a white panel. See kindConfig in lib/slide-render.js.
+    ...(kind === 'qr' ? { qr_ec: 'M', qr_fg: '#000000', qr_bg: '#FFFFFF' } : {}),
   };
 }
 
@@ -337,7 +377,11 @@ function renderEditor(container) {
     const s = slide(); if (!s) return;
     const e = newElement(b.dataset.add);
     s.template.elements.push(e);
-    if (TEXT_KINDS.includes(e.kind)) s.fields[e.slot] = KINDS[e.kind].label;
+    if (TEXT_KINDS.includes(e.kind)) {
+      s.fields[e.slot] = e.kind === 'qr' ? 'https://screentinker.com'
+        : e.kind === 'countdown' ? 'Now open'
+        : KINDS[e.kind].label;
+    }
     state.ei = s.template.elements.length - 1; state.tab = 'content';
     touch(container); play();
   });
@@ -407,11 +451,134 @@ function styleFor(e) {
   if (s.radius_cqw) out.push(`border-radius:${s.radius_cqw}cqw`);
   if (e.kind === 'rule' || e.kind === 'box') out.push(`background:${s.color}`);
   else out.push(`color:${s.color}`);
-  if (TEXT_KINDS.includes(e.kind)) {
+  if (GLYPH_KINDS.includes(e.kind)) {
     out.push(`font-family:${fontStack(s.font)}`, `font-size:${s.size_cqw}cqw`, `font-weight:${s.weight}`,
       `text-align:${s.align}`, 'line-height:1.08', 'white-space:pre-wrap');
   }
   return out.join(';');
+}
+
+/* ============ previewing the kinds that are not just text ============ */
+
+/*
+ * ⚠️ THE CANVAS HAS TO SHOW THE REAL CODE, so it asks the server to draw it with the SAME function
+ * the renderer uses (lib/slide-render.qrSvg, via GET /api/slide-decks/qr-preview). A second QR
+ * encoder in the browser would be a second thing to keep in step, and its failure mode — a preview
+ * that scans and a slide that does not, or the reverse — is invisible on the machine that authored
+ * the slide.
+ *
+ * ⚠️ AND IT ARRIVES AS AN <img>, NEVER AS innerHTML. The bytes are ours and carry no operator text,
+ * but fetched markup injected into the dashboard's own origin is a habit worth not having: an
+ * <img> cannot execute anything whatever the response turns out to be. The route hands back JSON
+ * for the same reason — nothing serves an SVG document from this origin.
+ */
+const qrCache = new Map();
+const qrKey = (text, ec, fg, bg) => `${ec}|${fg}|${bg}|${text}`;
+
+async function qrDataUrl(text, ec, fg, bg) {
+  if (!text) return null;
+  const key = qrKey(text, ec, fg, bg);
+  if (qrCache.has(key)) return qrCache.get(key);
+  const q = new URLSearchParams({ text, ec, fg, bg });
+  let url = null;
+  try {
+    const { svg } = await api.get(`/slide-decks/qr-preview?${q}`);
+    // A data: URL rather than a blob: one — nothing has to remember to revoke it, and the stage
+    // repaints on every drag.
+    if (svg) url = `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(svg)))}`;
+  } catch (err) { url = null; }
+  // Cached either way: a payload too long to encode should not be re-asked on every repaint.
+  qrCache.set(key, url);
+  if (qrCache.size > 60) qrCache.delete(qrCache.keys().next().value);
+  return url;
+}
+
+function paintQr(host, e, text) {
+  const gap = () => {
+    host.innerHTML = `<div style="width:100%;height:100%;display:grid;place-items:center;
+      background:rgba(255,255,255,.07);border:1px dashed rgba(255,255,255,.22);
+      color:rgba(255,255,255,.45);font-size:2.2cqw">QR</div>`;
+  };
+  gap();
+  qrDataUrl(text, e.qr_ec || 'M', e.qr_fg || '#000000', e.qr_bg || '#FFFFFF')
+    .then((url) => {
+      // The stage may have been rebuilt while the request was in flight; painting into a detached
+      // node is harmless but pointless, and painting a STALE code would be worse.
+      if (!url || !host.isConnected) return;
+      host.innerHTML = '';
+      const img = document.createElement('img');
+      img.alt = '';
+      img.style.cssText = 'width:100%;height:100%;object-fit:contain;display:block';
+      img.src = url;
+      host.appendChild(img);
+    })
+    .catch(() => {});
+}
+
+/*
+ * ⚠️ THE FORMAT VOCABULARY IS DUPLICATED FROM lib/slide-render.js, AND A TEST HOLDS THE TWO
+ * TOGETHER (test/slide-live-kinds.test.js). There is no module shared between a server lib and a
+ * browser view here, so the choice was a duplicate with a guard or an editor that offers options
+ * the server silently drops — which is the worse failure, because the operator sees their choice
+ * accepted and the wall ignores it.
+ */
+function liveText(e, now) {
+  if (e.kind === 'countdown') {
+    const t = Number(e.target);
+    if (!Number.isFinite(t)) return '';
+    const ms = t - now;
+    if (ms <= 0) return '';
+    const sec = Math.floor(ms / 1000);
+    const d = Math.floor(sec / 86400); const h = Math.floor((sec % 86400) / 3600);
+    const m = Math.floor((sec % 3600) / 60); const ss = sec % 60;
+    return d > 0 ? `${d}d ${h}h ${m}m` : h > 0 ? `${h}h ${m}m ${ss}s` : `${m}m ${ss}s`;
+  }
+  let o;
+  if (e.kind === 'clock') {
+    const f = e.clock_format || '24';
+    o = { hour: '2-digit', minute: '2-digit', hour12: f.charAt(0) === '1' };
+    if (f.includes('s')) o.second = '2-digit';
+  } else {
+    const g = e.date_format || 'long';
+    o = g === 'weekday' ? { weekday: 'long', month: 'long', day: 'numeric' }
+      : g === 'numeric' ? { year: 'numeric', month: '2-digit', day: '2-digit' }
+      : g === 'short' ? { year: 'numeric', month: 'short', day: 'numeric' }
+      : { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+  }
+  const loc = e.locale || undefined;
+  if (e.tz) {
+    try { return new Intl.DateTimeFormat(loc, { ...o, timeZone: e.tz }).format(new Date(now)); } catch (err) { /* fall through */ }
+  }
+  try { return new Intl.DateTimeFormat(loc, o).format(new Date(now)); } catch (err) { return ''; }
+}
+
+function paintLive(host, e) {
+  // A countdown whose target has passed shows its expiry message, exactly as the renderer does.
+  const v = liveText(e, Date.now());
+  host.textContent = (e.kind === 'countdown' && !v)
+    ? ((slide() && slide().fields[e.slot]) || '')
+    : v;
+}
+
+/*
+ * ⚠️ ONE TIMER FOR THE WHOLE CANVAS, started once. A timer per element would be started on every
+ * repaint — and the stage repaints on every drag — so they would accumulate silently until the
+ * editor was spending its frame budget formatting dates.
+ */
+let liveTimer = null;
+function ensureLiveTick() {
+  if (liveTimer) return;
+  liveTimer = setInterval(() => {
+    const s = slide(); if (!s) return;
+    const stage = document.getElementById('stage');
+    if (!stage || !stage.isConnected) return;
+    const els = elementsOf(s);
+    stage.querySelectorAll('[data-live]').forEach((node, idx) => {
+      // Index within the live subset, matched back to the element it was drawn from.
+      const live = els.filter((x) => LIVE_KINDS.includes(x.kind));
+      if (live[idx]) paintLive(node, live[idx]);
+    });
+  }, 1000);
 }
 
 function renderStage(container) {
@@ -455,6 +622,14 @@ function renderStage(container) {
         ? `<img src="${esc(url)}" alt="" style="width:100%;height:100%;object-fit:cover;display:block">`
         : `<div style="width:100%;height:100%;display:grid;place-items:center;background:rgba(255,255,255,.07);
              border:1px dashed rgba(255,255,255,.22);color:rgba(255,255,255,.45);font-size:2.2cqw">photo</div>`;
+    } else if (e.kind === 'qr') {
+      d.style.overflow = 'hidden';
+      paintQr(d, e, s.fields[e.slot] || '');
+    } else if (LIVE_KINDS.includes(e.kind)) {
+      // Painted now and again on the shared tick below, so the canvas shows the same thing the
+      // wall will — a clock frozen at whatever second the panel was last repainted reads as broken.
+      d.dataset.live = e.kind;
+      paintLive(d, e);
     } else if (TEXT_KINDS.includes(e.kind)) {
       d.textContent = s.fields[e.slot] || '';
     }
@@ -463,6 +638,7 @@ function renderStage(container) {
   });
   ensureKeyframes();
   ensureEditorStyles();
+  ensureLiveTick();
   const settle = settleOf(s);
   container.querySelector('#settleLabel').textContent =
     settle > s.dwell_sec
@@ -550,7 +726,11 @@ function renderStrip(container) {
         ${contentUrl(s.template.background_content_id) ? `<div style="position:absolute;inset:0;background-size:cover;background-position:center;background-image:url(${esc(contentUrl(s.template.background_content_id))})"></div>` : ''}
         ${(s.template.background_dim || 0) > 0 && contentUrl(s.template.background_content_id) ? `<div style="position:absolute;inset:0;background:rgba(0,0,0,${s.template.background_dim})"></div>` : ''}
         ${elementsOf(s).map((e) => `<div style="position:absolute;overflow:hidden;${esc(styleFor(e))}">${
-          TEXT_KINDS.includes(e.kind) ? esc(s.fields[e.slot] || '') : ''}</div>`).join('')}
+          // A thumbnail shows what the slide shows: a clock reads as a clock, and a QR is a shape
+          // rather than the raw URL behind it, which at 124px is unreadable noise either way.
+          LIVE_KINDS.includes(e.kind) ? esc(liveText(e, Date.now()) || (s.fields[e.slot] || ''))
+            : e.kind === 'qr' ? ''
+            : TEXT_KINDS.includes(e.kind) ? esc(s.fields[e.slot] || '') : ''}</div>`).join('')}
       </div>
       <div style="display:flex;gap:6px;padding:4px 6px;border-top:1px solid var(--border)">
         <span style="flex:1;font-size:11px;font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${esc(s.name)}</span>
@@ -598,6 +778,20 @@ function renderLayers(container) {
  * mid-drag — the bug that made Style and Motion unusable. Leaving it around would be leaving the
  * shape of that bug lying next to the code that replaced it.
  */
+/*
+ * Epoch milliseconds -> the value a <input type="datetime-local"> wants, in the AUTHOR's zone.
+ *
+ * ⚠️ NOT toISOString().slice(0,16). That is UTC, so an author in Chicago opening their own
+ * countdown would see it five or six hours off and "correct" it — moving the target every time the
+ * element was inspected. The offset has to be subtracted first.
+ */
+function localInput(ms) {
+  const n = Number(ms);
+  if (!Number.isFinite(n)) return '';
+  const d = new Date(n - new Date(n).getTimezoneOffset() * 60000);
+  return d.toISOString().slice(0, 16);
+}
+
 const row = (label, inner) =>
   `<div class="sl-row"><label>${label}</label>${inner}</div>`;
 
@@ -670,7 +864,38 @@ function renderProps(container) {
 
   if (state.tab === 'content') {
     host.innerHTML =
-      (isText
+      (e.kind === 'qr'
+        ? row('Encodes', `<textarea class="input" id="pText" rows="2" style="resize:vertical">${esc(s.fields[e.slot] || '')}</textarea>`)
+          + `<p style="font-size:11.5px;color:var(--text-muted);grid-column:1/-1;margin:0">
+               A URL, phone number or plain text. The code is drawn on the server, so it works with
+               no network at the panel.</p>`
+          + row('Error correction', `<select class="input" id="pQrEc">${QR_LEVELS.map(([v, lbl]) =>
+              `<option value="${v}" ${(e.qr_ec || 'M') === v ? 'selected' : ''}>${esc(lbl)}</option>`).join('')}</select>`)
+          + row('Modules', `<input type="color" class="input" id="pQrFg" value="${esc(e.qr_fg || '#000000')}">`)
+          + row('Code background', `<input type="color" class="input" id="pQrBg" value="${esc(e.qr_bg || '#FFFFFF')}">`)
+          + `<p style="font-size:11.5px;color:var(--text-muted);grid-column:1/-1;margin:0">
+               Keep a light panel behind the code — a camera reads it by contrast, and over a photo
+               it often will not scan at all.</p>`
+        : e.kind === 'clock'
+        ? row('Format', `<select class="input" id="pFmt">${CLOCK_FORMATS.map(([v, lbl]) =>
+              `<option value="${v}" ${(e.clock_format || '24') === v ? 'selected' : ''}>${esc(lbl)}</option>`).join('')}</select>`)
+          + row('Time zone', `<input class="input" id="pTz" placeholder="the panel's own" value="${esc(e.tz || '')}">`)
+          + row('Language', `<input class="input" id="pLoc" placeholder="the panel's own" value="${esc(e.locale || '')}">`)
+          + `<p style="font-size:11.5px;color:var(--text-muted);grid-column:1/-1;margin:0">
+               Leave both blank to follow the screen. A zone is an IANA name — Europe/London,
+               America/Chicago — which is how you run a lobby clock for another office.</p>`
+        : e.kind === 'date'
+        ? row('Format', `<select class="input" id="pFmt">${DATE_FORMATS.map(([v, lbl]) =>
+              `<option value="${v}" ${(e.date_format || 'long') === v ? 'selected' : ''}>${esc(lbl)}</option>`).join('')}</select>`)
+          + row('Time zone', `<input class="input" id="pTz" placeholder="the panel's own" value="${esc(e.tz || '')}">`)
+          + row('Language', `<input class="input" id="pLoc" placeholder="the panel's own" value="${esc(e.locale || '')}">`)
+        : e.kind === 'countdown'
+        ? row('Counts down to', `<input type="datetime-local" class="input" id="pTarget" value="${esc(localInput(e.target))}">`)
+          + row('Then shows', `<textarea class="input" id="pText" rows="2" style="resize:vertical">${esc(s.fields[e.slot] || '')}</textarea>`)
+          + `<p style="font-size:11.5px;color:var(--text-muted);grid-column:1/-1;margin:0">
+               The message replaces the counter once the moment passes, so the slide keeps working
+               without anybody editing it that morning.</p>`
+        : isText
         ? row('Text', `<textarea class="input" id="pText" rows="3" style="resize:vertical">${esc(s.fields[e.slot] || '')}</textarea>`)
         : e.kind === 'image'
           ? row('Photo', `<select class="input" id="pImg"><option value="">— none —</option>${
@@ -696,6 +921,32 @@ function renderProps(container) {
         s.fields[e.slot] = ev.target.value; touchValue(container);
       };
     }
+    /*
+     * ⚠️ touchValue, NOT touch, for every one of these — the same rule the Text box above states.
+     * touch() rewrites the panel's innerHTML, which destroys the control being used; on a <select>
+     * that closes the dropdown mid-choice, and on the zone box it eats the caret after one letter.
+     */
+    const bindCfg = (id, apply) => {
+      const el = host.querySelector(id);
+      if (el) el.onchange = (ev) => { apply(ev.target.value); touchValue(container); };
+      return el;
+    };
+    bindCfg('#pQrEc', (v) => { e.qr_ec = v; });
+    bindCfg('#pQrFg', (v) => { e.qr_fg = v; });
+    bindCfg('#pQrBg', (v) => { e.qr_bg = v; });
+    bindCfg('#pFmt', (v) => { if (e.kind === 'clock') e.clock_format = v; else e.date_format = v; });
+    bindCfg('#pTz', (v) => { e.tz = v.trim(); });
+    bindCfg('#pLoc', (v) => { e.locale = v.trim(); });
+    bindCfg('#pTarget', (v) => {
+      /*
+       * ⚠️ STORED AS EPOCH MILLISECONDS. A datetime-local input yields a string with no zone, so
+       * keeping it verbatim would mean the countdown resolved against whatever zone the PANEL is
+       * in — the same poster ending at different moments in two buildings. Date.parse of a
+       * zoneless string uses the AUTHOR's zone here, which is the one they meant.
+       */
+      const ms = Date.parse(v);
+      e.target = Number.isFinite(ms) ? ms : null;
+    });
     if (host.querySelector('#pImg')) {
       // A select is not a control you are mid-drag on, and swapping the photo changes nothing else
       // in this panel — but there is no reason to rebuild it either.
@@ -741,7 +992,7 @@ function renderProps(container) {
         + pair('Width', 'pW', 1, 120, 1, e.box.w, '%')
         + (e.box.h != null ? pair('Height', 'pH', 0.2, 110, 0.2, e.box.h, '%') : ''))
 
-      + (isText ? grp('Type',
+      + (GLYPH_KINDS.includes(e.kind) ? grp('Type',
           `<div class="sl-row"><label for="pFont">Font</label>
              <select class="input" id="pFont">${FONT_CATALOGUE.map((f) =>
                `<option value="${esc(f.id)}" ${f.id === resolveFont(st.font) ? 'selected' : ''}>${

--- a/server/lib/slide-deck.js
+++ b/server/lib/slide-deck.js
@@ -104,6 +104,27 @@ function normalizeDeck(raw) {
  * values are validated by the one authority that matters and then rewritten in the shape the
  * document has always used.
  */
+/**
+ * normalizeSlide's `cfg`, written back in the snake_case keys the document uses.
+ *
+ * ⚠️ THE FAILURE THIS EXISTS TO PREVENT IS SILENT. The map below rebuilds each element key by key,
+ * so anything not named here is DROPPED on every save — a clock would lose its time zone and a
+ * countdown its target the moment the deck was touched for an unrelated reason, with no error
+ * anywhere and the editor showing the operator's own choice until they reloaded. Every field the
+ * renderer accepts is a duty here too; the round-trip test in test/slide-deck-config-roundtrip.js
+ * is what holds the two lists together.
+ */
+function storedCfg(e) {
+  if (!e.cfg) return {};
+  switch (e.kind) {
+    case 'clock': return { clock_format: e.cfg.format, tz: e.cfg.tz, locale: e.cfg.locale };
+    case 'date': return { date_format: e.cfg.format, tz: e.cfg.tz, locale: e.cfg.locale };
+    case 'countdown': return { target: e.cfg.target };
+    case 'qr': return { qr_ec: e.cfg.ec, qr_fg: e.cfg.fg, qr_bg: e.cfg.bg };
+    default: return {};
+  }
+}
+
 function sanitizeStored(templateIn, fieldsIn) {
   const rawTemplate = (templateIn && typeof templateIn === 'object' && !Array.isArray(templateIn)) ? templateIn : { elements: [] };
   const rawFields = (fieldsIn && typeof fieldsIn === 'object' && !Array.isArray(fieldsIn)) ? fieldsIn : {};
@@ -128,6 +149,7 @@ function sanitizeStored(templateIn, fieldsIn) {
         opacity: e.style.opacity,
       },
       motion: e.motion,
+      ...storedCfg(e),
     })),
   };
 
@@ -150,9 +172,49 @@ function sanitizeStored(templateIn, fieldsIn) {
  * Returned rather than enforced. Refusing the save would be worse: an operator mid-edit has every
  * right to a slide that does not add up yet, and the editor can show this while they work.
  */
+/*
+ * Relative luminance and contrast ratio, the WCAG definitions.
+ *
+ * ⚠️ HERE BECAUSE A QR IS THE ONE ELEMENT THAT CAN BE DRAWN PERFECTLY AND STILL NOT WORK. A camera
+ * decodes it by thresholding light against dark, so a low-contrast pair produces a picture that is
+ * unmistakably a QR code and that no phone will read — and the person who made it has no way to
+ * tell by looking. Every other warning in this file is about something the author could eventually
+ * notice on a screen; this one they could not.
+ */
+function luminance(hex) {
+  const h = hex.replace('#', '');
+  const full = h.length === 3 ? h.split('').map((c) => c + c).join('') : h;
+  const ch = [0, 2, 4].map((i) => {
+    const v = parseInt(full.slice(i, i + 2), 16) / 255;
+    return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * ch[0] + 0.7152 * ch[1] + 0.0722 * ch[2];
+}
+
+function contrastRatio(a, b) {
+  const la = luminance(a); const lb = luminance(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+/** Below this a code is unreliable in the field even when it renders perfectly. */
+const QR_MIN_CONTRAST = 3;
+
 function deckWarnings(deck) {
   const out = [];
   for (const s of deck.slides) {
+    for (const e of normalizeSlide({ template: s.template, fields: s.fields }).elements) {
+      if (e.kind !== 'qr' || !e.cfg) continue;
+      const ratio = contrastRatio(e.cfg.fg, e.cfg.bg);
+      if (ratio >= QR_MIN_CONTRAST) continue;
+      out.push({
+        slide_id: s.id,
+        kind: 'qr-contrast',
+        message: `A QR code on "${s.name}" is ${e.cfg.fg} on ${e.cfg.bg} — a contrast of `
+          + `${ratio.toFixed(1)}:1. It will render, but a camera is unlikely to read it. `
+          + `Dark modules on a light panel scan best.`,
+        contrast: Number(ratio.toFixed(2)),
+      });
+    }
     const settle = settleTime(normalizeSlide({ template: s.template, fields: s.fields }));
     if (settle > s.dwell_sec) {
       out.push({

--- a/server/lib/slide-render.js
+++ b/server/lib/slide-render.js
@@ -73,14 +73,38 @@ const EASINGS = Object.freeze({
  */
 const slideFonts = require('./slide-fonts');
 
-/** Text kinds carry a field value; the rest are decoration and never read `fields`. */
+/*
+ * ⚠️ FOUR FLAGS, AND `text` AND `glyphs` ARE NOT THE SAME QUESTION.
+ *
+ *   text   — reads `fields[slot]`, so the kind takes part in the template/record split.
+ *   glyphs — puts characters on screen, so an @font-face must be emitted for its family.
+ *   live   — the ticking behaviour LIVE_SCRIPT implements for it, or null if it is static.
+ *   config — needs setup beyond geometry (a QR payload, a countdown target).
+ *
+ * `text` and `glyphs` used to be ONE flag, and that was correct only while every kind that showed
+ * words also got them from a field. A clock shows words and reads no field; a QR reads a field and
+ * shows no words. Collapsing them again drops the font for a clock — which renders it in whatever
+ * face the panel happens to have, the exact "different on every screen" failure the bundled font
+ * set exists to end — or emits a face for a QR that has nothing to set in it.
+ *
+ * `config` is what keeps these kinds out of the vocabulary offered to the AI slide generator
+ * (routes/ai.js): it can invent a headline, but it cannot invent a URL to encode or a date to count
+ * down to, and a kind it cannot fill would come back configured with defaults nobody asked for.
+ */
 const KINDS = Object.freeze({
-  head:  { text: true },
-  body:  { text: true },
-  stat:  { text: true },
-  image: { text: false },
-  rule:  { text: false },
-  box:   { text: false },
+  head:      { text: true,  glyphs: true,  live: null,        config: false },
+  body:      { text: true,  glyphs: true,  live: null,        config: false },
+  stat:      { text: true,  glyphs: true,  live: null,        config: false },
+  image:     { text: false, glyphs: false, live: null,        config: false },
+  rule:      { text: false, glyphs: false, live: null,        config: false },
+  box:       { text: false, glyphs: false, live: null,        config: false },
+  // The payload is a FIELD, so the URL behind a QR can be changed later without rebuilding the
+  // layout — the same reason a headline is a field. It draws no glyphs of its own.
+  qr:        { text: true,  glyphs: false, live: null,        config: true  },
+  clock:     { text: false, glyphs: true,  live: 'clock',     config: true  },
+  date:      { text: false, glyphs: true,  live: 'date',      config: true  },
+  // The field is the message shown once the target passes ("Doors open", "We are closed").
+  countdown: { text: true,  glyphs: true,  live: 'countdown', config: true  },
 });
 
 const clamp = (v, lo, hi, dflt) => {
@@ -130,6 +154,99 @@ function escapeHtml(s) {
 
 /** A slot name — the join key between template and record. */
 const SLOT_RE = /^[a-z0-9][a-z0-9_-]{0,39}$/i;
+
+/* ============ per-kind configuration: clock, date, countdown, qr ============ */
+
+/*
+ * ⚠️ ALLOWLISTS, NOT FORMAT STRINGS.
+ *
+ * The obvious design is to let an operator type a strftime-ish pattern and hand it to the player.
+ * That makes the pattern operator-controlled data flowing into a formatter, which is a much larger
+ * surface than this feature needs — and it is unnecessary, because the set of ways a signage screen
+ * should show a time is small and known. A fixed vocabulary means the renderer interpolates a value
+ * it chose itself, and the script in the page switches on it rather than interpreting it.
+ */
+const CLOCK_FORMATS = Object.freeze({ '24': 1, '24s': 1, '12': 1, '12s': 1 });
+const DATE_FORMATS = Object.freeze({ long: 1, short: 1, numeric: 1, weekday: 1 });
+const QR_EC = Object.freeze({ L: 1, M: 1, Q: 1, H: 1 });
+
+/*
+ * An IANA zone name, structurally. Deliberately NOT a list of the ~600 real ones: that list moves
+ * (zones are added and renamed by the tzdb), and a stale copy here would refuse a zone the panel
+ * actually supports. Structure is checked so nothing strange reaches an attribute; whether the zone
+ * EXISTS is answered by the platform, where Intl throws and the script falls back to local time.
+ */
+const TZ_RE = /^[A-Za-z][A-Za-z0-9_+-]*(?:\/[A-Za-z0-9_+-]+){0,2}$/;
+/** A BCP-47 tag, structurally, for the same reason. */
+const LOCALE_RE = /^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8}){0,2}$/;
+
+const pick = (table, v, dflt) =>
+  (typeof v === 'string' && Object.prototype.hasOwnProperty.call(table, v)) ? v : dflt;
+const matchOr = (re, v, max, dflt) =>
+  (typeof v === 'string' && v.length <= max && re.test(v)) ? v : dflt;
+
+/**
+ * A countdown target, as epoch milliseconds.
+ *
+ * ⚠️ MILLISECONDS, AND NEVER SECONDS. Accepting both means guessing which one a bare number is, and
+ * the guess is wrong for every target before 1970-01-01 in one direction and every target after
+ * 1970-01-21 in the other. An ISO string is accepted because that is what a date input emits, and
+ * it carries its own offset so there is nothing to infer.
+ */
+const MAX_INSTANT = Date.UTC(2200, 0, 1);
+function instant(v) {
+  const n = typeof v === 'number' ? v : (typeof v === 'string' ? Date.parse(v) : NaN);
+  if (!Number.isFinite(n) || n < 0 || n > MAX_INSTANT) return null;
+  return Math.round(n);
+}
+
+/**
+ * Everything a kind needs beyond geometry, or null for the kinds that need nothing.
+ *
+ * Total like the rest of normalize: an unrecognised format becomes the default, a malformed zone
+ * becomes absent, an unparseable target becomes null. Nothing here can fail to produce a value the
+ * renderer may interpolate.
+ */
+function kindConfig(kind, src) {
+  switch (kind) {
+    case 'clock':
+      return {
+        format: pick(CLOCK_FORMATS, src.clock_format, '24'),
+        tz: matchOr(TZ_RE, src.tz, 64, ''),
+        locale: matchOr(LOCALE_RE, src.locale, 32, ''),
+      };
+    case 'date':
+      return {
+        format: pick(DATE_FORMATS, src.date_format, 'long'),
+        tz: matchOr(TZ_RE, src.tz, 64, ''),
+        locale: matchOr(LOCALE_RE, src.locale, 32, ''),
+      };
+    case 'countdown':
+      return { target: instant(src.target) };
+    case 'qr':
+      /*
+       * ⚠️ THE MODULES ARE BLACK ON WHITE BY DEFAULT, AND THEY DO NOT INHERIT style.color.
+       *
+       * The obvious wiring is to draw the modules in the element's colour, the way every text kind
+       * does. It produces a QR THAT CANNOT BE READ: style.color defaults to #FFFFFF because slides
+       * are usually light text on a dark background, so a QR added with no styling is white modules
+       * on the white panel below — a solid white square. It renders without error, the path data is
+       * all there, and it looks like a blank box on the wall. Found by putting one on a screen; no
+       * amount of reading the code showed it.
+       *
+       * ⚠️ AND THE LIGHT PANEL IS NOT DECORATION EITHER. A camera reads a code by thresholding
+       * contrast, so dark modules straight over a photo are frequently unscannable — and the author
+       * cannot tell, because it still LOOKS like a QR. The quiet zone in qrSvg is the same point.
+       */
+      return {
+        ec: pick(QR_EC, src.qr_ec, 'M'),
+        fg: color(src.qr_fg, '#000000'),
+        bg: color(src.qr_bg, '#FFFFFF'),
+      };
+    default:
+      return null;
+  }
+}
 
 /**
  * Validate and clamp a stored slide config into exactly the shape the renderer expects.
@@ -200,6 +317,11 @@ function normalizeSlide(raw) {
         radius: clamp(style.radius_cqw, 0, 20, 0),
         opacity: clamp(style.opacity, 0, 1, 1),
       },
+      /*
+       * Per-kind setup, normalized here so the renderer never re-checks it — the same pairing the
+       * header describes. Null for every kind that needs none, so its absence is not ambiguous.
+       */
+      cfg: kindConfig(kind, src),
       motion: (m && Object.prototype.hasOwnProperty.call(ANIMATIONS, m.animation)) ? {
         animation: m.animation,
         // Bounded well below anything sane: a 40-second delay on a 10-second slide is not a slow
@@ -246,6 +368,183 @@ function settleTime(slide) {
   return (slide.elements || []).reduce(
     (max, e) => (e.motion ? Math.max(max, e.motion.delay + e.motion.duration) : max), 0);
 }
+
+/* ============ QR: drawn server-side, as an SVG, with no script at all ============ */
+
+/*
+ * ⚠️ LAZY AND CACHED. `qrcode` is already a dependency (routes/auth.js draws the MFA enrolment code
+ * with it), but it is a large module and the overwhelming majority of slides have no QR on them.
+ * Requiring it at module load makes every slide render pay for it.
+ */
+let _qrcode;
+function qrLib() {
+  if (_qrcode === undefined) {
+    try { _qrcode = require('qrcode'); } catch (e) { _qrcode = null; }
+  }
+  return _qrcode;
+}
+
+/**
+ * A QR code as an inline SVG, or null if the payload cannot be encoded.
+ *
+ * ⚠️ SERVER-SIDE AND SYNCHRONOUS, VIA `create()`. The library's `toString`/`toDataURL` are async and
+ * renderSlideHtml is not — making the renderer async to draw a QR would ripple into every caller
+ * (routes/widgets.js, routes/ai.js, the deck publisher) for no gain. `create()` returns the module
+ * matrix synchronously and the SVG below is arithmetic on it.
+ *
+ * ⚠️ AND NOT VIA A THIRD-PARTY IMAGE URL. The obvious shortcut is an <img> pointed at one of the
+ * public QR-rendering services. That puts a signage screen's content on someone else's uptime, and
+ * leaks whatever the code encodes to them on every render — for a thing this module can compute.
+ */
+function qrSvg(text, ec, darkIn, lightIn) {
+  const lib = qrLib();
+  const payload = String(text == null ? '' : text);
+  if (!lib || !payload) return null;
+  /*
+   * ⚠️ THE COLOURS AND THE LEVEL ARE RE-VALIDATED HERE, not trusted from the caller.
+   *
+   * On the render path they arrive from a normalized element and are already hex. This function is
+   * ALSO reachable from the deck editor's QR preview route, where they arrive from a QUERY STRING —
+   * and an unvalidated value lands inside `fill="…"`, which is an attribute breakout. Validating in
+   * the caller would mean every future caller has to remember; validating here means the function
+   * cannot emit anything but a colour whoever calls it and however they got there.
+   */
+  const dark = color(darkIn, '#000000');
+  const light = color(lightIn, '#FFFFFF');
+  const level = Object.prototype.hasOwnProperty.call(QR_EC, ec) ? ec : 'M';
+  let qr;
+  try {
+    qr = lib.create(payload, { errorCorrectionLevel: level });
+  } catch (e) {
+    /*
+     * Reachable without anybody doing anything wrong: MAX_FIELD_CHARS is 2000 and the largest QR
+     * holds less than that at error-correction levels above L, so a long payload throws here. The
+     * caller draws the same placeholder a missing photo gets — a slide with a hole in it is better
+     * than a slide that failed to render.
+     */
+    return null;
+  }
+  const size = qr.modules.size;
+  const data = qr.modules.data;
+
+  /*
+   * ⚠️ THE QUIET ZONE IS PART OF THE CODE, NOT PADDING. The spec requires four clear modules on
+   * every side, and a reader that cannot find them frequently will not decode at all. Dropping it
+   * makes the code look tidier in the editor and fail against real phones.
+   */
+  const QUIET = 4;
+  const dim = size + QUIET * 2;
+
+  // Horizontal runs rather than a rect per module: the same picture in roughly half the bytes, and
+  // a slide document is fetched fresh by every player on every play.
+  let d = '';
+  for (let y = 0; y < size; y++) {
+    let x = 0;
+    while (x < size) {
+      if (!data[y * size + x]) { x++; continue; }
+      let run = 1;
+      while (x + run < size && data[y * size + x + run]) run++;
+      d += `M${x + QUIET} ${y + QUIET}h${run}v1h-${run}z`;
+      x += run;
+    }
+  }
+
+  /*
+   * Every value interpolated below is generated here or already hex-validated by `color()`:
+   * `dim` and `d` are arithmetic on the matrix, `dark`/`light` are #RGB or #RRGGBB or the default.
+   * There is no path for operator text to reach the markup — the payload only ever becomes module
+   * coordinates.
+   */
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${dim} ${dim}" `
+    + `preserveAspectRatio="xMidYMid meet" shape-rendering="crispEdges" `
+    + `style="width:100%;height:100%;display:block">`
+    + `<rect width="${dim}" height="${dim}" fill="${light}"/>`
+    + `<path d="${d}" fill="${dark}"/></svg>`;
+}
+
+/* ============ the live elements: clock, date, countdown ============ */
+
+/*
+ * ⚠️ ONE CONSTANT SCRIPT, AND EVERY PARAMETER ARRIVES THROUGH THE DOM.
+ *
+ * This is the whole security design of the feature, and it is worth stating plainly because the
+ * obvious implementation is the dangerous one. `frontend/js/views/designer.js` builds a script per
+ * element by interpolating the element's configuration into JavaScript source — `setInterval` with
+ * a date pasted in, `fetch` with a URL pasted in. That makes operator input part of a program, and
+ * the only thing standing between a slide and arbitrary script in the frame is whether every one of
+ * those interpolations was escaped for a JS string context. Some of them are not.
+ *
+ * Here the script below is a CONSTANT: byte-for-byte identical in every document this module emits,
+ * containing no interpolation of any kind. Configuration reaches it as `data-` attributes, which
+ * pass through escapeHtml on the way in, and it reads them with getAttribute — a string API that
+ * cannot execute anything. It writes with `textContent` and never `innerHTML`, so even a value that
+ * somehow arrived carrying markup lands on the screen as the characters the operator typed rather
+ * than as elements. There is no path from a slide's configuration to executed code.
+ *
+ * ⚠️ A LIVE ELEMENT WITH NO WORKING SCRIPT RENDERS EMPTY, DELIBERATELY. The tempting fallback is to
+ * bake the time at render into the element so something shows if the script never runs. But a slide
+ * document is fetched once and can sit on a panel for the length of a playlist loop, so that
+ * fallback is a clock displaying a time that is quietly, plausibly wrong — which on a wall is worse
+ * than an empty box, because nobody can tell by looking.
+ */
+const LIVE_SCRIPT = `<script>
+(function () {
+  var els = document.querySelectorAll('.live');
+  if (!els.length) return;
+  function at(el, n, d) { var v = el.getAttribute(n); return v === null || v === '' ? d : v; }
+  function opts(el, kind) {
+    var o;
+    if (kind === 'clock') {
+      var f = at(el, 'data-fmt', '24');
+      o = { hour: '2-digit', minute: '2-digit', hour12: f.charAt(0) === '1' };
+      if (f.indexOf('s') >= 0) o.second = '2-digit';
+    } else {
+      var g = at(el, 'data-fmt', 'long');
+      o = g === 'weekday' ? { weekday: 'long', month: 'long', day: 'numeric' }
+        : g === 'numeric' ? { year: 'numeric', month: '2-digit', day: '2-digit' }
+        : g === 'short' ? { year: 'numeric', month: 'short', day: 'numeric' }
+        : { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+    }
+    return o;
+  }
+  function span(el, now) {
+    var t = parseInt(at(el, 'data-to', ''), 10);
+    if (!isFinite(t)) return '';
+    var ms = t - now;
+    if (ms <= 0) return at(el, 'data-done', '');
+    var s = Math.floor(ms / 1000);
+    var d = Math.floor(s / 86400), h = Math.floor((s % 86400) / 3600);
+    var m = Math.floor((s % 3600) / 60), ss = s % 60;
+    return d > 0 ? d + 'd ' + h + 'h ' + m + 'm'
+      : h > 0 ? h + 'h ' + m + 'm ' + ss + 's'
+      : m + 'm ' + ss + 's';
+  }
+  function text(el, kind, now) {
+    if (kind === 'countdown') return span(el, now);
+    var loc = at(el, 'data-loc', '') || undefined;
+    var tz = at(el, 'data-tz', '');
+    var o = opts(el, kind);
+    var when = new Date(now);
+    if (tz) {
+      o.timeZone = tz;
+      try { return new Intl.DateTimeFormat(loc, o).format(when); } catch (e) { delete o.timeZone; }
+    }
+    try { return new Intl.DateTimeFormat(loc, o).format(when); } catch (e) {}
+    try { return kind === 'clock' ? when.toLocaleTimeString() : when.toLocaleDateString(); } catch (e) {}
+    return '';
+  }
+  function tick() {
+    var now = Date.now();
+    for (var i = 0; i < els.length; i++) {
+      var el = els[i];
+      var v = text(el, el.getAttribute('data-live'), now);
+      if (el.textContent !== v) el.textContent = v;
+    }
+  }
+  tick();
+  setInterval(tick, 1000);
+})();
+</script>`;
 
 /**
  * Join the template to the record and emit a standalone document.
@@ -325,6 +624,15 @@ function renderSlideHtml(rawConfig, opts = {}) {
       return `<div class="e" style="${css.filter(Boolean).join(';')}">${inner}</div>`;
     }
 
+    if (e.kind === 'qr') {
+      // cfg.fg, NOT s.color — see kindConfig for the white-on-white failure that caused.
+      const svg = qrSvg(slide.fields[e.slot] || '', e.cfg.ec, e.cfg.fg, e.cfg.bg);
+      css.push('overflow:hidden');
+      // The same quiet placeholder a missing photo gets, for the same reason: an empty payload or
+      // one too long to encode should leave a gap somebody notices, not break the slide.
+      return `<div class="e" style="${css.filter(Boolean).join(';')}">${svg || '<div class="ph"></div>'}</div>`;
+    }
+
     css.push(
       `color:${s.color}`,
       `font-family:${fontFamilyFor(s.font)}`,
@@ -332,6 +640,27 @@ function renderSlideHtml(rawConfig, opts = {}) {
       `font-weight:${s.weight}`,
       `text-align:${s.align}`,
     );
+    const live = KINDS[e.kind].live;
+    if (live) {
+      /*
+       * ⚠️ EVERY ONE OF THESE VALUES IS ESCAPED ON THE WAY INTO THE ATTRIBUTE, even though
+       * normalizeSlide already restricted each to an allowlist, a structural regex or a number.
+       * That is the pairing the header describes and it is not redundancy for its own sake: the day
+       * somebody adds a format or widens a regex, this line is what decides whether that becomes a
+       * markup bug. `data-done` in particular carries operator text straight from a field.
+       */
+      const attrs = [`data-live="${escapeHtml(live)}"`];
+      if (live === 'countdown') {
+        if (e.cfg.target != null) attrs.push(`data-to="${e.cfg.target}"`);
+        attrs.push(`data-done="${escapeHtml(slide.fields[e.slot] || '')}"`);
+      } else {
+        attrs.push(`data-fmt="${escapeHtml(e.cfg.format)}"`);
+        if (e.cfg.tz) attrs.push(`data-tz="${escapeHtml(e.cfg.tz)}"`);
+        if (e.cfg.locale) attrs.push(`data-loc="${escapeHtml(e.cfg.locale)}"`);
+      }
+      return `<div class="e t live" ${attrs.join(' ')} style="${css.filter(Boolean).join(';')}"></div>`;
+    }
+
     return `<div class="e t" style="${css.filter(Boolean).join(';')}">${escapeHtml(slide.fields[e.slot] || '')}</div>`;
   }).join('\n    ');
 
@@ -366,7 +695,7 @@ function renderSlideHtml(rawConfig, opts = {}) {
      * Caught by looking at the emitted HTML, not by reading this function.
      */
     slide.elements
-      .filter((e) => KINDS[e.kind] && KINDS[e.kind].text)
+      .filter((e) => KINDS[e.kind] && KINDS[e.kind].glyphs)
       .map((e) => (slideFonts.isCustom(e.style.font)
         ? (customs.get(e.style.font) ? null : slideFonts.DEFAULT_FAMILY)
         : e.style.font))
@@ -412,11 +741,15 @@ function renderSlideHtml(rawConfig, opts = {}) {
 <body><div class="stage">
     ${bgLayers}
     ${body}
-</div></body></html>`;
+</div>${slide.elements.some((e) => KINDS[e.kind].live) ? LIVE_SCRIPT : ''}</body></html>`;
 }
 
 module.exports = {
   ANIMATIONS, EASINGS, KINDS,
+  CLOCK_FORMATS, DATE_FORMATS, QR_EC,
   MAX_ELEMENTS, MAX_FIELD_CHARS, MAX_FIELDS,
   normalizeSlide, settleTime, renderSlideHtml,
+  // Exported for tests: the QR matrix and the constant script are the two pieces whose properties
+  // have to be asserted directly rather than inferred from a rendered document.
+  qrSvg, LIVE_SCRIPT,
 };

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -258,7 +258,16 @@ router.post('/models', async (req, res) => {
  */
 const SLIDE_RENDER = require('../lib/slide-render');
 const SLIDE_ANIMATIONS = Object.keys(SLIDE_RENDER.ANIMATIONS || {}).filter((a) => a !== 'none');
-const SLIDE_KINDS = Object.keys(SLIDE_RENDER.KINDS || {}).filter((k) => k !== 'image');
+/*
+ * ⚠️ `config` KINDS ARE EXCLUDED ALONGSIDE `image`, and for the same reason it is.
+ *
+ * The generator writes a layout and the words in it. It cannot invent a URL worth encoding in a QR
+ * or a date worth counting down to, and offering it a kind it cannot fill produces an element
+ * configured entirely from defaults — a QR of nothing, a countdown to null — which looks like a
+ * broken slide rather than an empty one. See KINDS in lib/slide-render.js.
+ */
+const SLIDE_KINDS = Object.keys(SLIDE_RENDER.KINDS || {})
+  .filter((k) => k !== 'image' && !SLIDE_RENDER.KINDS[k].config);
 
 /*
  * The slide schema, described to a model.

--- a/server/routes/slide-decks.js
+++ b/server/routes/slide-decks.js
@@ -4,6 +4,7 @@ const { v4: uuidv4 } = require('uuid');
 const { db } = require('../db/database');
 const { accessContext } = require('../lib/tenancy');
 const deckLib = require('../lib/slide-deck');
+const slideRender = require('../lib/slide-render');
 
 /*
  * Slide decks — the authoring surface for PowerPoint-style slides.
@@ -47,6 +48,38 @@ function present(deck) {
     warnings: deckLib.deckWarnings(doc),
   };
 }
+
+/*
+ * The editor's QR preview.
+ *
+ * ⚠️ IT EXISTS SO THE CANVAS IS NOT A LIAR. The deck editor draws its own WYSIWYG stage rather than
+ * framing a server render, so without this a QR would preview as a grey rectangle and only become a
+ * real code once it reached a screen — the operator could not tell a working code from a broken one
+ * until the poster was on a wall. The designer this feature replaces did exactly that: its QR was a
+ * box with the word "QR" in it, and generateInnerHTML has no `qr` case at all, so the element
+ * vanished entirely from the published widget.
+ *
+ * ⚠️ AND IT CALLS THE RENDERER'S OWN DRAWING CODE. A second QR implementation in the browser would
+ * be a second thing to keep in step, and the failure — a preview that scans and a slide that does
+ * not, or the reverse — is invisible on the machine that authored it.
+ *
+ * ⚠️ RETURNED AS JSON, NOT AS image/svg+xml. Serving an SVG document from the dashboard's own
+ * origin is a category of thing worth not starting: an SVG loaded as a document can carry script,
+ * and the fact that THIS one is generated and carries no operator text is a property of today's
+ * code rather than of the content type. The editor base64s it into a data: URL for an <img>, which
+ * cannot execute anything whatever the bytes turn out to be.
+ */
+router.get('/qr-preview', (req, res) => {
+  const text = String(req.query.text || '').slice(0, slideRender.MAX_FIELD_CHARS);
+  const svg = slideRender.qrSvg(
+    text,
+    Object.prototype.hasOwnProperty.call(slideRender.QR_EC, req.query.ec) ? req.query.ec : 'M',
+    String(req.query.fg || ''),
+    String(req.query.bg || ''),
+  );
+  if (!svg) return res.status(422).json({ error: 'Payload is empty or too long to encode' });
+  res.json({ svg });
+});
 
 router.get('/', (req, res) => {
   if (!req.workspaceId) return res.json([]);

--- a/server/test/slide-live-kinds.test.js
+++ b/server/test/slide-live-kinds.test.js
@@ -1,0 +1,415 @@
+'use strict';
+
+/*
+ * The four kinds ported out of the designer: qr, clock, date, countdown.
+ *
+ * ⚠️ WHY THIS PORT NEEDED ITS OWN SECURITY ARGUMENT. frontend/js/views/designer.js implements the
+ * same four features by BUILDING A SCRIPT PER ELEMENT — interpolating the element's configuration
+ * into JavaScript source (`setInterval` with a date pasted in, `fetch` with a URL pasted in). Every
+ * one of those interpolations is a place where operator input becomes program text, and the slide
+ * renderer has spent its whole life keeping script out of its output on purpose.
+ *
+ * So the port is only sound if the script is a CONSTANT and the configuration travels as data. That
+ * is not a property you can eyeball once and trust — it is one edit away from being false — so it
+ * is asserted here directly: the emitted script is compared byte-for-byte against the constant, and
+ * the constant is checked for interpolation syntax.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const R = require('../lib/slide-render');
+
+const render = (elements, fields = {}) =>
+  R.renderSlideHtml({ template: { elements }, fields });
+
+/** Markup that would execute or restructure the document if any escape were missing. */
+const EVIL = '"><img src=x onerror=alert(1)><script>alert(2)</script>';
+
+/* ============ the script is a constant, and that is the whole design ============ */
+
+test('⚠️ the live script contains NO interpolation of any kind', () => {
+  /*
+   * The single property everything else rests on. A `${` in this string means some element's
+   * configuration is being pasted into JavaScript, which is the designer's model and the reason
+   * this file argues the port had to be done differently.
+   */
+  assert.ok(!R.LIVE_SCRIPT.includes('${'), 'template interpolation in the live script');
+  assert.ok(!/\+\s*(el|cfg|slide|e)\./.test(R.LIVE_SCRIPT), 'concatenation of an element value into source');
+});
+
+test('⚠️ the script never writes HTML — textContent only', () => {
+  // The second half of the argument: even a value that arrived carrying markup lands on screen as
+  // characters. An innerHTML here would reopen the exact hole the constant script closes.
+  assert.ok(!/innerHTML|insertAdjacentHTML|document\.write|outerHTML/.test(R.LIVE_SCRIPT));
+  assert.ok(R.LIVE_SCRIPT.includes('textContent'));
+});
+
+test('⚠️ the script contains no evaluator', () => {
+  assert.ok(!/\beval\b|new Function|setTimeout\(\s*['"]/.test(R.LIVE_SCRIPT));
+});
+
+test('the emitted script is byte-identical to the constant', () => {
+  const html = render([{ kind: 'clock' }]);
+  const emitted = html.slice(html.indexOf('<script>'), html.indexOf('</script>') + 9);
+  assert.equal(emitted, R.LIVE_SCRIPT, 'the document must carry the constant unmodified');
+});
+
+test('⚠️ the script selector matches the class the renderer emits', () => {
+  /*
+   * These two live 200 lines apart and nothing but this test connects them. Rename one and every
+   * clock on every screen silently stops ticking — with no error anywhere, because a selector that
+   * matches nothing is not an error.
+   */
+  const sel = R.LIVE_SCRIPT.match(/querySelectorAll\('([^']+)'\)/);
+  assert.ok(sel, 'the script must select its elements');
+  const html = render([{ kind: 'clock' }]);
+  assert.ok(html.includes(`class="e t ${sel[1].replace('.', '')}"`), `nothing carries ${sel[1]}`);
+});
+
+test('the script rides only on documents that need it', () => {
+  // Every player fetches this document fresh on every play; shipping a ticker to a slide of static
+  // text is dead weight on hardware that has little to spare.
+  assert.equal((render([{ kind: 'head', slot: 'a' }]).match(/<script/g) || []).length, 0);
+  assert.equal((render([{ kind: 'image' }, { kind: 'box' }]).match(/<script/g) || []).length, 0);
+});
+
+test('many live elements still emit exactly one script', () => {
+  const html = render([{ kind: 'clock' }, { kind: 'date' }, { kind: 'countdown', slot: 'a' }]);
+  assert.equal((html.match(/<script/g) || []).length, 1);
+});
+
+/* ============ configuration is validated, then escaped anyway ============ */
+
+test('⚠️ a hostile clock format / timezone / locale never reaches the document', () => {
+  const html = render([{ kind: 'clock', clock_format: EVIL, tz: EVIL, locale: EVIL }]);
+  assert.ok(html.includes('data-fmt="24"'), 'an unknown format must become the default');
+  assert.ok(!html.includes('data-tz='), 'a malformed zone must be dropped, not emitted');
+  assert.ok(!html.includes('data-loc='), 'a malformed locale must be dropped, not emitted');
+  assert.ok(!html.includes('<img'), 'markup breakout');
+});
+
+test('⚠️ the countdown done-message is operator text and is escaped', () => {
+  // The one value on a live element that comes straight from a field, so the one that matters most.
+  const html = render([{ kind: 'countdown', slot: 'd' }], { d: EVIL });
+  assert.ok(!html.includes('<img'), 'markup breakout through data-done');
+  assert.ok(html.includes('&quot;&gt;&lt;img'), 'the message must survive as escaped characters');
+  assert.equal((html.match(/<script/g) || []).length, 1, 'the payload must not add a script tag');
+});
+
+test('a legitimate zone and locale are carried through', () => {
+  const html = render([{ kind: 'clock', clock_format: '12s', tz: 'America/Chicago', locale: 'en-GB' }]);
+  assert.ok(html.includes('data-fmt="12s"'));
+  assert.ok(html.includes('data-tz="America/Chicago"'));
+  assert.ok(html.includes('data-loc="en-GB"'));
+});
+
+test('every clock format in the allowlist survives, and nothing else does', () => {
+  for (const f of Object.keys(R.CLOCK_FORMATS)) {
+    assert.ok(render([{ kind: 'clock', clock_format: f }]).includes(`data-fmt="${f}"`));
+  }
+  for (const f of ['', '36', 'HH:mm', null, 12, {}]) {
+    assert.ok(render([{ kind: 'clock', clock_format: f }]).includes('data-fmt="24"'), `${f} slipped through`);
+  }
+});
+
+test('every date format in the allowlist survives, and nothing else does', () => {
+  for (const f of Object.keys(R.DATE_FORMATS)) {
+    assert.ok(render([{ kind: 'date', date_format: f }]).includes(`data-fmt="${f}"`));
+  }
+  assert.ok(render([{ kind: 'date', date_format: 'yyyy-mm-dd' }]).includes('data-fmt="long"'));
+});
+
+/* ============ the countdown target ============ */
+
+test('a countdown target is normalized to epoch milliseconds', () => {
+  const n = R.normalizeSlide({ template: { elements: [{ kind: 'countdown', target: '2027-01-01T00:00:00Z' }] } });
+  assert.equal(n.elements[0].cfg.target, Date.UTC(2027, 0, 1));
+});
+
+test('a numeric target is taken as milliseconds', () => {
+  const n = R.normalizeSlide({ template: { elements: [{ kind: 'countdown', target: 1798761600000 }] } });
+  assert.equal(n.elements[0].cfg.target, 1798761600000);
+});
+
+test('⚠️ an unusable target becomes null rather than a wrong date', () => {
+  /*
+   * NaN interpolated into data-to would render as "NaN", and the script's parseInt would then make
+   * every countdown on the slide read as its done-message — a screen quietly announcing that an
+   * event has already happened.
+   */
+  for (const v of ['soon', '', null, undefined, {}, NaN, -1, Date.UTC(9999, 0, 1)]) {
+    const n = R.normalizeSlide({ template: { elements: [{ kind: 'countdown', target: v }] } });
+    assert.equal(n.elements[0].cfg.target, null, `${String(v)} should not produce a target`);
+  }
+  assert.ok(!render([{ kind: 'countdown', slot: 'a', target: 'soon' }]).includes('data-to='));
+});
+
+/* ============ QR ============ */
+
+test('a QR renders as an inline SVG with no script and no external request', () => {
+  const html = render([{ kind: 'qr', slot: 'q' }], { q: 'https://screentinker.com' });
+  assert.ok(html.includes('<svg'), 'no svg emitted');
+  assert.equal((html.match(/<script/g) || []).length, 0, 'a QR must not need script');
+  assert.ok(!/https?:\/\/(?!www\.w3\.org)/.test(html.match(/<svg[\s\S]*?<\/svg>/)[0]),
+    'the svg must not reference a third-party renderer');
+});
+
+test('⚠️ the payload becomes geometry, never markup', () => {
+  const html = render([{ kind: 'qr', slot: 'q' }], { q: EVIL });
+  assert.ok(!html.includes('<img'), 'markup breakout through the payload');
+  assert.ok(!html.includes('onerror=alert'), 'the payload must not appear as text either');
+});
+
+test('a different payload draws a different code', () => {
+  // Guards against the placeholder-for-everything failure, where a QR renders but encodes nothing.
+  const a = render([{ kind: 'qr', slot: 'q' }], { q: 'https://a.example' });
+  const b = render([{ kind: 'qr', slot: 'q' }], { q: 'https://b.example' });
+  assert.notEqual(a.match(/<path d="([^"]*)"/)[1], b.match(/<path d="([^"]*)"/)[1]);
+});
+
+test('⚠️ the quiet zone is present', () => {
+  /*
+   * Four clear modules a side are part of the spec, not padding. Without them a code still LOOKS
+   * correct in the editor and frequently will not decode against a real phone — a failure nobody
+   * discovers until the poster is on a wall.
+   */
+  const svg = R.qrSvg('https://screentinker.com', 'M', '#000000', '#FFFFFF');
+  const dim = Number(svg.match(/viewBox="0 0 (\d+)/)[1]);
+  const maxX = Math.max(...[...svg.matchAll(/M(\d+) (\d+)h(\d+)/g)].map((m) => +m[1] + +m[3]));
+  const minX = Math.min(...[...svg.matchAll(/M(\d+) /g)].map((m) => +m[1]));
+  assert.ok(minX >= 4, `modules start at ${minX}, inside the quiet zone`);
+  assert.ok(dim - maxX >= 4, `modules reach ${maxX} of ${dim}, inside the quiet zone`);
+});
+
+test('an empty or unencodable payload falls back to the placeholder, not an exception', () => {
+  assert.equal(R.qrSvg('', 'M', '#000', '#FFF'), null);
+  assert.equal(R.qrSvg('x'.repeat(2000), 'H', '#000', '#FFF'), null, 'too long for level H');
+  const html = render([{ kind: 'qr', slot: 'q' }], { q: '' });
+  assert.ok(html.includes('class="ph"'), 'an empty QR should show the same quiet gap a photo does');
+});
+
+test('QR colours come from the validated palette only', () => {
+  const html = render([{ kind: 'qr', slot: 'q', qr_bg: 'red;}</style><script>x()</script>' }],
+    { q: 'https://a.example' });
+  assert.ok(html.includes('fill="#FFFFFF"'), 'a non-hex background must fall back to white');
+  assert.equal((html.match(/<script/g) || []).length, 0);
+});
+
+/* ============ the flag split that is easy to get wrong ============ */
+
+test('⚠️ a clock gets an @font-face; a QR does not', () => {
+  /*
+   * THE BUG THIS PORT COULD EASILY HAVE SHIPPED. The face filter used to read KINDS[kind].text,
+   * which was right only while "reads a field" and "shows characters" were the same set. A clock
+   * shows characters and reads no field: under the old flag it rendered in whatever face the panel
+   * happened to have — differently on Android, Tizen and BrightSign — which is precisely the
+   * failure the bundled font set was built to end, and it is invisible on the machine that authored
+   * the slide because that machine has the font installed.
+   */
+  assert.ok(/@font-face/.test(render([{ kind: 'clock' }])), 'a clock must carry its font');
+  assert.ok(/@font-face/.test(render([{ kind: 'date' }])), 'a date must carry its font');
+  assert.ok(/@font-face/.test(render([{ kind: 'countdown', slot: 'a' }])), 'a countdown must carry its font');
+  assert.ok(!/@font-face/.test(render([{ kind: 'qr', slot: 'q' }], { q: 'https://a.example' })),
+    'a QR draws no glyphs and must not pull a font onto the wire');
+});
+
+test('the flags agree with what each kind actually emits', () => {
+  for (const [kind, k] of Object.entries(R.KINDS)) {
+    const html = render([{ kind, slot: 'a' }], { a: 'https://a.example' });
+    assert.equal(/@font-face/.test(html), k.glyphs, `${kind}: glyphs flag disagrees with the output`);
+    assert.equal(html.includes('data-live='), !!k.live, `${kind}: live flag disagrees with the output`);
+  }
+});
+
+/* ============ forward and backward compatibility ============ */
+
+test('⚠️ an older server meeting a newer deck degrades instead of throwing', () => {
+  // Decks outlive the servers that render them: a slide using a kind this build has never heard of
+  // must still put something on the wall.
+  const n = R.normalizeSlide({ template: { elements: [{ kind: 'hologram', slot: 'a' }] } });
+  assert.equal(n.elements[0].kind, 'body');
+  assert.equal(n.elements[0].cfg, null);
+});
+
+test('kinds that need no configuration carry none', () => {
+  for (const kind of ['head', 'body', 'stat', 'image', 'rule', 'box']) {
+    const n = R.normalizeSlide({ template: { elements: [{ kind }] } });
+    assert.equal(n.elements[0].cfg, null, `${kind} should not have gained a cfg`);
+  }
+});
+
+test('⚠️ the AI generator is not offered kinds it cannot fill', () => {
+  // It can write a headline. It cannot invent a URL to encode or a date to count down to, and a
+  // kind built entirely from defaults reads as a broken slide rather than an empty one.
+  const src = require('fs').readFileSync(require.resolve('../routes/ai.js'), 'utf8');
+  const listed = src.match(/const SLIDE_KINDS = [\s\S]*?;\n/)[0];
+  assert.ok(listed.includes('.config'), 'ai.js must exclude kinds that need configuration');
+  // And the flag is actually set on the four that need it, so the filter above has something to bite.
+  assert.deepEqual(
+    Object.keys(R.KINDS).filter((k) => R.KINDS[k].config).sort(),
+    ['clock', 'countdown', 'date', 'qr'],
+  );
+});
+
+/* ============ the save round-trip, where this feature could lose everything silently ============ */
+
+/*
+ * ⚠️ THE TRAP THIS SECTION EXISTS FOR. lib/slide-deck.js rebuilds every stored element KEY BY KEY
+ * on save — deliberately, because writing normalizeSlide's output back would rename half the
+ * document. Which means any field not explicitly named there is dropped, on every save, with no
+ * error: a clock loses its time zone and a countdown its target the next time the deck is touched
+ * for an unrelated reason, and the editor keeps showing the operator's own choice until they
+ * reload. The renderer's vocabulary and the writer's list are two halves of one duty.
+ */
+
+const deckLib = require('../lib/slide-deck');
+const VIEW = require('fs').readFileSync(
+  require.resolve('../../frontend/js/views/slides.js'), 'utf8');
+
+const deckWith = (elements, fields = {}) => ({
+  slides: [{ id: 's1', name: 'n', dwell_sec: 10, template: { elements }, fields }],
+});
+const savedEl = (deck, i = 0) => deckLib.normalizeDeck(deck).slides[0].template.elements[i];
+
+test('⚠️ a clock keeps its format, zone and language across a save', () => {
+  const e = savedEl(deckWith([{ kind: 'clock', slot: 'a', clock_format: '12s', tz: 'Europe/London', locale: 'en-GB' }]));
+  assert.equal(e.clock_format, '12s');
+  assert.equal(e.tz, 'Europe/London');
+  assert.equal(e.locale, 'en-GB');
+});
+
+test('⚠️ a date keeps its format across a save', () => {
+  const e = savedEl(deckWith([{ kind: 'date', slot: 'a', date_format: 'numeric', tz: 'Asia/Tokyo' }]));
+  assert.equal(e.date_format, 'numeric');
+  assert.equal(e.tz, 'Asia/Tokyo');
+});
+
+test('⚠️ a countdown keeps its target across a save', () => {
+  const t = Date.UTC(2027, 5, 1, 9, 30);
+  assert.equal(savedEl(deckWith([{ kind: 'countdown', slot: 'a', target: t }])).target, t);
+});
+
+test('⚠️ a QR keeps its level and background across a save', () => {
+  const e = savedEl(deckWith([{ kind: 'qr', slot: 'a', qr_ec: 'H', qr_bg: '#EEEEEE' }], { a: 'https://a.example' }));
+  assert.equal(e.qr_ec, 'H');
+  assert.equal(e.qr_bg, '#EEEEEE');
+});
+
+test('a second save changes nothing — the document is a fixed point', () => {
+  // Decks are re-saved constantly for unrelated reasons. A round-trip that drifts loses a little
+  // more each time, which is the shape of failure nobody notices until it has happened everywhere.
+  const deck = deckWith([
+    { kind: 'clock', slot: 'a', clock_format: '12', tz: 'Europe/London' },
+    { kind: 'countdown', slot: 'b', target: Date.UTC(2027, 0, 1) },
+    { kind: 'qr', slot: 'c', qr_ec: 'Q' },
+  ], { b: 'Open', c: 'https://a.example' });
+  const once = deckLib.normalizeDeck(deck);
+  assert.deepEqual(deckLib.normalizeDeck(once), once);
+});
+
+test('⚠️ hostile config does not survive a save either', () => {
+  // The stored document is read back by the editor, which draws the filmstrip with innerHTML — the
+  // path that was stored XSS once already. Saving is a second door onto the same decision.
+  const e = savedEl(deckWith([{ kind: 'clock', slot: 'a', clock_format: EVIL, tz: EVIL, locale: EVIL }]));
+  assert.equal(e.clock_format, '24');
+  assert.equal(e.tz, '');
+  assert.equal(e.locale, '');
+});
+
+test('a kind that needs no config gains no keys on save', () => {
+  const e = savedEl(deckWith([{ kind: 'head', slot: 'a' }], { a: 'hi' }));
+  for (const k of ['clock_format', 'date_format', 'tz', 'locale', 'target', 'qr_ec', 'qr_bg']) {
+    assert.ok(!(k in e), `a headline should not carry ${k}`);
+  }
+});
+
+/* ============ the editor offers exactly what the server accepts ============ */
+
+test('⚠️ the editor and the renderer agree on every allowlist', () => {
+  /*
+   * They are duplicated: there is no module shared between a server lib and a browser view here.
+   * The failure without this test is quiet in the worst way — the editor offers a format, the
+   * operator picks it, the save silently substitutes the default, and the wall shows something the
+   * person who built it never chose.
+   */
+  const pairs = (re) => {
+    const m = VIEW.match(re);
+    assert.ok(m, `list not found in the editor: ${re}`);
+    return [...m[1].matchAll(/\['([^']+)',/g)].map((x) => x[1]).sort();
+  };
+  assert.deepEqual(pairs(/const CLOCK_FORMATS = \[([\s\S]*?)\];/), Object.keys(R.CLOCK_FORMATS).sort());
+  assert.deepEqual(pairs(/const DATE_FORMATS = \[([\s\S]*?)\];/), Object.keys(R.DATE_FORMATS).sort());
+  assert.deepEqual(pairs(/const QR_LEVELS = \[([\s\S]*?)\];/), Object.keys(R.QR_EC).sort());
+});
+
+test('⚠️ the editor and the renderer agree on which kinds are live and which draw glyphs', () => {
+  // Three flat lists in the view against three flags in KINDS. Drift here is how a clock ends up
+  // without a font control, or a QR with one it cannot use.
+  const names = (re) => {
+    const m = VIEW.match(re);
+    assert.ok(m, `list not found in the editor: ${re}`);
+    return [...m[1].matchAll(/'([^']+)'/g)].map((x) => x[1]).sort();
+  };
+  const server = (flag) => Object.keys(R.KINDS).filter((k) => R.KINDS[k][flag]).sort();
+  assert.deepEqual(names(/const LIVE_KINDS = \[([^\]]*)\];/), server('live'));
+  assert.deepEqual(names(/const GLYPH_KINDS = \[([^\]]*)\];/), server('glyphs'));
+  assert.deepEqual(names(/const TEXT_KINDS = \[([^\]]*)\];/), server('text'));
+});
+
+/* ============ the defect a screenshot found and no amount of reading did ============ */
+
+test('⚠️ a QR added with no styling is BLACK ON WHITE, not white on white', () => {
+  /*
+   * THE BUG. The modules originally inherited style.color, the way every text kind does — and
+   * style.color defaults to #FFFFFF, because slides are usually light text on a dark background.
+   * So a QR dropped onto a slide rendered as white modules on the white panel behind them: a solid
+   * white square. Every assertion in this file still passed. The path data was all there, the quiet
+   * zone was right, the payload encoded correctly. It only showed up as an image.
+   */
+  const html = render([{ kind: 'qr', slot: 'q' }], { q: 'https://screentinker.com' });
+  const fills = [...html.matchAll(/fill="([^"]+)"/g)].map((m) => m[1]);
+  assert.deepEqual(fills, ['#FFFFFF', '#000000'], 'panel white, modules black');
+  assert.notEqual(fills[0], fills[1], 'a QR whose modules match its panel is a blank square');
+});
+
+test('⚠️ the modules do not follow style.color', () => {
+  // The wiring that caused it. A slide's text colour has nothing to do with whether a code scans.
+  const html = render([{ kind: 'qr', slot: 'q', style: { color: '#FF0000' } }], { q: 'https://a.example' });
+  assert.ok(!html.includes('fill="#FF0000"'), 'the element colour must not reach the modules');
+});
+
+test('a deliberate colour choice is still honoured', () => {
+  const html = render([{ kind: 'qr', slot: 'q', qr_fg: '#003366', qr_bg: '#FFEECC' }], { q: 'https://a.example' });
+  assert.ok(html.includes('fill="#FFEECC"') && html.includes('fill="#003366"'));
+});
+
+test('⚠️ a QR nobody can scan is a WARNING, not a silent render', () => {
+  /*
+   * The one element that can be drawn perfectly and still not work: a camera decodes by
+   * thresholding light against dark, so a low-contrast pair yields something unmistakably a QR
+   * that no phone reads — and the author cannot tell by looking at it.
+   */
+  const warn = deckLib.deckWarnings(deckLib.normalizeDeck({
+    slides: [{ id: 's1', name: 'Poster', dwell_sec: 10,
+      template: { elements: [{ kind: 'qr', slot: 'q', qr_fg: '#EEEEEE', qr_bg: '#FFFFFF' }] },
+      fields: { q: 'https://a.example' } }],
+  }));
+  const hit = warn.find((w) => w.kind === 'qr-contrast');
+  assert.ok(hit, 'a white-on-white QR must warn');
+  assert.ok(hit.contrast < 3, `contrast reported as ${hit.contrast}`);
+  assert.match(hit.message, /camera/i);
+});
+
+test('a normal QR produces no warning', () => {
+  const warn = deckLib.deckWarnings(deckLib.normalizeDeck({
+    slides: [{ id: 's1', name: 'Poster', dwell_sec: 10,
+      template: { elements: [{ kind: 'qr', slot: 'q' }] }, fields: { q: 'https://a.example' } }],
+  }));
+  assert.equal(warn.filter((w) => w.kind === 'qr-contrast').length, 0);
+});
+
+test('the QR foreground survives a save like every other config field', () => {
+  const e = savedEl(deckWith([{ kind: 'qr', slot: 'a', qr_fg: '#112233' }], { a: 'https://a.example' }));
+  assert.equal(e.qr_fg, '#112233');
+});


### PR DESCRIPTION
Tier 1 and 2 of moving the designer into slides: **clock, date, countdown and QR**, with editor tools, inspectors and a live WYSIWYG canvas for each.

Designer is labelled **"Designer (deprecating)"** in the nav rather than removed — existing designer-made widgets still play and are still re-editable there, and pulling the entry would strand them in the raw HTML editor.

## The escaping, since that is the whole reason this could be done at all

`views/designer.js` implements these same features by building **a script per element**, interpolating configuration into JavaScript source — `setInterval` with a date pasted in, `fetch` with a URL pasted in. That makes operator input part of a program, and the only defence is whether every interpolation was escaped for a JS string context.

Here the script is a **constant** — byte-identical in every document, no interpolation of any kind. Configuration reaches it as `data-` attributes through `escapeHtml`, is read with `getAttribute`, and is written with `textContent`, never `innerHTML`. There is no path from a slide's configuration to executed code.

That is asserted directly rather than by inspection: the emitted script is compared **byte-for-byte** against the constant, and the constant is checked for `${`, for `innerHTML` and for evaluators.

On top of that — formats are allowlists rather than format strings, zones and locales are structural regexes, the countdown target is normalised to epoch milliseconds, and the QR payload only ever becomes module coordinates. QR is drawn server-side from the already-bundled `qrcode`, so a code needs no network at the panel and no third-party image service.

## Two failures worth reading about

**The QR was a solid white square, and only a screenshot found it.** The modules first inherited `style.color`, the way every text kind does — and that defaults to `#FFFFFF`, because slides are usually light text on dark. So a QR added with no styling was white modules on the white panel behind them. Every test passed, the path data was correct, the payload encoded fine. Modules now have their own colour defaulting to black, and a new `qr-contrast` deck warning catches an unscannable pair at authoring time instead of on a wall.

**The save path would have silently eaten every new field.** `lib/slide-deck.js` rebuilds each stored element key by key — deliberately — so anything not named there is dropped on every save with no error. A clock would have lost its time zone the next time the deck was touched for an unrelated reason, and the editor would have kept showing the operator's own choice until they reloaded. `storedCfg` closes it, with a fixed-point test holding the two lists together.

## Also found

The designer's QR **was never real**: its editor draws a box with the word "QR" and 25 characters of the payload, and `generateInnerHTML` has no `qr` case at all, so the element vanishes entirely from the published widget. Anyone who thinks they have QR codes on screens today does not.

## Design notes

- `KINDS` now carries **two flags, not one**. `text` = reads `fields[slot]`; `glyphs` = draws characters and needs an `@font-face`. A clock draws characters and reads no field; a QR reads a field and draws none. Collapsing them drops the font for a clock, which renders it in whatever face the panel happens to have — invisible on the machine that authored the slide.
- Kinds needing configuration are excluded from the AI generator's vocabulary: it can write a headline but cannot invent a URL to encode or a date to count down to.
- The QR preview endpoint calls the renderer's own drawing code, so there is no second QR implementation to drift.

## Verification

Driven on a real render and in the editor: clock ticking in Europe/London 12-hour, date honouring the weekday format, countdown counting, and a genuine 41x41 QR with its quiet zone. Configuration survives a save made through the UI. No console errors.

- **41 new tests**; eleven mutations applied to the code, all caught.
- **2824 pass / 3 fail** — the three are `triggers-udp` multicast tests needing a real multicast interface; they fail identically on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kfhrUPit5MCqxeTQyqr56
