### PR TITLE
Video backgrounds for slides

### DIFF
--- a/frontend/js/views/slides.js
+++ b/frontend/js/views/slides.js
@@ -151,6 +151,18 @@ function ensureFontFaces() {
   document.head.appendChild(st);
 }
 
+/*
+ * ⚠️ THE VIDEO PICKER OFFERS ONLY VIDEO. The renderer cannot tell a clip from a photo — it resolves
+ * a content id to a URL and emits it — so a JPEG chosen here becomes a <video> that will never
+ * decode. It would not even look broken: the poster still shows, so the operator gets a still and
+ * no explanation for why it does not move.
+ */
+const VIDEO_EXT = /\.(mp4|webm|ogv|mov|mkv|m4v)$/i;
+function videoContent() {
+  return (state.contentIndex || []).filter((c) => (c.type && String(c.type).startsWith('video'))
+    || VIDEO_EXT.test(c.filename || ''));
+}
+
 function newElement(kind) {
   const k = KINDS[kind];
   return {
@@ -599,9 +611,25 @@ function renderStage(container) {
    * look right here and composite differently on a screen.
    */
   const bgUrl = contentUrl(s.template.background_content_id);
-  if (bgUrl) {
-    const bg = document.createElement('div');
-    bg.style.cssText = `position:absolute;inset:0;background-size:cover;background-position:center;background-image:url(${esc(bgUrl)})`;
+  const bgVidUrl = contentUrl(s.template.background_video_content_id);
+  if (bgUrl || bgVidUrl) {
+    let bg;
+    if (bgVidUrl) {
+      /*
+       * ⚠️ Built the same way the renderer builds it, muted and looping, so what the editor shows
+       * is what a panel shows. A preview that played sound here and not there — or that showed a
+       * still where the wall shows motion — would make the canvas a liar about the one thing this
+       * setting changes.
+       */
+      bg = document.createElement('video');
+      bg.autoplay = true; bg.muted = true; bg.loop = true; bg.playsInline = true;
+      if (bgUrl) bg.poster = bgUrl;
+      bg.src = bgVidUrl;
+      bg.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;object-fit:cover;display:block';
+    } else {
+      bg = document.createElement('div');
+      bg.style.cssText = `position:absolute;inset:0;background-size:cover;background-position:center;background-image:url(${esc(bgUrl)})`;
+    }
     stage.appendChild(bg);
     const d = s.template.background_dim == null ? 0 : s.template.background_dim;
     if (d > 0) {
@@ -741,7 +769,7 @@ function renderStrip(container) {
       border:1px solid ${i === state.si ? 'var(--primary)' : 'var(--border)'};border-radius:4px;overflow:hidden;background:var(--surface)">
       <div style="position:relative;aspect-ratio:${esc(aspectCss())};container-type:size;background:${esc(s.template.background || '#000')}">
         ${contentUrl(s.template.background_content_id) ? `<div style="position:absolute;inset:0;background-size:cover;background-position:center;background-image:url(${esc(contentUrl(s.template.background_content_id))})"></div>` : ''}
-        ${(s.template.background_dim || 0) > 0 && contentUrl(s.template.background_content_id) ? `<div style="position:absolute;inset:0;background:rgba(0,0,0,${s.template.background_dim})"></div>` : ''}
+        ${(s.template.background_dim || 0) > 0 && (contentUrl(s.template.background_content_id) || s.template.background_video_content_id) ? `<div style="position:absolute;inset:0;background:rgba(0,0,0,${s.template.background_dim})"></div>` : ''}
         ${elementsOf(s).map((e) => `<div style="position:absolute;overflow:hidden;${esc(styleFor(e))}">${
           // A thumbnail shows what the slide shows: a clock reads as a clock, and a QR is a shape
           // rather than the raw URL behind it, which at 124px is unreadable noise either way.
@@ -818,6 +846,7 @@ function renderProps(container) {
 
   if (state.tab === 'slide') {
     const bgId = s.template.background_content_id || '';
+    const bgVid = s.template.background_video_content_id || '';
     const dim = s.template.background_dim == null ? 0 : s.template.background_dim;
     host.innerHTML =
       `<div class="sl-group"><p class="sl-legend">Slide</p>
@@ -834,10 +863,17 @@ function renderProps(container) {
              <select class="input" id="sBgImg"><option value="">— none —</option>${
                (state.contentIndex || []).map((c) => `<option value="${esc(c.id)}" ${
                  c.id === bgId ? 'selected' : ''}>${esc(c.filename)}</option>`).join('')}</select></div>
-           ${bgId ? `<div class="sl-row"><label for="sDim">Dim</label>
+           <div class="sl-row"><label for="sBgVid">Video</label>
+             <select class="input" id="sBgVid"><option value="">— none —</option>${
+               videoContent().map((c) => `<option value="${esc(c.id)}" ${
+                 c.id === bgVid ? 'selected' : ''}>${esc(c.filename)}</option>`).join('')}</select></div>
+           ${bgVid ? `<p class="sl-note">The photo above becomes the poster — it shows while the
+              video loads, and stays on any panel that cannot decode it. Background video is always
+              silent; the playlist decides which zone has audio.</p>` : ''}
+           ${(bgId || bgVid) ? `<div class="sl-row"><label for="sDim">Dim</label>
              <div class="sl-slide"><input type="range" id="sDim" min="0" max="0.9" step="0.05" value="${dim}">
                <input type="number" class="sl-num" id="sDimn" min="0" max="0.9" step="0.05" value="${dim.toFixed(2)}"></div></div>
-             <p class="sl-note">Darkens the photo behind the text. A bright photo and white words is
+             <p class="sl-note">Darkens what is behind the text. A bright picture and white words is
                 unreadable from across a room — this fixes that without editing the image.</p>` : ''}
            <p class="sl-note">The colour shows while the photo loads, and stays if it never arrives.</p>
          </div>`
@@ -848,7 +884,13 @@ function renderProps(container) {
     // Changing the photo shows or hides the Dim row, so this one genuinely rebuilds the panel.
     host.querySelector('#sBgImg').onchange = (e) => {
       s.template.background_content_id = e.target.value || null;
-      if (!e.target.value) delete s.template.background_dim;
+      if (!e.target.value && !s.template.background_video_content_id) delete s.template.background_dim;
+      else if (s.template.background_dim == null) s.template.background_dim = 0.35;
+      state.dirty = true; paintAll(container);
+    };
+    host.querySelector('#sBgVid').onchange = (e) => {
+      s.template.background_video_content_id = e.target.value || null;
+      if (!e.target.value && !s.template.background_content_id) delete s.template.background_dim;
       else if (s.template.background_dim == null) s.template.background_dim = 0.35;
       state.dirty = true; paintAll(container);
     };

--- a/server/lib/slide-deck.js
+++ b/server/lib/slide-deck.js
@@ -135,6 +135,7 @@ function sanitizeStored(templateIn, fieldsIn) {
   const template = {
     background: settled.background,
     background_content_id: settled.backgroundContentId,
+    background_video_content_id: settled.backgroundVideoContentId,
     background_dim: settled.backgroundDim,
     elements: settled.elements.map((e) => ({
       slot: e.slot,

--- a/server/lib/slide-render.js
+++ b/server/lib/slide-render.js
@@ -385,6 +385,17 @@ function normalizeSlide(raw) {
      */
     backgroundContentId: typeof tplIn.background_content_id === 'string'
       && tplIn.background_content_id.length <= 64 ? tplIn.background_content_id : null,
+    /*
+     * ⚠️ MOTION BEHIND THE WORDS, AND THE STILL IS STILL THE FALLBACK.
+     *
+     * A video background does not replace background_content_id — it sits in front of it as the
+     * `poster`. A slide document is fetched fresh by every player on every play, and a video is
+     * megabytes: for the seconds before the first frame decodes, and for good on a panel that
+     * cannot decode it at all, what shows is the still. Making the video the only background would
+     * turn every one of those cases into a black rectangle behind white text.
+     */
+    backgroundVideoContentId: typeof tplIn.background_video_content_id === 'string'
+      && tplIn.background_video_content_id.length <= 64 ? tplIn.background_video_content_id : null,
     backgroundDim: clamp(tplIn.background_dim, 0, 1, 0),
     elements,
     fields,
@@ -764,8 +775,37 @@ function renderSlideHtml(rawConfig, opts = {}) {
    * on a zoned layout.
    */
   const bgUrl = slide.backgroundContentId ? resolveImage(slide.backgroundContentId) : null;
-  const bgLayers = (bgUrl ? `<div class="bg" style="background-image:url(${escapeHtml(cssUrl(bgUrl))})"></div>` : '')
-    + (bgUrl && slide.backgroundDim > 0
+  const bgVideoUrl = slide.backgroundVideoContentId ? resolveImage(slide.backgroundVideoContentId) : null;
+
+  /*
+   * ⚠️ ALWAYS MUTED, AND THAT IS NOT A DEFAULT — IT IS THE ONLY OPTION.
+   *
+   * Three separate reasons, any one of which is sufficient. Autoplay without a gesture is only
+   * permitted for muted media, so an unmuted background would simply never start. A slide is one
+   * item among many on a wall, and the player already decides which ZONE owns the audio
+   * (showZoneItem mutes every zone but the first) — a widget that made its own noise would fight
+   * that decision from inside an iframe it cannot see out of. And a background is scenery; scenery
+   * that talks over the video in the next zone is a support call.
+   *
+   * ⚠️ hwz="off" IS FOR BRIGHTSIGN AND IS THE WHOLE REASON THIS RENDERS AT ALL THERE.
+   *
+   * With hardware z-order the video decodes onto a plane the DOM sits BEHIND, so a background
+   * video would play OVER the headline and the cut-outs — the exact inverse of a background. The
+   * codebase already documents this for transitions and PiP (brightsign/st-bridge.js, and
+   * suppressMedia in the player, which pauses video rather than covering it because covering it
+   * does not work). `hwz="off"` asks that element to decode into the graphics plane instead, where
+   * it composites normally.
+   *
+   * It is per-element and reversible, deliberately unlike roVideoMode.SetGraphicsZOrder("front") —
+   * which st-bridge.js:482 says was left alone because changing z-order globally risks hiding video
+   * entirely on players that currently work. Every other platform ignores an unknown attribute.
+   */
+  const bgLayers = (bgVideoUrl
+    ? `<video class="bg" autoplay muted loop playsinline hwz="off"`
+      + `${bgUrl ? ` poster="${escapeHtml(bgUrl)}"` : ''}`
+      + ` src="${escapeHtml(bgVideoUrl)}"></video>`
+    : bgUrl ? `<div class="bg" style="background-image:url(${escapeHtml(cssUrl(bgUrl))})"></div>` : '')
+    + ((bgUrl || bgVideoUrl) && slide.backgroundDim > 0
       ? `<div class="scrim" style="background:rgba(0,0,0,${slide.backgroundDim})"></div>` : '');
 
   return `<!DOCTYPE html>
@@ -779,6 +819,8 @@ function renderSlideHtml(rawConfig, opts = {}) {
   .e { position:absolute; }
   /* Both fill the stage and sit beneath every element, in source order: photo, then scrim. */
   .bg { position:absolute; inset:0; background-size:cover; background-position:center; }
+  /* A video background fills the frame the way the still does, and is never letterboxed. */
+  video.bg { width:100%; height:100%; object-fit:cover; display:block; }
   .scrim { position:absolute; inset:0; }
   .t { line-height:1.08; white-space:pre-wrap; word-break:break-word; }
   .e img { width:100%; height:100%; object-fit:cover; display:block; }

--- a/server/test/slide-live-kinds.test.js
+++ b/server/test/slide-live-kinds.test.js
@@ -624,3 +624,117 @@ test('⚠️ the subhead is sized for its length, because the model ignores the 
   assert.equal(subheadSize('x'.repeat(48)), 3.6);
   assert.ok(subheadSize('x'.repeat(200)) >= 3, 'and never collapse to nothing');
 });
+
+/* ============ video backgrounds ============ */
+
+const renderBg = (template, fields = {}, urls = {}) =>
+  R.renderSlideHtml({ template, fields }, { resolveImage: (id) => urls[id] || null });
+
+test('a video background renders as a muted, looping, autoplaying layer', () => {
+  const html = renderBg({ background_video_content_id: 'v', elements: [] }, {},
+    { v: '/uploads/content/clip.mp4' });
+  const tag = html.match(/<video[^>]*>/)[0];
+  for (const attr of ['autoplay', 'muted', 'loop', 'playsinline']) {
+    assert.ok(tag.includes(attr), `a background video must be ${attr}`);
+  }
+  assert.ok(tag.includes('src="/uploads/content/clip.mp4"'));
+});
+
+test('⚠️ muted is not a default — there is no way to turn it off', () => {
+  /*
+   * Three reasons, any one sufficient: autoplay without a gesture is only permitted for muted
+   * media, so an unmuted background would never start; the player already decides which ZONE owns
+   * the audio and a widget cannot see out of its iframe to respect that; and scenery that talks
+   * over the next zone is a support call.
+   */
+  const html = renderBg({ background_video_content_id: 'v', elements: [] }, {}, { v: '/c.mp4' });
+  assert.match(html, /<video[^>]*\bmuted\b/);
+  const src = require('fs').readFileSync(require.resolve('../lib/slide-render.js'), 'utf8');
+  assert.ok(!/background_video_muted|video_audio|bg_audio/.test(src), 'muting must not be configurable');
+});
+
+test('⚠️ hwz="off" is emitted, or the video plays OVER the slide on a BrightSign', () => {
+  /*
+   * With hardware z-order the video decodes onto a plane the DOM sits BEHIND, so a background
+   * would cover the headline and the cut-outs — the exact inverse of a background. The codebase
+   * already documents this for transitions and PiP, and suppressMedia() pauses video rather than
+   * covering it precisely because covering it does not work.
+   */
+  const html = renderBg({ background_video_content_id: 'v', elements: [] }, {}, { v: '/c.mp4' });
+  assert.match(html, /<video[^>]*hwz="off"/);
+});
+
+test('⚠️ the still becomes the poster rather than being replaced', () => {
+  /*
+   * A slide document is fetched fresh on every play and a video is megabytes. For the seconds
+   * before the first frame decodes — and for good on a panel that cannot decode it — what shows is
+   * the still. Dropping it would turn every one of those cases into a black rectangle behind white
+   * text.
+   */
+  const html = renderBg({ background_content_id: 'i', background_video_content_id: 'v', elements: [] },
+    {}, { i: '/still.jpg', v: '/clip.mp4' });
+  assert.match(html, /<video[^>]*poster="\/still\.jpg"/);
+  assert.equal((html.match(/<div class="bg"/g) || []).length, 0,
+    'the still rides as the poster, not as a second layer to paint');
+});
+
+test('a video with no still is fine, and emits no empty poster', () => {
+  const html = renderBg({ background_video_content_id: 'v', elements: [] }, {}, { v: '/clip.mp4' });
+  assert.ok(!html.includes('poster='), 'an absent still must not become poster=""');
+});
+
+test('the scrim still applies over a video', () => {
+  // Text over moving footage is harder to read than over a still, not easier.
+  const html = renderBg({ background_video_content_id: 'v', background_dim: 0.4, elements: [] },
+    {}, { v: '/clip.mp4' });
+  assert.match(html, /<div class="scrim" style="background:rgba\(0,0,0,0\.4\)">/);
+  // Compared inside the BODY: `.scrim` also appears in the stylesheet above, so searching the whole
+  // document finds the CSS rule and says the scrim comes first no matter what the layers do.
+  const body = html.slice(html.indexOf('<body'));
+  assert.ok(body.indexOf('<video') < body.indexOf('<div class="scrim"'),
+    'the scrim must sit above the video');
+});
+
+test('a slide with neither still nor video gets no scrim, whatever the dim says', () => {
+  const html = renderBg({ background_dim: 0.5, elements: [] });
+  const body = html.slice(html.indexOf('<body'));
+  assert.ok(!body.includes('class="scrim"'), 'a scrim over a flat colour is just a darker flat colour');
+});
+
+test('⚠️ a hostile video url cannot break out of the attribute', () => {
+  const html = renderBg({ background_video_content_id: 'v', elements: [] }, {},
+    { v: '" onerror=alert(1) x="' });
+  /*
+   * The escaped characters DO still read as "onerror=alert(1)" inside the attribute value — that is
+   * the payload surviving as data, which is correct. What must not happen is the quote closing the
+   * attribute, so the test is on the structure of the tag, not on the presence of the string.
+   */
+  const tag = html.match(/<video[^>]*>/)[0];
+  assert.ok(tag.includes('&quot;'), 'the quote must be entity-encoded');
+  assert.equal((tag.match(/"/g) || []).length % 2, 0, 'attribute quoting must stay balanced');
+  assert.ok(!/\ssrc="[^"]*"\s+onerror/.test(tag), 'nothing may escape the src attribute');
+});
+
+test('the video background survives a save', () => {
+  // The same silent-loss trap: sanitizeStored rebuilds the template key by key.
+  const saved = deckLib.normalizeDeck({
+    slides: [{ id: 's1', name: 'n', dwell_sec: 10,
+      template: { background_video_content_id: 'vid-1', elements: [] }, fields: {} }],
+  }).slides[0];
+  assert.equal(saved.template.background_video_content_id, 'vid-1');
+});
+
+test('an over-long content id is refused rather than interpolated', () => {
+  const n = R.normalizeSlide({ template: { background_video_content_id: 'x'.repeat(200) } });
+  assert.equal(n.backgroundVideoContentId, null);
+});
+
+test('⚠️ the editor offers only video in the video picker', () => {
+  /*
+   * The renderer cannot tell a clip from a photo — it resolves an id to a URL and emits it — so a
+   * JPEG chosen here becomes a <video> that never decodes. It would not even look broken: the
+   * poster shows, so the operator gets a still and no explanation for why it does not move.
+   */
+  assert.match(VIEW, /function videoContent\(\)/, 'the picker must filter by type');
+  assert.match(VIEW, /id="sBgVid"[\s\S]{0,200}videoContent\(\)/, 'and the select must use it');
+});


### PR DESCRIPTION
The background layer of a slide can now be a clip: the same place the still sits, **in front of it rather than instead of it**.

## The still becomes the poster, not a casualty

A slide document is fetched fresh by every player on every play, and a video is megabytes. For the seconds before the first frame decodes — and for good on a panel that cannot decode it at all — what shows is the still. Making the clip the only background would turn every one of those cases into a black rectangle behind white text.

So `background_content_id` stays exactly as it was and becomes the video's `poster`. That path is the screenshot in the verification section below: still, scrim, and live elements over the top, with the video element present but not yet decoded.

## Always muted, and not configurable

Three reasons, any one of which is sufficient:

- Autoplay without a user gesture is only permitted for muted media, so an unmuted background would simply never start.
- The player already decides which **zone** owns the audio (`showZoneItem` mutes every zone but the first). A widget cannot see out of its iframe to respect that decision, so it must not make a competing one.
- A background is scenery, and scenery that talks over the next zone is a support call.

## `hwz="off"` is why this renders on a BrightSign at all

With hardware z-order the video decodes onto a plane the DOM sits **behind**, so a background video would play **over** the headline and the cut-outs — the exact inverse of a background. The codebase already documents this for transitions and PiP (`brightsign/st-bridge.js:475`), and `suppressMedia()` in the player pauses video rather than covering it precisely because covering it does not work.

The attribute is per-element and reversible, deliberately unlike `roVideoMode.SetGraphicsZOrder("front")` — which `st-bridge.js:482` says was left alone because changing z-order globally risks hiding video entirely on players that currently work. Every other platform ignores an unknown attribute.

**This is the one thing still unproven on hardware.** It is written from the documented behaviour of the platform; it needs a session on the XT245 to confirm.

## The picker offers only video

The renderer cannot tell a clip from a photo — it resolves a content id to a URL and emits it — so a JPEG chosen here would become a `<video>` that never decodes. It would not even look broken: the poster shows, so the operator would get a still and no explanation for why it does not move.

## Verification

- Playback **confirmed on alpha in a real browser**. Worth recording why that took a detour: the test browser used during development cannot decode video at all — a clip recorded in-page and played back from a blob failed identically — so an entire investigation that appeared to show a serving bug was measuring the harness. No conclusion about `Content-Security-Policy: sandbox` on media responses should be drawn from it; that question remains untested.
- Serving checked directly: `content-type: video/mp4`, `accept-ranges: bytes`, `206` on a range request, `cross-origin-resource-policy: cross-origin`. Video was already in `INLINE_SAFE_EXTS`, so this does not hit the trap fonts did where `hardenUploadResponse` forces `octet-stream` + `attachment`.
- Poster fallback, scrim ordering, save round-trip and the editor picker all covered by tests.
- **2869 pass / 3 fail** — the three are `triggers-udp` multicast tests needing a real multicast interface; they fail identically on a clean tree.
- Five mutations applied (dropped `hwz`, dropped `muted`, dropped `poster`, unescaped `src`, save forgetting the field) — all caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kfhrUPit5MCqxeTQyqr56
