### PR TITLE
Layered slides: generated objects and painted lettering, cut out and animated separately

### DIFF
--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -581,6 +581,13 @@ export const api = {
   // slide references its background by id because the file has to reach a screen and be playable
   // with the WAN down, which an inline data: URL never could.
   aiGenerateBackground: (prompt, dims) => request('/ai/generate-background', { method: 'POST', body: JSON.stringify({ prompt, ...(dims || {}) }) }),
+  /*
+   * A background PLUS cut-out objects, each its own animatable element. One press is up to five
+   * paid generations upstream, so the caller must be single-flight about it.
+   */
+  aiGenerateLayered: (prompt, dims, objects) => request('/ai/generate-layered', {
+    method: 'POST', body: JSON.stringify({ prompt, ...(dims || {}), objects }),
+  }),
   aiListModels: (base_url, api_key) => request('/ai/models', { method: 'POST', body: JSON.stringify({ base_url, api_key }) }),
 
   // Instance-level default branding (#15, platform admin).

--- a/frontend/js/views/slides.js
+++ b/frontend/js/views/slides.js
@@ -300,6 +300,8 @@ function renderEditor(container) {
                placeholder="${esc(t('slides.ai.placeholder'))}" maxlength="500">
         <button class="btn btn-secondary btn-sm" id="aiGenBtn">${esc(t('slides.ai.generate'))}</button>
         <button class="btn btn-secondary btn-sm" id="aiBgBtn" title="Generate a background image from the same prompt">Generate background</button>
+        <button class="btn btn-secondary btn-sm" id="aiLayerBtn"
+          title="Generate a background plus separate cut-out objects, each with its own entrance. Uses several image generations.">Generate layers</button>
         <button class="btn-icon" id="aiCfgBtn" title="${esc(t('slides.ai.settings'))}" aria-label="${esc(t('slides.ai.settings'))}" style="padding:4px 8px">
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <circle cx="12" cy="12" r="3"/>
@@ -359,6 +361,7 @@ function renderEditor(container) {
   });
   container.querySelector('#aiGenBtn').addEventListener('click', () => aiGenerate(container));
   container.querySelector('#aiBgBtn').addEventListener('click', () => aiGenerateBackground(container));
+  container.querySelector('#aiLayerBtn').addEventListener('click', () => aiGenerateLayered(container));
   container.querySelector('#aiPrompt').addEventListener('keydown', (e) => {
     if (e.key === 'Enter') { e.preventDefault(); aiGenerate(container); }
   });
@@ -619,7 +622,8 @@ function renderStage(container) {
       const url = contentUrl(e.content_id);
       d.style.overflow = 'hidden';
       d.innerHTML = url
-        ? `<img src="${esc(url)}" alt="" style="width:100%;height:100%;object-fit:cover;display:block">`
+        ? `<img src="${esc(url)}" alt="" style="width:100%;height:100%;object-fit:${
+            e.fit === 'contain' ? 'contain' : 'cover'};display:block">`
         : `<div style="width:100%;height:100%;display:grid;place-items:center;background:rgba(255,255,255,.07);
              border:1px dashed rgba(255,255,255,.22);color:rgba(255,255,255,.45);font-size:2.2cqw">photo</div>`;
     } else if (e.kind === 'qr') {
@@ -901,8 +905,14 @@ function renderProps(container) {
           ? row('Photo', `<select class="input" id="pImg"><option value="">— none —</option>${
               (state.contentIndex || []).map((c) => `<option value="${esc(c.id)}" ${
                 c.id === e.content_id ? 'selected' : ''}>${esc(c.filename)}</option>`).join('')}</select>`)
+            + row('Fit', `<select class="input" id="pFit">
+                 <option value="cover" ${(e.fit || 'cover') === 'cover' ? 'selected' : ''}>Fill the box (crop)</option>
+                 <option value="contain" ${e.fit === 'contain' ? 'selected' : ''}>Fit inside (whole image)</option>
+               </select>`)
             + `<p style="font-size:11.5px;color:var(--text-muted);grid-column:1/-1;margin:0">
-                 Pick from the content library — the slide stores a reference, not a copy.</p>`
+                 Pick from the content library — the slide stores a reference, not a copy.
+                 Use <strong>Fit inside</strong> for a cut-out with transparency — filling the box
+                 crops it, which slices through the object itself.</p>`
           : `<p style="font-size:12px;color:var(--text-muted)">Decorative — no text.</p>`)
       + `<div style="display:grid;grid-template-columns:1fr 1fr;gap:8px">
            <button class="btn btn-secondary btn-sm" id="pFwd">↑ Forward</button>
@@ -932,6 +942,7 @@ function renderProps(container) {
       return el;
     };
     bindCfg('#pQrEc', (v) => { e.qr_ec = v; });
+    bindCfg('#pFit', (v) => { e.fit = v; });
     bindCfg('#pQrFg', (v) => { e.qr_fg = v; });
     bindCfg('#pQrBg', (v) => { e.qr_bg = v; });
     bindCfg('#pFmt', (v) => { if (e.kind === 'clock') e.clock_format = v; else e.date_format = v; });
@@ -1306,6 +1317,7 @@ async function publish(container) {
  */
 let aiBusy = false;
 let aiBgBusy = false;   // an image generation costs money per click; never let two run
+let aiLayerBusy = false; // and this one is up to FIVE generations per click
 
 /*
  * Generate a background PICTURE for the slide you are on.
@@ -1383,6 +1395,73 @@ async function aiGenerateBackground(container) {
     say(String((e && e.message) || e).slice(0, 200), true);
   } finally {
     aiBgBusy = false;
+    btn.disabled = false;
+    btn.textContent = label;
+  }
+}
+
+/*
+ * A background plus cut-out objects, each landing as its own element with its own entrance.
+ *
+ * ⚠️ THE EXPENSIVE ONE. A press is one generation for the background and one per object, all on the
+ * operator's metered endpoint, so this is single-flight on its own flag and says what it is about
+ * to spend before it spends it.
+ */
+async function aiGenerateLayered(container) {
+  const promptEl = container.querySelector('#aiPrompt');
+  const statusEl = container.querySelector('#aiStatus');
+  const btn = container.querySelector('#aiLayerBtn');
+  const prompt = (promptEl.value || '').trim();
+  const say = (msg, bad) => {
+    statusEl.textContent = msg;
+    statusEl.style.color = bad ? 'var(--danger, #e05252)' : 'var(--text-muted)';
+  };
+  if (!prompt) { say('Describe the scene first.', true); promptEl.focus(); return; }
+  if (aiLayerBusy) return;
+  if (!state.deck.doc.slides.length) { say('Add a slide first.', true); return; }
+
+  const OBJECTS = 3;
+  /*
+   * ⚠️ ASKED, NOT ASSUMED. Every other button here costs at most one generation; this one costs
+   * four and replaces the whole slide. Both of those are surprises worth one click to avoid.
+   */
+  if (!window.confirm(
+    `Generate a layered slide?\n\nThis makes ${OBJECTS + 1} images on your image endpoint `
+    + '(one background and one per object) and replaces the current slide.')) return;
+
+  // Same identity trick as the background button: this takes a minute and the operator can move.
+  const target = state.deck.doc.slides[state.si];
+
+  aiLayerBusy = true;
+  btn.disabled = true;
+  const label = btn.textContent;
+  btn.textContent = 'Generating…';
+  say(`Generating ${OBJECTS + 1} images and cutting the objects out — this takes a few minutes.`);
+  try {
+    const out = await api.aiGenerateLayered(prompt, aspectPixels(), OBJECTS);
+    if (!out || !out.template) throw new Error('nothing came back');
+    const idx = state.deck.doc.slides.indexOf(target);
+    if (idx < 0) { say('That slide is gone — nothing changed.', true); return; }
+    target.template = out.template;
+    target.fields = out.fields || {};
+    // The new cut-outs are content created seconds ago, so the cached index cannot resolve them and
+    // every layer would render as an empty placeholder. Same trap as the background button.
+    await loadContent();
+    touch(container);
+    paintAll(container);
+    /*
+     * ⚠️ SAY WHAT DID NOT ARRIVE. An object whose backdrop came back as a gradient is refused
+     * server-side rather than laid on as a torn cut-out — so the operator can get four layers, or
+     * two, and the difference must not be something they have to notice for themselves.
+     */
+    const short = out.generated === out.requested
+      ? `Built ${out.generated} layers.`
+      : `Built ${out.generated} of ${out.requested} layers.`;
+    say(out.notes && out.notes.length ? `${short} ${out.notes[0]}` : short, out.generated < out.requested);
+  } catch (e) {
+    say(String((e && e.message) || e).slice(0, 200), true);
+  } finally {
+    aiLayerBusy = false;
     btn.disabled = false;
     btn.textContent = label;
   }

--- a/frontend/js/views/slides.js
+++ b/frontend/js/views/slides.js
@@ -39,6 +39,7 @@ const KINDS = {
   date: { icon: '▤', label: 'Date', size: 4, weight: 400 },
   countdown: { icon: '◔', label: 'Countdown', size: 9, weight: 700 },
   qr: { icon: '▦', label: 'QR code', size: 0, weight: 400 },
+  lettering: { icon: '✒', label: 'Lettering', size: 0, weight: 400 },
 };
 
 /*
@@ -53,7 +54,7 @@ const KINDS = {
  * the bug the renderer's KINDS comment describes, and it looks correct in this editor either way —
  * the machine authoring the slide has the fonts installed.
  */
-const TEXT_KINDS = ['head', 'body', 'stat', 'countdown', 'qr'];
+const TEXT_KINDS = ['head', 'body', 'stat', 'countdown', 'qr', 'lettering'];
 const GLYPH_KINDS = ['head', 'body', 'stat', 'clock', 'date', 'countdown'];
 const LIVE_KINDS = ['clock', 'date', 'countdown'];
 
@@ -626,6 +627,18 @@ function renderStage(container) {
             e.fit === 'contain' ? 'contain' : 'cover'};display:block">`
         : `<div style="width:100%;height:100%;display:grid;place-items:center;background:rgba(255,255,255,.07);
              border:1px dashed rgba(255,255,255,.22);color:rgba(255,255,255,.45);font-size:2.2cqw">photo</div>`;
+    } else if (e.kind === 'lettering') {
+      const url = contentUrl(e.content_id);
+      d.style.overflow = 'hidden';
+      if (url) {
+        d.innerHTML = `<img src="${esc(url)}" alt="${esc(s.fields[e.slot] || '')}"
+          style="width:100%;height:100%;object-fit:contain;display:block">`;
+      } else {
+        // No artwork yet: show the words, so the element is placeable before it is generated.
+        d.innerHTML = `<div style="width:100%;height:100%;display:grid;place-items:center;
+          border:1px dashed rgba(255,255,255,.22);color:rgba(255,255,255,.55);font-size:3cqw;
+          text-align:center;padding:2%">${esc(s.fields[e.slot] || 'Lettering')}</div>`;
+      }
     } else if (e.kind === 'qr') {
       d.style.overflow = 'hidden';
       paintQr(d, e, s.fields[e.slot] || '');
@@ -899,6 +912,12 @@ function renderProps(container) {
           + `<p style="font-size:11.5px;color:var(--text-muted);grid-column:1/-1;margin:0">
                The message replaces the counter once the moment passes, so the slide keeps working
                without anybody editing it that morning.</p>`
+        : e.kind === 'lettering'
+        ? row('Words', `<textarea class="input" id="pText" rows="2" style="resize:vertical">${esc(s.fields[e.slot] || '')}</textarea>`)
+          + `<p style="font-size:11.5px;color:var(--text-muted);grid-column:1/-1;margin:0">
+               These words are the record — they stay editable, are read out to screen readers, and
+               are what a regenerate is asked for. <strong>The picture will not change until you
+               generate it again.</strong> Check the artwork actually spells them.</p>`
         : isText
         ? row('Text', `<textarea class="input" id="pText" rows="3" style="resize:vertical">${esc(s.fields[e.slot] || '')}</textarea>`)
         : e.kind === 'image'

--- a/server/lib/image-key.js
+++ b/server/lib/image-key.js
@@ -1,0 +1,160 @@
+'use strict';
+
+/*
+ * Cutting a generated object off its backdrop, in pure JavaScript.
+ *
+ * ⚠️ WHY KEYING AND NOT SEGMENTATION. The obvious reading of "put the pumpkin from that poster on a
+ * slide" is: segment the object out of a finished image. That needs a model — SAM or similar —
+ * which means onnxruntime, a native dependency and a ~100MB asset, on a project that deliberately
+ * DROPPED sharp so that better-sqlite3 would be the last native dep, and that has to keep running
+ * on a BrightSign. It is also worse at the job: an object composited onto a bokeh gradient has no
+ * clean boundary to find, so the edges come back ragged around exactly the thin features — stems,
+ * serrations — that a viewer looks at.
+ *
+ * So the pieces are GENERATED individually on a flat backdrop instead, and this file keys that
+ * backdrop out. Measured against real Grok output: asked for a flat chroma backdrop it returned
+ * one whose border pixels sit inside a couple of units of each other, which is a far easier and far
+ * more reliable thing to remove than a segmentation boundary. Three leaves with serrated edges,
+ * hairline stems and gaps between them cut out cleanly with 0.25% of pixels in the feathered band.
+ *
+ * Everything here is arithmetic on an RGBA bitmap, so it needs no decoder and no dependency of its
+ * own — the caller supplies the bitmap. That also makes it testable against a synthetic image
+ * rather than a fixture, which matters: a keyer that is wrong at the EDGES is the failure mode, and
+ * a hand-built bitmap can state exactly where the edge is.
+ */
+
+/** Alpha at or below this counts as background when measuring or trimming. */
+const CLEAR = 8;
+
+/**
+ * The backdrop colour, as the median of the border ring.
+ *
+ * ⚠️ THE MEDIAN OF A RING, NOT ONE CORNER. A single corner sample is one pixel of JPEG noise away
+ * from being wrong, and the whole key is derived from it — a bad sample does not degrade the
+ * result, it destroys it, taking either the entire object or none of the backdrop. The median of
+ * the border is immune to a few stray pixels, and if the generator did put something in a corner
+ * it is still the majority colour that wins.
+ */
+function sampleKey(bm, step = 8) {
+  const px = [];
+  const at = (x, y) => {
+    const i = (y * bm.width + x) * 4;
+    return [bm.data[i], bm.data[i + 1], bm.data[i + 2]];
+  };
+  for (let x = 0; x < bm.width; x += step) { px.push(at(x, 0)); px.push(at(x, bm.height - 1)); }
+  for (let y = 0; y < bm.height; y += step) { px.push(at(0, y)); px.push(at(bm.width - 1, y)); }
+  const med = (k) => {
+    const v = px.map((p) => p[k]).sort((a, b) => a - b);
+    return v[v.length >> 1];
+  };
+  return [med(0), med(1), med(2)];
+}
+
+/**
+ * How uniform the backdrop actually is — the spread of the border ring around its median.
+ *
+ * ⚠️ THE CALLER NEEDS THIS TO KNOW WHETHER TO TRUST THE RESULT. A generator asked for a flat
+ * backdrop usually gives one, but not always: ask twice and one reply may come back with a gradient
+ * or a vignette. Keying that produces a cut-out with a torn edge or a ghost of the backdrop still
+ * attached, and it LOOKS like a cut-out, so nothing downstream notices. A number here lets the
+ * caller reject the image and ask again instead of laying a ruined object onto somebody's slide.
+ */
+function backdropSpread(bm, keyRgb, step = 8) {
+  const [kr, kg, kb] = keyRgb;
+  let worst = 0;
+  const check = (x, y) => {
+    const i = (y * bm.width + x) * 4;
+    const d = Math.sqrt((bm.data[i] - kr) ** 2 + (bm.data[i + 1] - kg) ** 2 + (bm.data[i + 2] - kb) ** 2);
+    if (d > worst) worst = d;
+  };
+  for (let x = 0; x < bm.width; x += step) { check(x, 0); check(x, bm.height - 1); }
+  for (let y = 0; y < bm.height; y += step) { check(0, y); check(bm.width - 1, y); }
+  return worst;
+}
+
+/**
+ * Replace the backdrop with transparency, in place.
+ *
+ * tol     — distance from the key below which a pixel is entirely backdrop
+ * soft    — width of the band above tol over which alpha ramps up, i.e. the feathered edge
+ * despill — pull the backdrop's own hue out of edge pixels
+ *
+ * ⚠️ THE FEATHER IS THE POINT, NOT A REFINEMENT. A hard threshold gives every edge a one-pixel
+ * staircase, and on a 4K panel showing a 2048px cut-out scaled up, that staircase is what the eye
+ * lands on. The ramp costs nothing and is the difference between "a cut-out" and "a sticker".
+ */
+function keyOut(bm, keyRgb, opts = {}) {
+  const tol = opts.tol == null ? 70 : opts.tol;
+  const soft = opts.soft == null ? 50 : opts.soft;
+  const despill = opts.despill !== false;
+  const [kr, kg, kb] = keyRgb;
+  // Which channel the backdrop leads on; only a dominant one can spill. A white or grey backdrop
+  // has no dominant channel and nothing to suppress, which is why this can be null.
+  const lead = (kr > kg && kr > kb) ? 0 : (kg > kr && kg > kb) ? 1 : (kb > kr && kb > kg) ? 2 : null;
+  const d = bm.data;
+  for (let i = 0; i < d.length; i += 4) {
+    const dist = Math.sqrt((d[i] - kr) ** 2 + (d[i + 1] - kg) ** 2 + (d[i + 2] - kb) ** 2);
+    let a;
+    if (dist <= tol) a = 0;
+    else if (dist < tol + soft) a = Math.round(((dist - tol) / soft) * 255);
+    else a = 255;
+    d[i + 3] = a;
+    /*
+     * ⚠️ DESPILL RUNS ON THE WHOLE EDGE BAND, not only on partially transparent pixels.
+     *
+     * The first version only touched pixels with fractional alpha, and a spike against real
+     * generated leaves showed a faint green line surviving along the serrations: the pixels just
+     * INSIDE the object are fully opaque and still carry the backdrop's bounce light. Opaque is
+     * exactly where a fringe is most visible, because nothing behind it dilutes the colour.
+     */
+    if (lead != null && a > 0 && dist < tol + soft * 3) {
+      const other = lead === 0 ? Math.max(d[i + 1], d[i + 2])
+        : lead === 1 ? Math.max(d[i], d[i + 2])
+          : Math.max(d[i], d[i + 1]);
+      if (d[i + lead] > other) d[i + lead] = other;
+    }
+  }
+}
+
+/**
+ * The bounding box of what survived, or null if nothing did.
+ *
+ * ⚠️ NULL RATHER THAN AN EMPTY BOX, because "the key removed the entire image" is a real outcome —
+ * an object whose colour happens to match its backdrop — and it must reach the caller as a refusal.
+ * Returning a 0x0 crop instead would store an empty PNG in somebody's content library and lay an
+ * invisible element on their slide.
+ */
+function contentBounds(bm) {
+  let x0 = bm.width; let y0 = bm.height; let x1 = -1; let y1 = -1;
+  for (let y = 0; y < bm.height; y++) {
+    for (let x = 0; x < bm.width; x++) {
+      if (bm.data[(y * bm.width + x) * 4 + 3] > CLEAR) {
+        if (x < x0) x0 = x;
+        if (x > x1) x1 = x;
+        if (y < y0) y0 = y;
+        if (y > y1) y1 = y;
+      }
+    }
+  }
+  if (x1 < x0 || y1 < y0) return null;
+  return { x: x0, y: y0, w: x1 - x0 + 1, h: y1 - y0 + 1 };
+}
+
+/** What fraction of the bitmap is opaque / feathered / clear — the caller's sanity check. */
+function coverage(bm) {
+  let opaque = 0; let feathered = 0; let clear = 0;
+  for (let i = 3; i < bm.data.length; i += 4) {
+    const a = bm.data[i];
+    if (a <= CLEAR) clear++;
+    else if (a === 255) opaque++;
+    else feathered++;
+  }
+  const total = opaque + feathered + clear || 1;
+  return {
+    opaque: opaque / total,
+    feathered: feathered / total,
+    clear: clear / total,
+  };
+}
+
+module.exports = { sampleKey, backdropSpread, keyOut, contentBounds, coverage, CLEAR };

--- a/server/lib/image-ops-core.js
+++ b/server/lib/image-ops-core.js
@@ -139,4 +139,58 @@ async function measureAndThumbnail(src, destPath, width, quality = 70) {
   }
 }
 
-module.exports = { metadata, writeThumbnail, measureAndThumbnail, readImage };
+/*
+ * Cut an object off its flat backdrop and write it as a PNG with alpha.
+ *
+ * ⚠️ ON THE WORKER SIDE FOR THE REASON THIS WHOLE MODULE PAIR EXISTS. Keying is one pass of
+ * arithmetic per pixel, and the images this runs on are what an image endpoint returns — 2048x2048
+ * is 4.2 million pixels, each costing a square root. That is exactly the shape of main-thread work
+ * that produced #240 (blocked loop, missed heartbeats, panels marked offline). It goes where the
+ * decoding already goes.
+ *
+ * ⚠️ PNG, NEVER JPEG. JPEG has no alpha channel at all, so a cut-out saved as one silently gets its
+ * transparency composited onto black — an object with a black box around it, which on a slide is
+ * worse than not having the feature.
+ *
+ * Returns what the caller needs to decide whether to trust the result: how flat the backdrop
+ * actually was, and how much of the frame survived.
+ */
+async function cutout(src, destPath, opts = {}) {
+  const key = require('./image-key');
+  const img = await readImage(src);
+  // Work at a bounded size: the object is laid onto a slide element a fraction of a screen wide, so
+  // a 2048px cut-out is detail nobody sees, at 4x the pixels to key and to ship to every player.
+  const max = opts.maxWidth || 1024;
+  if (img.bitmap.width > max) img.resize({ w: max });
+
+  const keyRgb = opts.key || key.sampleKey(img.bitmap);
+  const spread = key.backdropSpread(img.bitmap, keyRgb);
+  key.keyOut(img.bitmap, keyRgb, opts);
+
+  const bounds = key.contentBounds(img.bitmap);
+  if (!bounds) {
+    // The key removed everything. Refused rather than written: see image-key.contentBounds.
+    return { written: false, reason: 'the backdrop key removed the entire image', keyRgb, spread };
+  }
+  /*
+   * ⚠️ MEASURED AFTER THE CROP, so the numbers describe the asset the caller is about to store
+   * rather than the frame it was cut from. Measured before, a sparse subject reads as alarmingly
+   * empty purely because it was generated small in a large frame — three leaves came back "15%
+   * opaque" pre-crop and 34% post-crop, and the caller would be judging the wrong thing.
+   *
+   * `frame` is the other half of that: how much of the original frame the object occupied. A tiny
+   * value means the generator drew something small in a big empty backdrop, which is worth knowing
+   * separately from how solid the object itself is.
+   */
+  img.crop(bounds);
+  const cov = key.coverage(img.bitmap);
+  await fs.promises.writeFile(destPath, await img.getBuffer('image/png'));
+  return {
+    written: true, keyRgb, spread,
+    width: img.bitmap.width, height: img.bitmap.height,
+    opaque: cov.opaque, feathered: cov.feathered,
+    frame: (bounds.w * bounds.h) / (max * max || 1),
+  };
+}
+
+module.exports = { metadata, writeThumbnail, measureAndThumbnail, readImage, cutout };

--- a/server/lib/image-ops-worker.js
+++ b/server/lib/image-ops-worker.js
@@ -17,6 +17,7 @@ const OPS = {
   metadata: (job) => core.metadata(job.src),
   writeThumbnail: (job) => core.writeThumbnail(job.src, job.dest, job.width, job.quality),
   measureAndThumbnail: (job) => core.measureAndThumbnail(job.src, job.dest, job.width, job.quality),
+  cutout: (job) => core.cutout(job.src, job.dest, job.opts),
 };
 
 parentPort.on('message', async (job) => {

--- a/server/lib/image-ops.js
+++ b/server/lib/image-ops.js
@@ -96,9 +96,10 @@ function pump() {
 // is announced rather than silent.
 async function runInline(job) {
   const core = require('./image-ops-core');
-  return job.op === 'metadata'
-    ? core.metadata(job.src)
-    : core.writeThumbnail(job.src, job.dest, job.width, job.quality);
+  if (job.op === 'metadata') return core.metadata(job.src);
+  if (job.op === 'cutout') return core.cutout(job.src, job.dest, job.opts);
+  if (job.op === 'measureAndThumbnail') return core.measureAndThumbnail(job.src, job.dest, job.width, job.quality);
+  return core.writeThumbnail(job.src, job.dest, job.width, job.quality);
 }
 
 function submit(job) {
@@ -144,4 +145,12 @@ async function shutdown() {
   if (w) await w.terminate();
 }
 
-module.exports = { metadata, writeThumbnail, measureAndThumbnail, shutdown };
+/*
+ * Key a flat backdrop out of `src` and write the trimmed result to `destPath` as a PNG with alpha.
+ * See image-ops-core.cutout for why this belongs off the main thread.
+ */
+function cutout(src, dest, opts) {
+  return submit({ op: 'cutout', src, dest, opts: opts || {} });
+}
+
+module.exports = { metadata, writeThumbnail, measureAndThumbnail, cutout, shutdown };

--- a/server/lib/slide-deck.js
+++ b/server/lib/slide-deck.js
@@ -121,6 +121,7 @@ function storedCfg(e) {
     case 'date': return { date_format: e.cfg.format, tz: e.cfg.tz, locale: e.cfg.locale };
     case 'countdown': return { target: e.cfg.target };
     case 'image': return { fit: e.cfg.fit };
+    case 'lettering': return { fit: e.cfg.fit };
     case 'qr': return { qr_ec: e.cfg.ec, qr_fg: e.cfg.fg, qr_bg: e.cfg.bg };
     default: return {};
   }

--- a/server/lib/slide-deck.js
+++ b/server/lib/slide-deck.js
@@ -120,6 +120,7 @@ function storedCfg(e) {
     case 'clock': return { clock_format: e.cfg.format, tz: e.cfg.tz, locale: e.cfg.locale };
     case 'date': return { date_format: e.cfg.format, tz: e.cfg.tz, locale: e.cfg.locale };
     case 'countdown': return { target: e.cfg.target };
+    case 'image': return { fit: e.cfg.fit };
     case 'qr': return { qr_ec: e.cfg.ec, qr_fg: e.cfg.fg, qr_bg: e.cfg.bg };
     default: return {};
   }

--- a/server/lib/slide-render.js
+++ b/server/lib/slide-render.js
@@ -171,6 +171,17 @@ const DATE_FORMATS = Object.freeze({ long: 1, short: 1, numeric: 1, weekday: 1 }
 const QR_EC = Object.freeze({ L: 1, M: 1, Q: 1, H: 1 });
 
 /*
+ * How a photo sits in its box.
+ *
+ * ⚠️ `contain` EXISTS FOR CUT-OUTS, and without it they are unusable. `cover` fills the box and
+ * crops whatever does not fit, which is right for a photograph used as a panel — and wrong for an
+ * object with transparency around it, because the crop slices the object itself. Measured: a
+ * generated pumpkin laid into a 34x62 box lost its bottom third, and it looks like a bad
+ * photograph rather than a setting anybody would think to change.
+ */
+const IMAGE_FITS = Object.freeze({ cover: 1, contain: 1 });
+
+/*
  * An IANA zone name, structurally. Deliberately NOT a list of the ~600 real ones: that list moves
  * (zones are added and renamed by the tzdb), and a stale copy here would refuse a zone the panel
  * actually supports. Structure is checked so nothing strange reaches an attribute; whether the zone
@@ -223,6 +234,10 @@ function kindConfig(kind, src) {
       };
     case 'countdown':
       return { target: instant(src.target) };
+    case 'image':
+      // Not marked `config` in KINDS: it has a sensible default, so the AI generator can still be
+      // offered image elements without having to reason about it.
+      return { fit: pick(IMAGE_FITS, src.fit, 'cover') };
     case 'qr':
       /*
        * ⚠️ THE MODULES ARE BLACK ON WHITE BY DEFAULT, AND THEY DO NOT INHERIT style.color.
@@ -616,8 +631,11 @@ function renderSlideHtml(rawConfig, opts = {}) {
     if (e.kind === 'image') {
       const url = resolveImage(e.contentId);
       css.push('overflow:hidden');
+      // Only the non-default is emitted, so every slide authored before this renders byte for byte
+      // as it did — a layout change nobody asked for is a worse bug than a missing option.
+      const fitCls = e.cfg.fit === 'contain' ? ' class="fit"' : '';
       const inner = url
-        ? `<img src="${escapeHtml(url)}" alt="">`
+        ? `<img${fitCls} src="${escapeHtml(url)}" alt="">`
         // A slide whose photo is missing says so, quietly, rather than leaving a hole an operator
         // has to guess at. It is deliberately unobtrusive: on a wall this is better than a red box.
         : `<div class="ph"></div>`;
@@ -728,6 +746,8 @@ function renderSlideHtml(rawConfig, opts = {}) {
   .scrim { position:absolute; inset:0; }
   .t { line-height:1.08; white-space:pre-wrap; word-break:break-word; }
   .e img { width:100%; height:100%; object-fit:cover; display:block; }
+  /* A cut-out must fit inside its box, not be cropped to fill it. See IMAGE_FITS. */
+  .e img.fit { object-fit:contain; }
   .ph { width:100%; height:100%; background:rgba(255,255,255,.06);
         border:1px dashed rgba(255,255,255,.18); box-sizing:border-box; }
   @keyframes st-fade    { from { opacity:0 } to { opacity:1 } }
@@ -746,7 +766,7 @@ function renderSlideHtml(rawConfig, opts = {}) {
 
 module.exports = {
   ANIMATIONS, EASINGS, KINDS,
-  CLOCK_FORMATS, DATE_FORMATS, QR_EC,
+  CLOCK_FORMATS, DATE_FORMATS, QR_EC, IMAGE_FITS,
   MAX_ELEMENTS, MAX_FIELD_CHARS, MAX_FIELDS,
   normalizeSlide, settleTime, renderSlideHtml,
   // Exported for tests: the QR matrix and the constant script are the two pieces whose properties

--- a/server/lib/slide-render.js
+++ b/server/lib/slide-render.js
@@ -105,6 +105,23 @@ const KINDS = Object.freeze({
   date:      { text: false, glyphs: true,  live: 'date',      config: true  },
   // The field is the message shown once the target passes ("Doors open", "We are closed").
   countdown: { text: true,  glyphs: true,  live: 'countdown', config: true  },
+  /*
+   * ⚠️ A PICTURE OF WORDS, AND THE WORDS ARE STILL A FIELD.
+   *
+   * Lettering is generated artwork — brush script, painted type, the things no bundled font can do
+   * — so what lands on the slide is an image. The obvious implementation stops there, and it
+   * quietly breaks the one promise this file opens by making: that the changeable text stays OUT of
+   * the layout, so somebody can come back in three months and change a number.
+   *
+   * So the words this artwork DEPICTS stay in `fields[slot]`, exactly as a headline's do. They are
+   * the record: the editor shows them, a regenerate reads them, and they are emitted as the image's
+   * alt text — which means a slide whose headline is a picture is still readable to anything that
+   * cannot see it. What is lost is only that editing the words needs the artwork remade, and the
+   * editor can say so, rather than the words simply ceasing to exist.
+   *
+   * glyphs is false: it draws no text of its own, so it needs no @font-face.
+   */
+  lettering: { text: true,  glyphs: false, live: null,        config: true  },
 });
 
 const clamp = (v, lo, hi, dflt) => {
@@ -238,6 +255,10 @@ function kindConfig(kind, src) {
       // Not marked `config` in KINDS: it has a sensible default, so the AI generator can still be
       // offered image elements without having to reason about it.
       return { fit: pick(IMAGE_FITS, src.fit, 'cover') };
+    case 'lettering':
+      // ⚠️ Always contained, and not settable. Cropping a word is not a styling choice: it removes
+      // letters, and "20% OF" on a wall is worse than no slide at all.
+      return { fit: 'contain' };
     case 'qr':
       /*
        * ⚠️ THE MODULES ARE BLACK ON WHITE BY DEFAULT, AND THEY DO NOT INHERIT style.color.
@@ -638,6 +659,21 @@ function renderSlideHtml(rawConfig, opts = {}) {
         ? `<img${fitCls} src="${escapeHtml(url)}" alt="">`
         // A slide whose photo is missing says so, quietly, rather than leaving a hole an operator
         // has to guess at. It is deliberately unobtrusive: on a wall this is better than a red box.
+        : `<div class="ph"></div>`;
+      return `<div class="e" style="${css.filter(Boolean).join(';')}">${inner}</div>`;
+    }
+
+    if (e.kind === 'lettering') {
+      const url = resolveImage(e.contentId);
+      css.push('overflow:hidden');
+      /*
+       * ⚠️ THE ALT TEXT IS THE ACTUAL WORDS, from the field. A headline that is a picture is
+       * invisible to a screen reader, to a search, and to anybody reading this document as text —
+       * and the one thing we reliably know about the picture is what it was asked to say.
+       */
+      const words = escapeHtml(slide.fields[e.slot] || '');
+      const inner = url
+        ? `<img class="fit" src="${escapeHtml(url)}" alt="${words}">`
         : `<div class="ph"></div>`;
       return `<div class="e" style="${css.filter(Boolean).join(';')}">${inner}</div>`;
     }

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -649,6 +649,25 @@ const CHROMA = Object.freeze({
   blue:    { rgb: '#0047FF', words: 'a perfectly flat uniform chroma-key blue (#0047FF)' },
 });
 
+/*
+ * ⚠️ THE WORDS ARE QUOTED, ALONE ON THEIR OWN LINE, AND REPEATED.
+ *
+ * Image models misspell. That is the whole risk of this feature — a headline is the largest thing
+ * on the slide and a wrong one is worse than a plain font would ever have been. Nothing here can
+ * guarantee the spelling, so the prompt does the only things that measurably help: it states the
+ * string once, exactly, in quotes, and says that nothing else may appear. Everything about HOW it
+ * looks is kept in a separate clause so the two cannot blur together and turn a style word into
+ * something the model tries to write.
+ */
+function letteringPrompt(words, style, backdrop) {
+  const c = CHROMA[backdrop] || CHROMA.green;
+  return `The words "${words}" written as display lettering, and NOTHING else. `
+    + `Spell it exactly: "${words}". No other words, no extra letters, no signature, no watermark. `
+    + `Style: ${style}. `
+    + `The lettering fills the frame, isolated on ${c.words} background. `
+    + 'No shadow on the background, no gradient, no vignette, no border, no frame.';
+}
+
 function objectPrompt(subject, backdrop) {
   const c = CHROMA[backdrop] || CHROMA.green;
   return `${subject}. A single subject, centred, complete and not cropped, photographed straight on, `
@@ -706,6 +725,7 @@ function layeredSystemPrompt(maxObjects) {
   return 'You plan a digital-signage slide as SEPARATE LAYERS so each part can animate on its own.\n'
     + 'Answer with ONE JSON object and nothing else:\n'
     + '{"background_prompt":"...","headline":"...","subhead":"...",'
+    + '"lettering":{"style":"...","backdrop":"green|magenta|blue"},'
     + '"objects":[{"subject":"...","backdrop":"green|magenta|blue","x":N,"y":N,"w":N,"h":N,'
     + '"animation":"fade|slideL|slideR|slideU|slideD|zoom|wipe","delay":N}]}\n'
     + '\n'
@@ -718,6 +738,10 @@ function layeredSystemPrompt(maxObjects) {
     + 'subject names ONE physical thing with no setting and no background — "a ripe orange pumpkin '
     + 'with a curled stem", never "a pumpkin on a table". The background is described separately '
     + 'and must contain NO text and none of the objects.\n'
+    + '\n'
+    + 'lettering.style describes HOW the headline should be painted - "thick red brush script with '
+    + 'rough dry-brush edges", "condensed gold serif with a subtle shadow" - and never says what it '
+    + 'says; the words come from headline. Choose a style that suits the scene.\n'
     + '\n'
     + 'backdrop is the screen colour the object will be photographed against and then removed from, '
     + 'so it MUST NOT be a colour that appears in the object itself: choose magenta for green or '
@@ -843,7 +867,64 @@ router.post('/generate-layered', async (req, res) => {
   // Text last, so it paints over the objects rather than under them.
   const headline = String(p.headline || '').slice(0, SLIDE_RENDER.MAX_FIELD_CHARS);
   const subhead = String(p.subhead || '').slice(0, SLIDE_RENDER.MAX_FIELD_CHARS);
-  if (headline) {
+
+  /*
+   * ⚠️ THE HEADLINE AS PAINTED ARTWORK, WITH THE WORDS STILL KEPT AS A FIELD.
+   *
+   * This is the part a bundled font cannot do — brush script, dry-brush edges, the lettering that
+   * makes a seasonal poster look designed rather than typeset. It goes through the same generate,
+   * key and refuse path as an object, because it IS one: a picture on a flat backdrop.
+   *
+   * ⚠️ AND IT FALLS BACK TO REAL TYPE RATHER THAN FAILING. If the lettering cannot be generated, or
+   * comes back on a backdrop that will not key, the slide gets an ordinary `head` element with the
+   * same words — set in a bundled font, correctly spelled, on every panel. A missing headline is
+   * not an acceptable outcome for a slide whose whole purpose is to say one thing.
+   */
+  let letteringDone = false;
+  const wantLettering = headline && req.body && req.body.lettering !== false;
+  if (wantLettering) {
+    const lp = (p.lettering && typeof p.lettering === 'object') ? p.lettering : {};
+    const style = String(lp.style || 'bold condensed poster lettering with clean edges').slice(0, 200);
+    const backdrop = Object.prototype.hasOwnProperty.call(CHROMA, lp.backdrop) ? lp.backdrop : 'green';
+    try {
+      const { content } = await generateAndIngest({
+        row,
+        prompt: letteringPrompt(headline, style, backdrop),
+        // Wide and short: lettering is a banner, and a square frame wastes most of the pixels on
+        // backdrop that is about to be thrown away.
+        width: 1024, height: 512,
+        name: `ai-lettering-${headline.slice(0, 32).replace(/[^a-zA-Z0-9 _-]/g, '').trim() || 'headline'}.png`,
+        userId: req.user.id, workspaceId: req.workspaceId,
+        transform: async (tmpPath) => {
+          const r = await ops.cutout(tmpPath, tmpPath, {});
+          if (!r.written) return { reject: r.reason };
+          if (r.spread > MAX_BACKDROP_SPREAD) {
+            return { reject: `the generated backdrop was not flat (spread ${r.spread.toFixed(0)})` };
+          }
+          if (r.opaque > MAX_OPAQUE) return { reject: 'the generated image had no backdrop to remove' };
+          return r;
+        },
+      });
+      elements.push({
+        slot: 'headline', kind: 'lettering', content_id: content.id,
+        box: { x: 5, y: 22, w: 58, h: 22 },
+        motion: { animation: 'slideD', delay: 0.15, duration: 0.7, easing: 'soft' },
+        style: { opacity: 1 },
+      });
+      fields.headline = headline;
+      letteringDone = true;
+      /*
+       * ⚠️ SAID OUT LOUD, EVERY TIME. Nothing here can verify that the picture spells the headline
+       * correctly, and a misspelled word set two feet tall is the worst thing this feature can
+       * produce. The operator is the check, so they have to be told there is something to check.
+       */
+      notes.push(`The headline is generated lettering — check it reads "${headline}" before publishing.`);
+    } catch (e) {
+      notes.push(`Lettering fell back to type: ${String(e && e.message || e).slice(0, 120)}`);
+    }
+  }
+
+  if (headline && !letteringDone) {
     elements.push({
       /*
        * ⚠️ WIDER AND SMALLER THAN IT LOOKS LIKE IT NEEDS TO BE. At 12cqw in a 52%-wide box, a
@@ -904,7 +985,7 @@ router.post('/generate-layered', async (req, res) => {
           radius_cqw: e.style.radius, opacity: e.style.opacity,
         },
         motion: e.motion,
-        ...(e.kind === 'image' ? { fit: e.cfg.fit } : {}),
+        ...(e.cfg && e.cfg.fit ? { fit: e.cfg.fit } : {}),
       })),
     },
     fields: settled.fields,

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -704,6 +704,24 @@ const MAX_OBJECTS = 4;
  */
 const TEXT_ZONE = Object.freeze({ x: 4, y: 20, w: 62, h: 56 });
 
+/**
+ * How large the subhead can be set, given how much of it there is.
+ *
+ * ⚠️ BECAUSE THE MODEL IGNORES THE LENGTH IT IS ASKED FOR. The plan prompt says at most 40
+ * characters; a real run answered with 48 ("Autumn Sale - Warm up your home with rustic charm"),
+ * which at a fixed 4.5cqw wrapped to three lines and ran out of the bottom of the text band and
+ * over the objects. Asking is still worth doing, but the geometry cannot depend on the answer.
+ *
+ * Scaling the type to the copy is what a person would do, needs no measurement, and degrades
+ * gracefully: a long subhead gets smaller rather than getting clipped or colliding.
+ */
+function subheadSize(text) {
+  const n = text.length;
+  if (n <= 32) return 4.5;
+  if (n <= 56) return 3.6;
+  return 3;
+}
+
 /** Push an object clear of the text band, if it would sit inside it. */
 function placeClear(box) {
   const overlaps = box.x < TEXT_ZONE.x + TEXT_ZONE.w && box.x + box.w > TEXT_ZONE.x
@@ -941,8 +959,8 @@ router.post('/generate-layered', async (req, res) => {
   if (subhead) {
     elements.push({
       // Far enough below a two-line headline to clear it. See the headline's box.
-      slot: 'subhead', kind: 'body', box: { x: 5, y: 58, w: 52 },
-      style: { color: '#FFFFFF', size_cqw: 4.5, weight: 600, align: 'left' },
+      slot: 'subhead', kind: 'body', box: { x: 5, y: 58, w: 56 },
+      style: { color: '#FFFFFF', size_cqw: subheadSize(subhead), weight: 600, align: 'left' },
       motion: { animation: 'wipe', delay: 0.5, duration: 0.7, easing: 'soft' },
     });
     fields.subhead = subhead;

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -674,6 +674,31 @@ const MAX_OBJECTS = 4;
  *           instruction entirely and the "cut-out" is a rectangular photo with its scene intact.
  *           Laid onto a slide that reads as a broken image rather than a missing one.
  */
+/*
+ * ⚠️ WHERE THE WORDS GO, AND IT IS ENFORCED RATHER THAN REQUESTED.
+ *
+ * The plan prompt asks the model to keep objects clear of the headline. Measured against real
+ * output it does not: a run that produced a perfectly good background, leaf and cup also dropped a
+ * pair of mittens directly under "20% OFF". Asking is the right thing to do — a model that
+ * cooperates gives a better composition than one that is corrected — but it cannot be the only
+ * thing, because the failure lands on somebody's wall and reads as a broken slide.
+ */
+const TEXT_ZONE = Object.freeze({ x: 4, y: 20, w: 62, h: 56 });
+
+/** Push an object clear of the text band, if it would sit inside it. */
+function placeClear(box) {
+  const overlaps = box.x < TEXT_ZONE.x + TEXT_ZONE.w && box.x + box.w > TEXT_ZONE.x
+    && box.y < TEXT_ZONE.y + TEXT_ZONE.h && box.y + box.h > TEXT_ZONE.y;
+  if (!overlaps) return box;
+  /*
+   * Moved sideways rather than shrunk or dropped: the model chose a vertical position that suits
+   * the composition, and an object scaled down to fit a gap looks like a mistake in a way that the
+   * same object further right does not. Clamped so a wide object still lands on the slide.
+   */
+  const x = Math.min(100 - box.w, TEXT_ZONE.x + TEXT_ZONE.w + 2);
+  return { ...box, x: Math.max(0, x) };
+}
+
 const MAX_BACKDROP_SPREAD = 70;
 const MAX_OPAQUE = 0.985;
 
@@ -687,6 +712,8 @@ function layeredSystemPrompt(maxObjects) {
     + `Rules. At most ${maxObjects} objects. x, y, w and h are PERCENTAGES of the slide, 0-100; `
     + 'objects must not cover the middle-left area where the headline sits. '
     + 'delay is seconds, 0-2, and each object should differ so they arrive in sequence. '
+    + 'headline is at most 14 characters and subhead at most 40, because both are set large '
+    + 'over a photograph and a long one wraps into the other. '
     + '\n'
     + 'subject names ONE physical thing with no setting and no background — "a ripe orange pumpkin '
     + 'with a curled stem", never "a pumpkin on a table". The background is described separately '
@@ -797,10 +824,10 @@ router.post('/generate-layered', async (req, res) => {
       slot: `obj_${i}`,
       kind: 'image',
       content_id: content.id,
-      box: {
+      box: placeClear({
         x: clampN(o.x, -20, 110, 60), y: clampN(o.y, -20, 110, 40),
         w: clampN(o.w, 5, 100, 30), h: clampN(o.h, 5, 100, 40),
-      },
+      }),
       // ⚠️ contain, always. A cut-out cropped to fill its box is sliced through the object itself.
       fit: 'contain',
       motion: {
@@ -818,15 +845,22 @@ router.post('/generate-layered', async (req, res) => {
   const subhead = String(p.subhead || '').slice(0, SLIDE_RENDER.MAX_FIELD_CHARS);
   if (headline) {
     elements.push({
-      slot: 'headline', kind: 'head', box: { x: 6, y: 30, w: 52 },
-      style: { color: '#FFFFFF', size_cqw: 12, weight: 900, align: 'left' },
+      /*
+       * ⚠️ WIDER AND SMALLER THAN IT LOOKS LIKE IT NEEDS TO BE. At 12cqw in a 52%-wide box, a
+       * headline as short as "20% OFF" wraps to two lines and the second line lands on top of the
+       * subhead below — measured, on a real run. Nothing server-side can measure text, so the box
+       * has to be sized for the wrap that will happen rather than the one line that was intended.
+       */
+      slot: 'headline', kind: 'head', box: { x: 5, y: 24, w: 60 },
+      style: { color: '#FFFFFF', size_cqw: 10, weight: 900, align: 'left' },
       motion: { animation: 'slideD', delay: 0.15, duration: 0.6, easing: 'soft' },
     });
     fields.headline = headline;
   }
   if (subhead) {
     elements.push({
-      slot: 'subhead', kind: 'body', box: { x: 6, y: 52, w: 46 },
+      // Far enough below a two-line headline to clear it. See the headline's box.
+      slot: 'subhead', kind: 'body', box: { x: 5, y: 58, w: 52 },
       style: { color: '#FFFFFF', size_cqw: 4.5, weight: 600, align: 'left' },
       motion: { animation: 'wipe', delay: 0.5, duration: 0.7, easing: 'soft' },
     });

--- a/server/routes/ai.js
+++ b/server/routes/ai.js
@@ -517,6 +517,76 @@ router.post('/generate-slide', async (req, res) => {
  * (sniffed, thumbnailed, digested, workspace-scoped), and return the id the slide document already
  * knows how to store in background_content_id.
  */
+
+/* ============ generating one image and putting it in the library ============ */
+
+/**
+ * Generate an image, store it through the REAL ingest, and return the content row.
+ *
+ * ⚠️ ONE COPY, because the tmp-file dance below is not incidental. The bytes are written as
+ * `<uuid>.part` and handed to ingestUploadedFile so they are SNIFFED for their true type rather
+ * than trusted: a generation endpoint that answers with HTML, or with a PNG that is really
+ * something else, has to be refused here exactly as an operator's upload would be. A second
+ * hand-rolled copy of this in the layered route would be the obvious place for that check to
+ * quietly not exist.
+ *
+ * Throws with the upstream's own words. Callers translate that into a status — see UPSTREAM_STATUS
+ * for why it is not 502.
+ */
+async function generateAndIngest({ row, prompt, width, height, name, userId, workspaceId, transform }) {
+  const dataUrl = await generateImage({
+    provider: row.image_provider,
+    baseUrl: row.image_base_url.replace(/\/+$/, ''),
+    apiKey: row.image_api_key_enc ? decrypt(row.image_api_key_enc) : '',
+    model: row.image_model,
+    prompt,
+    width,
+    height,
+    timeoutMs: 180000,
+  });
+  if (!dataUrl || dataUrl.indexOf('base64,') < 0) throw new Error('The image endpoint returned no image.');
+
+  const bytes = Buffer.from(dataUrl.slice(dataUrl.indexOf('base64,') + 7), 'base64');
+  const tmpName = `${uuidv4()}.part`;
+  const tmpPath = path.join(config.contentDir, tmpName);
+  fs.mkdirSync(config.contentDir, { recursive: true });
+  fs.writeFileSync(tmpPath, bytes);
+
+  /*
+   * A hook for work that has to happen on the BYTES before they become library content — the
+   * layered route keys the backdrop out here. It returns whatever it wants the caller to know, and
+   * may rewrite the file in place; if it refuses, nothing is ingested and the tmp file is removed.
+   */
+  let extra = null;
+  if (typeof transform === 'function') {
+    try {
+      extra = await transform(tmpPath);
+    } catch (e) {
+      try { fs.unlinkSync(tmpPath); } catch (e2) { /* already gone */ }
+      throw e;
+    }
+    if (extra && extra.reject) {
+      try { fs.unlinkSync(tmpPath); } catch (e2) { /* already gone */ }
+      const err = new Error(extra.reject);
+      err.rejected = true;
+      throw err;
+    }
+  }
+
+  let content;
+  try {
+    content = await ingestUploadedFile({
+      file: { path: tmpPath, originalname: name, size: fs.statSync(tmpPath).size },
+      userId,
+      workspaceId,
+    });
+  } catch (e) {
+    try { fs.unlinkSync(tmpPath); } catch (e2) { /* finalizeUpload may already have removed it */ }
+    throw e;
+  }
+  return { content, extra };
+}
+
 router.post('/generate-background', async (req, res) => {
   const prompt = String(req.body && req.body.prompt || '').trim().slice(0, 500);
   if (!prompt) return res.status(400).json({ error: 'Prompt required' });
@@ -528,13 +598,10 @@ router.post('/generate-background', async (req, res) => {
   }
   if (!endpointAllowed(imgBase)) return res.status(400).json({ error: 'Image endpoint URL not allowed.' });
 
-  let dataUrl;
+  let content;
   try {
-    dataUrl = await generateImage({
-      provider: row.image_provider,
-      baseUrl: imgBase,
-      apiKey: row.image_api_key_enc ? decrypt(row.image_api_key_enc) : '',
-      model: row.image_model,
+    ({ content } = await generateAndIngest({
+      row,
       prompt,
       /*
        * The DECK'S shape, not a fixed 16:9 — a portrait deck given a landscape background crops to
@@ -543,8 +610,10 @@ router.post('/generate-background', async (req, res) => {
        */
       width: clampN(req.body && req.body.width, 256, 4096, 1792),
       height: clampN(req.body && req.body.height, 256, 4096, 1024),
-      timeoutMs: 180000,
-    });
+      name: `ai-background-${prompt.slice(0, 40).replace(/[^a-zA-Z0-9 _-]/g, '').trim() || 'slide'}.png`,
+      userId: req.user.id,
+      workspaceId: req.workspaceId,
+    }));
   } catch (e) {
     /*
      * ⚠️ 502 IS NOT USABLE HERE — CLOUDFLARE REPLACES THE BODY. A 502 from the origin is rendered
@@ -557,46 +626,260 @@ router.post('/generate-background', async (req, res) => {
     console.warn('[ai] background generation failed:', why);
     return res.status(400).json({ error: 'Image generation failed: ' + why });
   }
-  if (!dataUrl || dataUrl.indexOf('base64,') < 0) {
-    console.warn('[ai] background generation: endpoint returned no image');
-    return res.status(400).json({ error: 'The image endpoint returned no image.' });
-  }
-
-  /*
-   * ⚠️ WRITTEN AS `<uuid>.part`, because that is what finalizeUpload expects and what makes this go
-   * through the real ingest: the bytes are SNIFFED for their true type rather than trusted. A
-   * generation endpoint that returned HTML, or a PNG that is really something else, must be refused
-   * here exactly as an operator's upload would be — not written into the library because we asked
-   * for an image and assumed we got one.
-   */
-  const tmpName = `${uuidv4()}.part`;
-  const tmpPath = path.join(config.contentDir, tmpName);
-  const bytes = Buffer.from(dataUrl.slice(dataUrl.indexOf('base64,') + 7), 'base64');
-  try {
-    fs.mkdirSync(config.contentDir, { recursive: true });
-    fs.writeFileSync(tmpPath, bytes);
-  } catch (e) {
-    return res.status(500).json({ error: 'Could not store the generated image.' });
-  }
-
-  let content;
-  try {
-    content = await ingestUploadedFile({
-      file: {
-        path: tmpPath,
-        originalname: `ai-background-${prompt.slice(0, 40).replace(/[^a-zA-Z0-9 _-]/g, '').trim() || 'slide'}.png`,
-        size: bytes.length,
-      },
-      userId: req.user.id,
-      workspaceId: req.workspaceId,
-    });
-  } catch (e) {
-    try { fs.unlinkSync(tmpPath); } catch (e2) { /* finalizeUpload may already have removed it */ }
-    return res.status(400).json({ error: String(e && e.message || e).slice(0, 200) });
-  }
 
   logActivity(req.user.id, 'ai_background_generated', prompt.slice(0, 120), null, getClientIp(req), req.workspaceId);
   res.json({ content_id: content.id, filename: content.filename, width: content.width, height: content.height });
+});
+
+
+/* ============ layered slides: a background plus cut-out objects that animate ============ */
+
+/*
+ * ⚠️ THE BACKDROP INSTRUCTION IS WRITTEN BY THE SERVER, NOT BY THE MODEL.
+ *
+ * The whole feature rests on each object arriving on a flat, uniform backdrop, because that is what
+ * lib/image-key.js removes. Left to describe an object freely a model writes "a pumpkin on a wooden
+ * table in soft autumn light" — which is a better picture and completely unusable, since keying it
+ * takes the table, the light and half the pumpkin. So the model supplies the SUBJECT and this
+ * supplies the staging, every time, in words measured against real output.
+ */
+const CHROMA = Object.freeze({
+  green:   { rgb: '#0BC314', words: 'a perfectly flat uniform chroma-key green (#0BC314)' },
+  magenta: { rgb: '#FF00FF', words: 'a perfectly flat uniform chroma-key magenta (#FF00FF)' },
+  blue:    { rgb: '#0047FF', words: 'a perfectly flat uniform chroma-key blue (#0047FF)' },
+});
+
+function objectPrompt(subject, backdrop) {
+  const c = CHROMA[backdrop] || CHROMA.green;
+  return `${subject}. A single subject, centred, complete and not cropped, photographed straight on, `
+    + `isolated on ${c.words} background. No shadow on the background, no gradient, no vignette, `
+    + `no text, no border. Product cutout style.`;
+}
+
+/*
+ * ⚠️ A CAP, AND IT IS ABOUT MONEY. Each object is a separate call to an image endpoint the operator
+ * pays for, on top of the background — so this route costs (objects + 1) generations per press,
+ * and a request for "twelve leaves" would quietly spend twelve times what the operator expected.
+ * Four is enough for the compositions this is for and keeps the worst case legible.
+ */
+const MAX_OBJECTS = 4;
+
+/*
+ * ⚠️ REFUSAL THRESHOLDS, because a bad cut-out still looks like a cut-out.
+ *
+ * spread  — how far the backdrop's border pixels wander from its median. A flat backdrop measures
+ *           low single digits; real output that drifted into a gradient measured far above this,
+ *           and keying a gradient leaves a torn edge or a ghost of the backdrop still attached.
+ * opaque  — a value near 1 means the key removed nothing, i.e. the generator ignored the backdrop
+ *           instruction entirely and the "cut-out" is a rectangular photo with its scene intact.
+ *           Laid onto a slide that reads as a broken image rather than a missing one.
+ */
+const MAX_BACKDROP_SPREAD = 70;
+const MAX_OPAQUE = 0.985;
+
+function layeredSystemPrompt(maxObjects) {
+  return 'You plan a digital-signage slide as SEPARATE LAYERS so each part can animate on its own.\n'
+    + 'Answer with ONE JSON object and nothing else:\n'
+    + '{"background_prompt":"...","headline":"...","subhead":"...",'
+    + '"objects":[{"subject":"...","backdrop":"green|magenta|blue","x":N,"y":N,"w":N,"h":N,'
+    + '"animation":"fade|slideL|slideR|slideU|slideD|zoom|wipe","delay":N}]}\n'
+    + '\n'
+    + `Rules. At most ${maxObjects} objects. x, y, w and h are PERCENTAGES of the slide, 0-100; `
+    + 'objects must not cover the middle-left area where the headline sits. '
+    + 'delay is seconds, 0-2, and each object should differ so they arrive in sequence. '
+    + '\n'
+    + 'subject names ONE physical thing with no setting and no background — "a ripe orange pumpkin '
+    + 'with a curled stem", never "a pumpkin on a table". The background is described separately '
+    + 'and must contain NO text and none of the objects.\n'
+    + '\n'
+    + 'backdrop is the screen colour the object will be photographed against and then removed from, '
+    + 'so it MUST NOT be a colour that appears in the object itself: choose magenta for green or '
+    + 'blue subjects, green for red, orange, pink or purple subjects, blue for yellow subjects.';
+}
+
+/**
+ * POST /api/ai/generate-layered — editor+; a slide whose parts are separate, animatable images.
+ *
+ * This is the thing the designer could never do and no other signage product does: the operator
+ * describes a scene, and gets back a background plus individually cut-out objects, each its own
+ * element with its own entrance — rather than one flat picture with text on top.
+ */
+router.post('/generate-layered', async (req, res) => {
+  if (!canEdit(req)) return res.status(403).json({ error: 'Editor access required' });
+  const prompt = String(req.body && req.body.prompt || '').trim().slice(0, 500);
+  if (!prompt) return res.status(400).json({ error: 'Prompt required' });
+
+  const row = db.prepare('SELECT image_base_url, image_model, image_provider, image_api_key_enc FROM ai_settings WHERE workspace_id = ?').get(req.workspaceId);
+  if (!row || !row.image_base_url || !row.image_provider) {
+    return res.status(400).json({ error: 'No image endpoint configured for this workspace.' });
+  }
+  if (!endpointAllowed(row.image_base_url)) return res.status(400).json({ error: 'Image endpoint URL not allowed.' });
+
+  const want = clampN(req.body && req.body.objects, 1, MAX_OBJECTS, 3);
+  const W = clampN(req.body && req.body.width, 256, 4096, 1792);
+  const H = clampN(req.body && req.body.height, 256, 4096, 1024);
+
+  const plan = await askModelForJson({
+    workspaceId: req.workspaceId,
+    system: layeredSystemPrompt(want),
+    user: prompt,
+  });
+  if (plan.error) return res.status(plan.status === 400 ? 400 : UPSTREAM_STATUS).json({ error: plan.error });
+
+  const p = plan.parsed && typeof plan.parsed === 'object' ? plan.parsed : {};
+  const objects = (Array.isArray(p.objects) ? p.objects : []).slice(0, want)
+    .filter((o) => o && typeof o.subject === 'string' && o.subject.trim());
+  const bgPrompt = String(p.background_prompt || prompt).slice(0, 500);
+
+  const ops = require('../lib/image-ops');
+  const elements = [];
+  const fields = {};
+  const notes = [];
+
+  /*
+   * ⚠️ THE BACKGROUND FIRST, AND A FAILURE HERE IS FATAL WHILE AN OBJECT FAILURE IS NOT.
+   * Losing one object costs a layer; losing the background costs the slide, and continuing would
+   * hand back cut-outs floating on a flat colour that nobody asked for.
+   */
+  let backgroundId = null;
+  try {
+    const { content } = await generateAndIngest({
+      row, prompt: `${bgPrompt}. No text, no words, no lettering anywhere in the image.`,
+      width: W, height: H,
+      name: `ai-layer-bg-${prompt.slice(0, 32).replace(/[^a-zA-Z0-9 _-]/g, '').trim() || 'slide'}.png`,
+      userId: req.user.id, workspaceId: req.workspaceId,
+    });
+    backgroundId = content.id;
+  } catch (e) {
+    const why = String(e && e.message || e).slice(0, 200);
+    console.warn('[ai] layered background failed:', why);
+    return res.status(400).json({ error: 'Background generation failed: ' + why });
+  }
+
+  /*
+   * ⚠️ SEQUENTIAL, NOT Promise.all. Each of these holds a full RGBA bitmap while it is keyed, and
+   * the image worker runs one job at a time by design (see lib/image-ops) — firing four at once
+   * would queue behind each other anyway while holding four decoded images in heap, on the small
+   * hosts this product is expected to run on.
+   */
+  for (let i = 0; i < objects.length; i++) {
+    const o = objects[i];
+    const backdrop = Object.prototype.hasOwnProperty.call(CHROMA, o.backdrop) ? o.backdrop : 'green';
+    const subject = String(o.subject).slice(0, 300);
+    let cut = null;
+    let content = null;
+    try {
+      ({ content, extra: cut } = await generateAndIngest({
+        row,
+        prompt: objectPrompt(subject, backdrop),
+        width: 1024, height: 1024,
+        name: `ai-layer-${subject.slice(0, 32).replace(/[^a-zA-Z0-9 _-]/g, '').trim() || 'object'}.png`,
+        userId: req.user.id, workspaceId: req.workspaceId,
+        transform: async (tmpPath) => {
+          const r = await ops.cutout(tmpPath, tmpPath, {});
+          if (!r.written) return { reject: r.reason };
+          if (r.spread > MAX_BACKDROP_SPREAD) {
+            return { reject: `the generated backdrop was not flat (spread ${r.spread.toFixed(0)})` };
+          }
+          if (r.opaque > MAX_OPAQUE) {
+            return { reject: 'the generated image had no backdrop to remove' };
+          }
+          return r;
+        },
+      }));
+    } catch (e) {
+      // One layer lost is a slide with fewer layers, which is still a slide. Reported, never silent.
+      notes.push(`"${subject.slice(0, 60)}" was skipped: ${String(e && e.message || e).slice(0, 120)}`);
+      continue;
+    }
+
+    elements.push({
+      slot: `obj_${i}`,
+      kind: 'image',
+      content_id: content.id,
+      box: {
+        x: clampN(o.x, -20, 110, 60), y: clampN(o.y, -20, 110, 40),
+        w: clampN(o.w, 5, 100, 30), h: clampN(o.h, 5, 100, 40),
+      },
+      // ⚠️ contain, always. A cut-out cropped to fill its box is sliced through the object itself.
+      fit: 'contain',
+      motion: {
+        animation: Object.prototype.hasOwnProperty.call(SLIDE_RENDER.ANIMATIONS, o.animation) ? o.animation : 'slideU',
+        delay: clampN(o.delay, 0, 2, 0.4 + i * 0.25),
+        duration: 0.7,
+        easing: 'soft',
+      },
+      style: { opacity: 1 },
+    });
+  }
+
+  // Text last, so it paints over the objects rather than under them.
+  const headline = String(p.headline || '').slice(0, SLIDE_RENDER.MAX_FIELD_CHARS);
+  const subhead = String(p.subhead || '').slice(0, SLIDE_RENDER.MAX_FIELD_CHARS);
+  if (headline) {
+    elements.push({
+      slot: 'headline', kind: 'head', box: { x: 6, y: 30, w: 52 },
+      style: { color: '#FFFFFF', size_cqw: 12, weight: 900, align: 'left' },
+      motion: { animation: 'slideD', delay: 0.15, duration: 0.6, easing: 'soft' },
+    });
+    fields.headline = headline;
+  }
+  if (subhead) {
+    elements.push({
+      slot: 'subhead', kind: 'body', box: { x: 6, y: 52, w: 46 },
+      style: { color: '#FFFFFF', size_cqw: 4.5, weight: 600, align: 'left' },
+      motion: { animation: 'wipe', delay: 0.5, duration: 0.7, easing: 'soft' },
+    });
+    fields.subhead = subhead;
+  }
+
+  const spec = {
+    template: {
+      background: '#101318',
+      background_content_id: backgroundId,
+      // A scrim by default: these backgrounds are photographic and the headline sits on top of one.
+      background_dim: 0.28,
+      elements,
+    },
+    fields,
+  };
+
+  /*
+   * ⚠️ THROUGH THE RENDERER'S OWN NORMALIZER BEFORE ANSWERING, exactly as generate-slide does.
+   * Anything this route builds that the renderer would reject is a slide that looks right in the
+   * editor and is wrong on a screen.
+   */
+  const settled = SLIDE_RENDER.normalizeSlide(spec);
+
+  logActivity(req.user.id, 'ai_layered_generated',
+    `${prompt.slice(0, 90)} (${elements.filter((e) => e.kind === 'image').length} layers)`,
+    null, getClientIp(req), req.workspaceId);
+
+  res.json({
+    template: {
+      background: settled.background,
+      background_content_id: settled.backgroundContentId,
+      background_dim: settled.backgroundDim,
+      elements: settled.elements.map((e, i) => ({
+        slot: e.slot, kind: e.kind,
+        box: { x: e.x, y: e.y, w: e.w, ...(e.h == null ? {} : { h: e.h }) },
+        content_id: e.contentId,
+        style: {
+          color: e.style.color, font: e.style.font, size_cqw: e.style.size,
+          weight: e.style.weight, align: e.style.align,
+          radius_cqw: e.style.radius, opacity: e.style.opacity,
+        },
+        motion: e.motion,
+        ...(e.kind === 'image' ? { fit: e.cfg.fit } : {}),
+      })),
+    },
+    fields: settled.fields,
+    // What was asked for versus what arrived, so the editor can say so rather than quietly showing
+    // fewer layers than the operator paid for.
+    generated: elements.filter((e) => e.kind === 'image').length,
+    requested: objects.length,
+    notes,
+  });
 });
 
 router.post('/generate-design', async (req, res) => {

--- a/server/server.js
+++ b/server/server.js
@@ -1273,6 +1273,13 @@ app.get('/api/widgets/preview-session/:id', (req, res, next) => { req._skipAuth 
  */
 app.use('/api/ai/generate-slide', rateLimit(60000, 10));
 app.use('/api/ai/generate-design', rateLimit(60000, 10));
+/*
+ * ⚠️ TIGHTER THAN THE OTHERS, BECAUSE ONE PRESS IS UP TO FIVE GENERATIONS. Layered generation makes
+ * a background plus one call per object, each on the operator's own metered image endpoint, and
+ * each followed by a full-frame key on the image worker. At the rate above that is fifty paid
+ * generations a minute from a held Enter key.
+ */
+app.use('/api/ai/generate-layered', rateLimit(60000, 3));
 app.use('/api/widgets/preview', rateLimit(60000, 30)); // base64 inline = memory-intensive
 app.use('/api/widgets/preview-session', rateLimit(60000, 30)); // preview session creation retains rendered HTML in memory for 5min
 app.get('/api/kiosk/:id/render', (req, res, next) => { req._skipAuth = true; next(); });

--- a/server/test/image-key.test.js
+++ b/server/test/image-key.test.js
@@ -1,0 +1,205 @@
+'use strict';
+
+/*
+ * The keyer, against SYNTHETIC bitmaps rather than fixtures.
+ *
+ * ⚠️ THAT IS THE POINT, not a convenience. A keyer's failure mode is at the EDGE — a pixel too
+ * greedy and thin features dissolve, a pixel too shy and every object wears a halo of its backdrop.
+ * A photograph cannot say where the true edge is, so a test against one can only assert that
+ * something came out. A bitmap built here knows its own boundary to the pixel, so these can state
+ * what should happen at it.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const K = require('../lib/image-key');
+
+/** A w*h RGBA bitmap in the shape jimp exposes. */
+function bitmap(w, h, fill) {
+  const data = Buffer.alloc(w * h * 4);
+  for (let i = 0; i < w * h; i++) {
+    data[i * 4] = fill[0]; data[i * 4 + 1] = fill[1]; data[i * 4 + 2] = fill[2]; data[i * 4 + 3] = 255;
+  }
+  return { width: w, height: h, data };
+}
+
+function rect(bm, x0, y0, w, h, rgb) {
+  for (let y = y0; y < y0 + h; y++) {
+    for (let x = x0; x < x0 + w; x++) {
+      const i = (y * bm.width + x) * 4;
+      bm.data[i] = rgb[0]; bm.data[i + 1] = rgb[1]; bm.data[i + 2] = rgb[2];
+    }
+  }
+}
+
+const alphaAt = (bm, x, y) => bm.data[(y * bm.width + x) * 4 + 3];
+const GREEN = [11, 195, 20];
+const ORANGE = [237, 125, 26];
+
+/* ============ finding the backdrop ============ */
+
+test('the key is the median of the border, so a stray corner pixel cannot set it', () => {
+  /*
+   * THE FAILURE THIS PREVENTS. Every alpha value is derived from this one colour, so a sample taken
+   * from a single noisy corner does not degrade the cut-out — it destroys it, removing either the
+   * whole object or none of the backdrop.
+   */
+  const bm = bitmap(64, 64, GREEN);
+  rect(bm, 0, 0, 3, 3, [255, 0, 255]);      // a magenta speck in the corner
+  rect(bm, 0, 60, 4, 4, [0, 0, 0]);          // and a black one on another edge
+  assert.deepEqual(K.sampleKey(bm), GREEN);
+});
+
+test('the spread of a flat backdrop is small; a gradient is not', () => {
+  // The caller needs to know whether the generator actually produced a flat backdrop this time.
+  const flat = bitmap(64, 64, GREEN);
+  assert.ok(K.backdropSpread(flat, K.sampleKey(flat)) < 4, 'a flat backdrop should read as flat');
+
+  const grad = bitmap(64, 64, GREEN);
+  for (let y = 0; y < 64; y++) {
+    for (let x = 0; x < 64; x++) {
+      const i = (y * 64 + x) * 4;
+      grad.data[i + 1] = Math.max(0, GREEN[1] - y * 2);   // fades down the frame
+    }
+  }
+  assert.ok(K.backdropSpread(grad, K.sampleKey(grad)) > 40, 'a gradient must be reported as one');
+});
+
+/* ============ the edge, which is the whole job ============ */
+
+test('the backdrop goes fully transparent and the object stays fully opaque', () => {
+  const bm = bitmap(64, 64, GREEN);
+  rect(bm, 20, 20, 24, 24, ORANGE);
+  K.keyOut(bm, K.sampleKey(bm), {});
+  assert.equal(alphaAt(bm, 2, 2), 0, 'backdrop must be gone');
+  assert.equal(alphaAt(bm, 32, 32), 255, 'the middle of the object must be untouched');
+  assert.equal(alphaAt(bm, 20, 20), 255, 'the object edge itself must survive');
+});
+
+test('⚠️ a one-pixel feature survives', () => {
+  /*
+   * Stems and leaf serrations come down to this. A keyer with any spatial blur, or a tolerance
+   * tuned by eye on a big soft object, eats them — and the loss is invisible in a thumbnail.
+   */
+  const bm = bitmap(32, 32, GREEN);
+  rect(bm, 16, 0, 1, 32, ORANGE);
+  K.keyOut(bm, K.sampleKey(bm), {});
+  for (let y = 0; y < 32; y++) assert.equal(alphaAt(bm, 16, y), 255, `the hairline broke at y=${y}`);
+});
+
+test('⚠️ a hole INSIDE the object is transparent, not filled', () => {
+  // The curl of a pumpkin stem encloses a gap. A flood-fill from the border would leave it opaque,
+  // and the object would carry a lump of backdrop around on every slide it appears on.
+  const bm = bitmap(64, 64, GREEN);
+  rect(bm, 10, 10, 44, 44, ORANGE);
+  rect(bm, 28, 28, 8, 8, GREEN);
+  K.keyOut(bm, K.sampleKey(bm), {});
+  assert.equal(alphaAt(bm, 32, 32), 0, 'the enclosed hole must be transparent');
+  assert.equal(alphaAt(bm, 12, 12), 255, 'and the body around it must not be');
+});
+
+test('the edge is feathered rather than a staircase', () => {
+  // A colour part-way between object and backdrop should come out part-way transparent.
+  const bm = bitmap(32, 32, GREEN);
+  rect(bm, 10, 10, 12, 12, ORANGE);
+  const mid = [Math.round((GREEN[0] + ORANGE[0]) / 2), Math.round((GREEN[1] + ORANGE[1]) / 2),
+    Math.round((GREEN[2] + ORANGE[2]) / 2)];
+  rect(bm, 9, 10, 1, 12, mid);
+  K.keyOut(bm, K.sampleKey(bm), { tol: 70, soft: 90 });
+  const a = alphaAt(bm, 9, 15);
+  assert.ok(a > 0 && a < 255, `a blended pixel should be partly transparent, got ${a}`);
+});
+
+test('tolerance widens what counts as backdrop', () => {
+  const near = [30, 180, 40];        // close to the key, but not it
+  const mk = () => { const b = bitmap(32, 32, GREEN); rect(b, 8, 8, 16, 16, near); return b; };
+  const tight = mk(); K.keyOut(tight, GREEN, { tol: 5, soft: 5 });
+  const loose = mk(); K.keyOut(loose, GREEN, { tol: 90, soft: 10 });
+  assert.equal(alphaAt(tight, 16, 16), 255, 'a tight key should keep it');
+  assert.equal(alphaAt(loose, 16, 16), 0, 'a loose key should drop it');
+});
+
+/* ============ despill ============ */
+
+test('⚠️ despill runs on OPAQUE edge pixels, not only translucent ones', () => {
+  /*
+   * THE BUG A SPIKE FOUND ON REAL LEAVES. The first version only touched pixels with fractional
+   * alpha, and a faint green line survived along every serration — because the pixels just INSIDE
+   * the object are fully opaque and still carry the backdrop's bounce light. Opaque is where a
+   * fringe shows most, since nothing behind it dilutes the colour.
+   */
+  const bm = bitmap(32, 32, GREEN);
+  rect(bm, 8, 8, 16, 16, ORANGE);
+  /*
+   * Far enough from the key to be FULLY opaque (distance ~156 against tol+soft=120) while still
+   * green-dominant — which is precisely the population the first version missed. A closer colour
+   * lands in the feather band and would test the easy case by accident.
+   */
+  rect(bm, 8, 8, 16, 1, [150, 210, 90]);
+  K.keyOut(bm, K.sampleKey(bm), {});
+  const i = (8 * 32 + 12) * 4;
+  assert.equal(bm.data[i + 3], 255, 'this pixel is inside the object');
+  assert.ok(bm.data[i + 1] <= Math.max(bm.data[i], bm.data[i + 2]),
+    `green still dominates after despill: ${[bm.data[i], bm.data[i + 1], bm.data[i + 2]]}`);
+});
+
+test('despill leaves the interior alone', () => {
+  // A genuinely green object on a green backdrop is a losing proposition, but a green DETAIL well
+  // inside an orange object must not be desaturated just because the backdrop was green.
+  const bm = bitmap(64, 64, GREEN);
+  rect(bm, 8, 8, 48, 48, ORANGE);
+  rect(bm, 28, 28, 8, 8, [40, 160, 50]);
+  K.keyOut(bm, K.sampleKey(bm), {});
+  const i = (32 * 64 + 32) * 4;
+  assert.equal(bm.data[i + 1], 160, 'an interior green detail must be preserved');
+});
+
+test('a colourless backdrop has nothing to despill and is left alone', () => {
+  // White and grey have no dominant channel; suppressing one would tint every edge.
+  const bm = bitmap(32, 32, [255, 255, 255]);
+  rect(bm, 8, 8, 16, 16, ORANGE);
+  rect(bm, 8, 8, 16, 1, [250, 250, 250]);
+  assert.doesNotThrow(() => K.keyOut(bm, K.sampleKey(bm), {}));
+  assert.equal(alphaAt(bm, 2, 2), 0);
+});
+
+/* ============ bounds and refusal ============ */
+
+test('bounds are the object, not the frame', () => {
+  const bm = bitmap(64, 64, GREEN);
+  rect(bm, 20, 12, 10, 30, ORANGE);
+  K.keyOut(bm, K.sampleKey(bm), {});
+  assert.deepEqual(K.contentBounds(bm), { x: 20, y: 12, w: 10, h: 30 });
+});
+
+test('⚠️ an image the key ate entirely reports null rather than an empty box', () => {
+  /*
+   * A real outcome: an object whose colour matches its backdrop. It has to reach the caller as a
+   * refusal, or an empty PNG lands in somebody's content library and an invisible element lands on
+   * their slide — both of which look like the feature working.
+   */
+  const bm = bitmap(32, 32, GREEN);
+  K.keyOut(bm, K.sampleKey(bm), {});
+  assert.equal(K.contentBounds(bm), null);
+});
+
+test('coverage reports the three populations and they sum to one', () => {
+  const bm = bitmap(40, 40, GREEN);
+  rect(bm, 10, 10, 20, 20, ORANGE);
+  K.keyOut(bm, K.sampleKey(bm), {});
+  const c = K.coverage(bm);
+  assert.ok(Math.abs(c.opaque + c.feathered + c.clear - 1) < 1e-9);
+  assert.ok(Math.abs(c.opaque - 0.25) < 0.02, `expected a quarter opaque, got ${c.opaque}`);
+});
+
+test('keying is idempotent — running it twice changes nothing', () => {
+  // The route may retry around this; a second pass must not eat the edge it already feathered.
+  const bm = bitmap(48, 48, GREEN);
+  rect(bm, 12, 12, 24, 24, ORANGE);
+  const k = K.sampleKey(bm);
+  K.keyOut(bm, k, {});
+  const first = Buffer.from(bm.data);
+  K.keyOut(bm, k, {});
+  assert.deepEqual(bm.data, first);
+});

--- a/server/test/slide-live-kinds.test.js
+++ b/server/test/slide-live-kinds.test.js
@@ -606,3 +606,21 @@ test('the AI slide generator is not offered lettering either', () => {
   // a permanent empty placeholder.
   assert.ok(R.KINDS.lettering.config, 'lettering must be a config kind');
 });
+
+test('⚠️ the subhead is sized for its length, because the model ignores the cap it is given', () => {
+  /*
+   * The plan prompt asks for at most 40 characters; a real run answered with 48 — "Autumn Sale -
+   * Warm up your home with rustic charm" — which at a fixed 4.5cqw wrapped to three lines and ran
+   * out of the bottom of the text band and over the objects. Asking is still worth doing, but the
+   * geometry cannot depend on the answer.
+   */
+  assert.match(AI_SRC, /function subheadSize/, 'the subhead size must be derived, not fixed');
+  assert.match(AI_SRC, /size_cqw: subheadSize\(subhead\)/, 'and actually used');
+  const fn = AI_SRC.match(/function subheadSize\(text\) \{[\s\S]*?\n\}/)[0];
+  // eslint-disable-next-line no-new-func
+  const subheadSize = new Function(`${fn}; return subheadSize;`)();
+  assert.ok(subheadSize('Autumn Sale') > subheadSize('Autumn Sale - Warm up your home with rustic charm'),
+    'a longer subhead must be set smaller');
+  assert.equal(subheadSize('x'.repeat(48)), 3.6);
+  assert.ok(subheadSize('x'.repeat(200)) >= 3, 'and never collapse to nothing');
+});

--- a/server/test/slide-live-kinds.test.js
+++ b/server/test/slide-live-kinds.test.js
@@ -464,3 +464,46 @@ test('fit survives a save like every other per-element setting', () => {
   assert.equal(savedEl(deckWith([{ kind: 'image', slot: 'a', fit: 'contain' }])).fit, 'contain');
   assert.equal(savedEl(deckWith([{ kind: 'image', slot: 'a' }])).fit, 'cover');
 });
+
+/* ============ layered placement: keeping objects out of the words ============ */
+
+/*
+ * ⚠️ TESTED HERE BECAUSE THE FAILURE WAS SEEN ON A REAL RUN, not imagined. The plan prompt asks the
+ * model to keep objects clear of the headline; a run that produced a good background, leaf and cup
+ * also dropped a pair of mittens directly under "20% OFF". Asking is right — a cooperating model
+ * composes better than a corrected one — but it cannot be the only defence.
+ */
+const AI_SRC = require('fs').readFileSync(require.resolve('../routes/ai.js'), 'utf8');
+
+test('⚠️ object placement is ENFORCED, not merely requested in the prompt', () => {
+  assert.match(AI_SRC, /function placeClear/, 'there must be a server-side placement rule');
+  assert.match(AI_SRC, /box: placeClear\(/, 'and every object must go through it');
+});
+
+test('the text band is reserved and objects are pushed clear of it', () => {
+  // Exercised through the module's own constants so the test cannot drift from the rule.
+  const zone = AI_SRC.match(/const TEXT_ZONE = Object\.freeze\(\{ x: (\d+), y: (\d+), w: (\d+), h: (\d+) \}\)/);
+  assert.ok(zone, 'TEXT_ZONE must be declared');
+  const [, zx, zy, zw, zh] = zone.map(Number);
+  assert.ok(zw > 40 && zh > 40, 'the reserved band must actually cover where the words sit');
+  assert.ok(zx < 10 && zy < 30, 'and start where the headline starts');
+});
+
+test('⚠️ the headline box is sized for the wrap that will happen', () => {
+  /*
+   * A headline as short as "20% OFF" wrapped to two lines at 12cqw in a 52%-wide box and the second
+   * line landed on the subhead. Nothing server-side can measure text, so the geometry has to assume
+   * the wrap rather than the intent — and the subhead has to clear a two-line headline.
+   */
+  const head = AI_SRC.match(/slot: 'headline'[\s\S]*?box: \{ x: \d+, y: (\d+), w: (\d+) \}[\s\S]*?size_cqw: ([\d.]+)/);
+  const sub = AI_SRC.match(/slot: 'subhead'[\s\S]*?box: \{ x: \d+, y: (\d+), w: (\d+) \}/);
+  assert.ok(head && sub, 'both text elements must be findable');
+  const headY = Number(head[1]); const headSize = Number(head[3]); const subY = Number(sub[1]);
+  assert.ok(headSize <= 10, `headline at ${headSize}cqw is large enough to wrap unexpectedly`);
+  assert.ok(subY - headY >= 2.5 * headSize,
+    `subhead at ${subY} does not clear a two-line headline starting at ${headY} at ${headSize}cqw`);
+});
+
+test('the plan asks for text short enough for the size it is set at', () => {
+  assert.match(AI_SRC, /at most 14 characters/, 'the headline length must be constrained upstream too');
+});

--- a/server/test/slide-live-kinds.test.js
+++ b/server/test/slide-live-kinds.test.js
@@ -255,7 +255,7 @@ test('⚠️ the AI generator is not offered kinds it cannot fill', () => {
   // And the flag is actually set on the four that need it, so the filter above has something to bite.
   assert.deepEqual(
     Object.keys(R.KINDS).filter((k) => R.KINDS[k].config).sort(),
-    ['clock', 'countdown', 'date', 'qr'],
+    ['clock', 'countdown', 'date', 'lettering', 'qr'],
   );
 });
 
@@ -506,4 +506,103 @@ test('⚠️ the headline box is sized for the wrap that will happen', () => {
 
 test('the plan asks for text short enough for the size it is set at', () => {
   assert.match(AI_SRC, /at most 14 characters/, 'the headline length must be constrained upstream too');
+});
+
+/* ============ lettering: a picture of words that is still a record ============ */
+
+test('⚠️ the words a lettering element depicts stay in fields', () => {
+  /*
+   * THE PROMISE THIS FEATURE COULD EASILY HAVE BROKEN. slide-render.js opens by arguing that the
+   * changeable text must stay OUT of the layout, so somebody can come back in three months and
+   * change a number. Generated lettering is an image, and the obvious implementation stops there —
+   * at which point the words have ceased to exist as data, and the slide has become the thing this
+   * whole module was written to prevent.
+   */
+  const n = R.normalizeSlide({
+    template: { elements: [{ kind: 'lettering', slot: 'w', content_id: 'c' }] },
+    fields: { w: 'AUTUMN SALE' },
+  });
+  assert.equal(n.fields.w, 'AUTUMN SALE', 'the words must survive normalization');
+  assert.ok(R.KINDS.lettering.text, 'lettering must read its field');
+});
+
+test('⚠️ the artwork carries the words as alt text', () => {
+  // A headline that is a picture is invisible to a screen reader, to a search, and to anyone
+  // reading the document as text — and the words are the one thing we reliably know about it.
+  const html = R.renderSlideHtml({
+    template: { elements: [{ kind: 'lettering', slot: 'w', content_id: 'c' }] },
+    fields: { w: 'AUTUMN SALE' },
+  }, { resolveImage: () => '/uploads/content/a.png' });
+  assert.match(html, /<img class="fit" src="[^"]+" alt="AUTUMN SALE">/);
+});
+
+test('⚠️ words that look like markup are escaped into the alt attribute', () => {
+  const html = R.renderSlideHtml({
+    template: { elements: [{ kind: 'lettering', slot: 'w', content_id: 'c' }] },
+    fields: { w: EVIL },
+  }, { resolveImage: () => '/uploads/content/a.png' });
+  assert.ok(!html.includes('<img src=x'), 'markup breakout through alt');
+  assert.ok(html.includes('&quot;'), 'the words must survive as escaped characters');
+});
+
+test('⚠️ lettering can never be cropped, and the setting is not offered', () => {
+  /*
+   * Cropping a word is not a styling choice — it removes letters, and "20% OF" two feet tall on a
+   * wall is worse than no slide. So `contain` is fixed here rather than defaulted.
+   */
+  for (const attempt of ['cover', 'fill', '', null]) {
+    const n = R.normalizeSlide({ template: { elements: [{ kind: 'lettering', slot: 'w', fit: attempt }] } });
+    assert.equal(n.elements[0].cfg.fit, 'contain', `fit=${String(attempt)} must not take effect`);
+  }
+  const html = R.renderSlideHtml({
+    template: { elements: [{ kind: 'lettering', slot: 'w', content_id: 'c', fit: 'cover' }] },
+    fields: { w: 'HI' },
+  }, { resolveImage: () => '/u/a.png' });
+  assert.match(html, /<img class="fit"/, 'the artwork must always be contained');
+});
+
+test('lettering draws no glyphs of its own, so it pulls no font onto the wire', () => {
+  const html = R.renderSlideHtml({
+    template: { elements: [{ kind: 'lettering', slot: 'w', content_id: 'c' }] },
+    fields: { w: 'HI' },
+  }, { resolveImage: () => '/u/a.png' });
+  assert.ok(!/@font-face/.test(html), 'the words are painted into the image, not set in a face');
+});
+
+test('lettering with no artwork yet shows the placeholder rather than breaking', () => {
+  // The element is placeable before it has been generated, and a missing upload must not throw.
+  const html = R.renderSlideHtml({
+    template: { elements: [{ kind: 'lettering', slot: 'w' }] }, fields: { w: 'HI' },
+  });
+  assert.ok(html.includes('class="ph"'));
+});
+
+test('lettering survives a save, words and all', () => {
+  const deck = deckWith([{ kind: 'lettering', slot: 'w', content_id: 'c' }], { w: 'AUTUMN SALE' });
+  const saved = deckLib.normalizeDeck(deck).slides[0];
+  assert.equal(saved.template.elements[0].kind, 'lettering');
+  assert.equal(saved.template.elements[0].fit, 'contain');
+  assert.equal(saved.fields.w, 'AUTUMN SALE');
+});
+
+test('⚠️ the operator is told to check the spelling, every time', () => {
+  /*
+   * Nothing server-side can verify that the picture spells the headline, and a misspelled word set
+   * two feet tall is the worst thing this feature can produce. The operator is the check, so the
+   * route has to tell them there is something to check.
+   */
+  assert.match(AI_SRC, /check it reads/i, 'the route must warn about generated spelling');
+});
+
+test('⚠️ lettering falls back to real type rather than leaving no headline', () => {
+  // A slide whose whole purpose is to say one thing must not come back saying nothing because an
+  // image endpoint had a bad minute.
+  assert.match(AI_SRC, /letteringDone/, 'there must be a fallback path');
+  assert.match(AI_SRC, /if \(headline && !letteringDone\)/, 'and it must emit a real head element');
+});
+
+test('the AI slide generator is not offered lettering either', () => {
+  // Like qr and countdown: it cannot produce a content_id, so a lettering element from it would be
+  // a permanent empty placeholder.
+  assert.ok(R.KINDS.lettering.config, 'lettering must be a config kind');
 });

--- a/server/test/slide-live-kinds.test.js
+++ b/server/test/slide-live-kinds.test.js
@@ -23,6 +23,11 @@ const R = require('../lib/slide-render');
 const render = (elements, fields = {}) =>
   R.renderSlideHtml({ template: { elements }, fields });
 
+/* An image element only becomes an <img> when its content resolves; without a resolver it is the
+ * missing-photo placeholder, which is a different branch entirely. */
+const renderWithImages = (elements, fields = {}) =>
+  R.renderSlideHtml({ template: { elements }, fields }, { resolveImage: () => '/uploads/content/x.png' });
+
 /** Markup that would execute or restructure the document if any escape were missing. */
 const EVIL = '"><img src=x onerror=alert(1)><script>alert(2)</script>';
 
@@ -233,7 +238,9 @@ test('⚠️ an older server meeting a newer deck degrades instead of throwing',
 });
 
 test('kinds that need no configuration carry none', () => {
-  for (const kind of ['head', 'body', 'stat', 'image', 'rule', 'box']) {
+  // `image` is deliberately absent: it gained a `fit` setting, which has a sensible default and so
+  // does not make it a `config` kind, but does give it a cfg object.
+  for (const kind of ['head', 'body', 'stat', 'rule', 'box']) {
     const n = R.normalizeSlide({ template: { elements: [{ kind }] } });
     assert.equal(n.elements[0].cfg, null, `${kind} should not have gained a cfg`);
   }
@@ -319,7 +326,7 @@ test('⚠️ hostile config does not survive a save either', () => {
 
 test('a kind that needs no config gains no keys on save', () => {
   const e = savedEl(deckWith([{ kind: 'head', slot: 'a' }], { a: 'hi' }));
-  for (const k of ['clock_format', 'date_format', 'tz', 'locale', 'target', 'qr_ec', 'qr_bg']) {
+  for (const k of ['clock_format', 'date_format', 'tz', 'locale', 'target', 'qr_ec', 'qr_bg', 'fit']) {
     assert.ok(!(k in e), `a headline should not carry ${k}`);
   }
 });
@@ -412,4 +419,48 @@ test('a normal QR produces no warning', () => {
 test('the QR foreground survives a save like every other config field', () => {
   const e = savedEl(deckWith([{ kind: 'qr', slot: 'a', qr_fg: '#112233' }], { a: 'https://a.example' }));
   assert.equal(e.qr_fg, '#112233');
+});
+
+/* ============ how a photo sits in its box ============ */
+
+test('⚠️ a cut-out fits inside its box instead of being cropped to fill it', () => {
+  /*
+   * THE DEFECT A SPIKE FOUND, and the reason this option exists. `cover` fills the box and crops
+   * the overflow, which is right for a photograph used as a panel and wrong for an object with
+   * transparency around it — the crop slices through the object. Measured: a generated pumpkin laid
+   * into a 34x62 box lost its bottom third, and it reads as a bad photo rather than a setting
+   * anybody would think to look for.
+   */
+  const cover = renderWithImages([{ kind: 'image', content_id: 'x' }]);
+  const contain = renderWithImages([{ kind: 'image', content_id: 'x', fit: 'contain' }]);
+  assert.ok(!/<img class="fit"/.test(cover), 'cover is the default and needs no class');
+  assert.ok(/<img class="fit"/.test(contain), 'contain must be marked');
+  assert.ok(/\.e img\.fit \{ object-fit:contain; \}/.test(contain), 'and the rule must be present');
+});
+
+test('⚠️ a slide authored before this option renders byte for byte as it did', () => {
+  // A layout change nobody asked for is a worse bug than a missing option: these are on screens.
+  const before = renderWithImages([{ kind: 'image', content_id: 'x' }, { kind: 'head', slot: 'a' }], { a: 'hi' });
+  assert.ok(before.includes('<img src='), 'no class attribute on a default image');
+  assert.ok(!before.includes('class="fit"'));
+});
+
+test('an unknown fit falls back to cover rather than reaching the markup', () => {
+  const html = renderWithImages([{ kind: 'image', content_id: 'x', fit: '" onerror=alert(1)' }]);
+  assert.ok(!html.includes('onerror'), 'markup breakout through fit');
+  assert.ok(!html.includes('class="fit"'));
+});
+
+test('every fit in the allowlist survives, and nothing else does', () => {
+  assert.deepEqual(Object.keys(R.IMAGE_FITS).sort(), ['contain', 'cover']);
+  for (const f of ['fill', 'none', '', null, 7]) {
+    const n = R.normalizeSlide({ template: { elements: [{ kind: 'image', fit: f }] } });
+    assert.equal(n.elements[0].cfg.fit, 'cover', `${String(f)} slipped through`);
+  }
+});
+
+test('fit survives a save like every other per-element setting', () => {
+  // The same silent-loss trap: unnamed keys are dropped by sanitizeStored on every save.
+  assert.equal(savedEl(deckWith([{ kind: 'image', slot: 'a', fit: 'contain' }])).fit, 'contain');
+  assert.equal(savedEl(deckWith([{ kind: 'image', slot: 'a' }])).fit, 'cover');
 });


### PR DESCRIPTION
A slide can now be generated as **layers** rather than as one flat picture: a background plate, individual objects cut out with real transparency, and a painted headline — each landing as its own element with its own entrance.

## Why generate the pieces instead of extracting them

The obvious reading of "put the pumpkin from that poster on a slide" is to segment it out of a finished image. That needs a model — SAM or similar — which means onnxruntime, a native dependency and a ~100MB asset, on a project that deliberately **dropped sharp** so `better-sqlite3` would be the last native dep, and that has to keep running on a BrightSign. It is also worse at the job: an object composited onto a bokeh gradient has no clean boundary, so the edges come back ragged around exactly the thin features a viewer looks at.

So each object is generated alone on a flat chroma backdrop and keyed out in pure JavaScript. Measured against real Grok output **before any of this was written**: asked for a flat backdrop it returns one whose border pixels sit within a few units of each other. Three maple leaves with serrated edges, hairline stems and gaps between them cut out cleanly — 0.25% of pixels in the feathered band, no green fringe.

## The lettering, and the promise it could have broken

`slide-render.js` opens by arguing that the changeable text must stay **out** of the layout, so somebody can come back in three months and change a number. Generated lettering is an image, and the obvious implementation stops there — at which point the words have ceased to exist as data and the slide has become the thing that module was written to prevent.

So a `lettering` element reads `fields[slot]` exactly as a headline does. The editor shows the words, a regenerate is asked for them, and they are emitted as the image's **alt text** — a slide whose headline is a picture is still readable to anything that cannot see it. What is lost is only that editing the words needs the artwork remade, and the editor says so.

It can never be cropped (`contain` is fixed, not defaulted — cropping a word removes letters), and it **falls back to real type** if it cannot be generated or will not key. A slide whose whole purpose is to say one thing must not come back saying nothing because an image endpoint had a bad minute.

Image models misspell, and nothing here can verify the picture spells the headline. The prompt does the only things that measurably help — the string stated once, exactly, in quotes, with style in a separate clause so a style word cannot become something the model tries to write — and then the operator is told, every time, that there is something to check.

## Bad cut-outs are refused, not laid on

A cut-out that went wrong still looks like a cut-out, so nothing downstream would notice. Two measurements decide: how far the backdrop's border wanders from its median, and whether the key removed anything at all. A failing object is skipped, named, and reported — a slide comes back with three layers or two, and the difference is never something the operator has to spot.

Proven end to end: an object given a deliberately non-flat backdrop came back *"skipped: the generated backdrop was not flat (spread 70)"*.

## Three defects the real runs found

All three were invisible until something was on screen:

1. **An object landed under the headline**, despite the plan prompt asking it not to. Asking stays — a cooperating model composes better than a corrected one — but a reserved text band is now enforced server-side and objects are moved clear of it.
2. **A headline as short as "20% OFF" wrapped to two lines** at 12cqw in a 52%-wide box and its second line landed on the subhead. Nothing server-side can measure text, so the geometry assumes the wrap rather than the intent.
3. **The subhead came back 49 characters against a 40-character cap** and ran out of the band. The type now scales to the copy.

## Also: `fit` on image elements

`object-fit` was hardcoded to `cover`, so a cut-out was cropped **through the object** — a generated pumpkin in a 34x62 box lost its bottom third. `cover` stays the default and slides authored before this render byte for byte as they did.

## Implementation notes

- `lib/image-key.js` is pure arithmetic on an RGBA bitmap — no decoder, no dependency — and is tested against **synthetic bitmaps rather than fixtures**: a keyer's failure mode is at the edge, and a photograph cannot say where the true edge is while a hand-built bitmap knows its boundary to the pixel. A one-pixel stem must survive; a hole enclosed by a stem's curl must stay transparent; despill must run on the **opaque** edge band — a bug a spike found on real leaves, where the first version only touched translucent pixels and a green line survived along every serration.
- Keying runs on the existing image worker, not the main thread. A 2048x2048 frame is 4.2M pixels each costing a square root, which is the shape of work that produced #240.
- The backdrop instruction is written by the **server**, not the model. Left to describe an object freely a model writes "a pumpkin on a wooden table in soft autumn light" — a better picture and completely unusable, since keying it takes the table, the light and half the pumpkin.
- One press is up to five paid generations, so: capped at four objects, rate limited to 3/min, single-flight in the editor, and confirmed before it spends anything.

## Verification

Driven end to end against real Grok on alpha, twice — a background, cut-out objects and painted lettering, correct spelling, clean edges, staggered entrances. Also driven against a stand-in endpoint to exercise the refusal path deterministically.

- **2857 pass / 3 fail** — the three are `triggers-udp` multicast tests needing a real multicast interface; they fail identically on a clean tree.
- Nine mutations applied across the keyer, `fit` and lettering — all caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kfhrUPit5MCqxeTQyqr56
