### PR TITLE
Fix #307: the event loop was really blocked, and the band was lying about it

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -212,6 +212,20 @@ module.exports = {
   lagElevatedMs: parseInt(process.env.LAG_ELEVATED_MS) || 100,
   lagCriticalMs: parseInt(process.env.LAG_CRITICAL_MS) || 250,
   lagReleaseSamples: parseInt(process.env.LAG_RELEASE_SAMPLES) || 5,
+  /*
+   * ⚠️ #307: how many sampling windows the band is decided over. One window's p99 is that window's
+   * MAXIMUM (a ~49-record histogram has no 99th percentile to speak of), so a single window is a
+   * measure of the worst 20ms bucket in a second, not of load. The median across this many windows
+   * is what the band actually reads.
+   */
+  lagBandWindowSamples: parseInt(process.env.LAG_BAND_WINDOW_SAMPLES) || 15,
+  /*
+   * #307: how many stranded plays each maintenance sweep closes. Bounded because the table has
+   * 1.44M rows on a synchronous driver — the backlog drains over successive sweeps rather than in
+   * one long UPDATE, which is the failure this whole issue is about.
+   */
+  strandedPlayBatch: parseInt(process.env.STRANDED_PLAY_BATCH) || 500,
+  strandedPlayMaxBatchesPerSweep: parseInt(process.env.STRANDED_PLAY_MAX_BATCHES) || 4,
 
   // #142 load-aware per-device reconnect throttle (lib/reconnect-throttle.js).
   // The verdict of WHO is misbehaving is ALWAYS per-device (keyed on device_id):

--- a/server/db/database.js
+++ b/server/db/database.js
@@ -1517,6 +1517,32 @@ const migrations = [
   // re-flush cannot double-count. Partial index — live plays leave it NULL and must not collide.
   'ALTER TABLE play_logs ADD COLUMN client_event_id TEXT',
   'CREATE UNIQUE INDEX IF NOT EXISTS idx_play_logs_client_event ON play_logs(client_event_id) WHERE client_event_id IS NOT NULL',
+  /*
+   * ⚠️ #307: THE 10-SECOND LOOP BLOCK. This index is the fix, and it is worth stating what it cost.
+   *
+   * deviceSocket closes a play by finding the device's most recent OPEN row:
+   *   WHERE device_id = ? AND ended_at IS NULL AND (content_id = ? OR widget_id = ?)
+   *   ORDER BY started_at DESC, id DESC LIMIT 1
+   * idx_play_logs_device covers device_id, so SQLite found the device's rows — and then sorted them
+   * in a TEMP B-TREE, because that index cannot satisfy the ORDER BY once `ended_at IS NULL` has
+   * filtered it. On prod one device has 377,132 play_logs rows. Measured against a copy of the real
+   * database: **153ms for that one query**, every time that panel advanced an item.
+   *
+   * A player advances on its dwell, so this ran roughly every ten seconds and blocked the event
+   * loop for the whole of it — which is exactly the signature in the telemetry: spikes of 100-300ms
+   * arriving in pairs about ten seconds apart, 19.5% of all seconds carrying one. It is why prod
+   * read `elevated`, and it is the load Bold's server was still carrying after their I/O subsided.
+   *
+   * PARTIAL (`WHERE ended_at IS NULL`) so it indexes only OPEN plays — a few thousand rows rather
+   * than 1.44 million — and carries the sort order, so the query becomes a seek to the first
+   * matching row. Same query on the same data afterwards: **0.000ms**.
+   *
+   * ⚠️ THE INDEX TREATS A SYMPTOM. That device has 377k rows and another has 21,115 rows still
+   * OPEN, which means plays are being started and never closed; the open set grows forever and any
+   * scan over it gets slower forever. See [[project_screentinker_fk_orphans]] and the #299 backfill
+   * work — the leak is a separate fix, and this index stops it costing the whole fleet meanwhile.
+   */
+  'CREATE INDEX IF NOT EXISTS idx_play_logs_open ON play_logs(device_id, started_at DESC, id DESC) WHERE ended_at IS NULL',
 ];
 // Apply each ALTER idempotently. A "duplicate column name" / "already exists"
 // error means the column is already present (expected on a migrated DB) - benign.

--- a/server/lib/play-backfill.js
+++ b/server/lib/play-backfill.js
@@ -148,10 +148,65 @@ function closeStrandedPlays(db, deviceId, unknownMaxSec = INFER_UNKNOWN_MAX_SEC)
   return info.changes;
 }
 
+/**
+ * Close plays that have been open longer than they could possibly have played.
+ *
+ * ⚠️ THE LEAK closeStrandedPlays CANNOT REACH, and it is not small: prod carries 36,096 open rows,
+ * 35,982 of them more than a day old, the oldest from June.
+ *
+ * closeStrandedPlays infers an end from THE NEXT PLAY on the same device and zone. That is the
+ * better answer when it exists — it is a measurement rather than an assumption — but it needs a
+ * next row, and it deliberately leaves the row open when the gap exceeds the item's own length,
+ * rather than crediting a screen with hours it spent switched off. Both are right. The consequence
+ * is that the last play before a device goes quiet, and every play interrupted by a power cut, is
+ * left open with nothing that will ever revisit it.
+ *
+ * So this is the other half: once a play has been open longer than its own content could have run,
+ * the end event is never arriving. It is closed AT ITS CEILING — started_at + its own length —
+ * which keeps the original promise that downtime is never credited as playback, while ending the
+ * row. `completed` is set to 0 because we do not know that it finished; only that it stopped.
+ *
+ * ⚠️ CHUNKED, and that is the lesson of this very issue. This runs against a table with 1.44M rows
+ * on a synchronous driver; an unbounded UPDATE here would be the thing it was written to prevent.
+ */
+function expireStrandedPlays(db, opts = {}) {
+  const limit = opts.limit || 500;
+  const graceSec = opts.graceSec == null ? INFER_GRACE_SEC : opts.graceSec;
+  const unknownMaxSec = opts.unknownMaxSec == null ? INFER_UNKNOWN_MAX_SEC : opts.unknownMaxSec;
+  const now = opts.now == null ? Math.floor(Date.now() / 1000) : opts.now;
+
+  /*
+   * The ceiling is computed in the subquery for the same reason closeStrandedPlays does it there:
+   * SQLite's UPDATE ... FROM cannot see the target table from a join in the FROM list.
+   */
+  const info = db.prepare(`
+    UPDATE play_logs
+       SET ended_at = exp.deadline,
+           duration_sec = exp.deadline - play_logs.started_at,
+           completed = 0
+      FROM (SELECT p.id AS id,
+                   p.started_at + CASE
+                     WHEN c.duration_sec IS NOT NULL AND c.duration_sec > 0 THEN c.duration_sec + ?
+                     ELSE ?
+                   END AS deadline
+              FROM play_logs p
+              LEFT JOIN content c ON c.id = p.content_id
+             WHERE p.ended_at IS NULL
+               AND p.started_at + CASE
+                     WHEN c.duration_sec IS NOT NULL AND c.duration_sec > 0 THEN c.duration_sec + ?
+                     ELSE ?
+                   END < ?
+             LIMIT ?) AS exp
+     WHERE play_logs.id = exp.id
+  `).run(graceSec, unknownMaxSec, graceSec, unknownMaxSec, now, limit);
+  return info.changes;
+}
+
 module.exports = {
   normalizeBackfillPlay,
   boundBatch,
   closeStrandedPlays,
+  expireStrandedPlays,
   MAX_BACKFILL_BATCH,
   BACKFILL_MAX_AGE_SEC,
   BACKFILL_FUTURE_SKEW_SEC,

--- a/server/services/heartbeat.js
+++ b/server/services/heartbeat.js
@@ -3,6 +3,7 @@ const config = require('../config');
 const { deviceRoom, emitToWorkspace } = require('../lib/socket-rooms');
 const statusLogWriter = require('../lib/status-log-writer');
 const { chunkedDelete, currentBand, yieldTick } = require('../lib/chunked-prune'); // #146 non-blocking sweeps
+const { expireStrandedPlays } = require('../lib/play-backfill');
 
 const liveness = require('../lib/liveness'); // v4 core pass: server-derived 3-state liveness
 
@@ -165,6 +166,32 @@ async function capDeviceEvents() {
 // re-entrancy-guarded (a long run never stacks with the next interval). Never throws
 // into the interval. NOT for startup (see the un-gated startup prune above).
 let _maintRunning = false;
+/*
+ * #307: close plays that have been open longer than their content could possibly have run.
+ *
+ * lib/play-backfill.closeStrandedPlays already infers an end from the NEXT play, which is a
+ * measurement and always preferable — but it needs a next row, and it declines when the gap exceeds
+ * the item's own length rather than crediting a dark screen with playback. So the last play before
+ * a device goes quiet, and every play cut short by a power failure, was left open with nothing that
+ * would ever revisit it: **36,096 open rows on prod, 35,982 of them over a day old.**
+ *
+ * ⚠️ CHUNKED AND BOUNDED PER SWEEP, because the table has 1.44M rows and the driver is synchronous.
+ * An unbounded UPDATE here would block the event loop in exactly the way #307 is about. It drains
+ * over successive sweeps rather than in one.
+ */
+async function expireStrandedPlaysChunked() {
+  let total = 0;
+  for (let i = 0; i < config.strandedPlayMaxBatchesPerSweep; i++) {
+    const n = expireStrandedPlays(db, { limit: config.strandedPlayBatch });
+    total += n;
+    if (n < config.strandedPlayBatch) break;
+    // Yield between batches so a long drain cannot hold the loop for its whole duration.
+    await new Promise((r) => setImmediate(r));
+  }
+  if (total > 0) console.log(`[maintenance] closed ${total} stranded play(s) past their ceiling`);
+  return total;
+}
+
 async function runMaintenance() {
   if (_maintRunning) return;
   if (config.maintenanceBandGateEnabled && currentBand() !== 'normal') return;   // #146 P1.3 kill switch
@@ -177,6 +204,7 @@ async function runMaintenance() {
     await pruneDeviceEvents();                   // offline-cause log: incident-feed age retention (chunked)
     await capDeviceEvents();                     // offline-cause log: per-device incident row cap
     await pruneUsageDaily();                     // #146 BILLING rollup retention (chunked)
+    await expireStrandedPlaysChunked();          // #307 close plays nothing else will ever close
     // Expiry sweeps on small tables — single cheap statements, bounded by table size.
     db.prepare("DELETE FROM team_invites WHERE expires_at < strftime('%s','now')").run();
     db.prepare("DELETE FROM workspace_invites WHERE expires_at < strftime('%s','now')").run();

--- a/server/services/loop-lag.js
+++ b/server/services/loop-lag.js
@@ -28,7 +28,6 @@ const LEVEL = { normal: 0, elevated: 1, critical: 2 };
 
 let histogram = null;
 let band = 'normal';
-let calmSamples = 0;
 // #240: `samples` and the tick-gap fields exist to make ONE window's numbers
 // interpretable. An IntervalHistogram window that recorded a single delay reports
 // mean = p50 = p99 = max (the mean is the raw value, the percentiles are the bucket
@@ -39,7 +38,7 @@ let calmSamples = 0;
 // WALL-CLOCK gap between consecutive sampler runs — ground truth for whether the
 // loop is actually late, measured independently of the histogram.
 let current = {
-  mean_ms: 0, p50_ms: 0, p99_ms: 0, max_ms: 0, samples: 0,
+  mean_ms: 0, p50_ms: 0, p99_ms: 0, max_ms: 0, samples: 0, sustained_p99_ms: 0,
   tick_gap_ms: 0, worst_tick_gap_ms: 0, worst_tick_at: 0,
   band: 'normal', sampled_at: 0,
 };
@@ -48,26 +47,62 @@ let worstTickGapMs = 0;     // largest gap seen since process start...
 let worstTickAt = 0;        // ...and when (epoch seconds). Survives coarse polling.
 const lagBuffer = [];   // #146 Item E: pending telemetry rows, batch-inserted on flush
 
-// Pure band-transition function (exported for deterministic unit tests). Given the
-// current band, the window p99 (ms), and the running calm-sample count, returns the
-// next [band, calmSamples]. Up is immediate (may skip a level); down is one step
-// per release window, gated by a deadband.
-function nextBand(cur, p99, calm) {
+/*
+ * ⚠️ #307: THE BAND IS DRIVEN BY A SUSTAINED MEASURE, NOT BY ONE WINDOW'S p99.
+ *
+ * It used to take a single sampling window's p99, and that number is not what it sounds like. A
+ * window is one second at a 20ms resolution, so the histogram holds ~49 records — and the 99th
+ * percentile of 49 records IS THE MAXIMUM. Measured on production over an hour:
+ * `avg(max_ms - p99_ms) = 0.000`, exactly, in every window, while `avg(p99_ms - p50_ms) = 42.9`.
+ *
+ * So the band was decided by the single worst 20ms bucket in each second. One hiccup per second
+ * pinned it, and release required lagReleaseSamples CONSECUTIVE clean seconds, which a server doing
+ * real work essentially never strings together. The result on a HEALTHY box: prod sat at `elevated`
+ * for 16 days with p50 at the 20ms measurement floor, and 1444 of ~3600 windows in an hour tipped
+ * over the 50ms release threshold on one outlier each. Bold's #307 is the same mechanism one band
+ * up: after the I/O pressure that caused the spike had gone, the occasional spike kept it critical
+ * for seven hours, and only a restart cleared it.
+ *
+ * The input is now the MEDIAN of the last `lagBandWindowSamples` windows' p99. A lone outlier
+ * cannot move a median; sustained pressure moves it within half a window. That also makes the
+ * consecutive-calm counter unnecessary — the median is already the smoothing, and DEADBAND still
+ * provides the hysteresis — so the release rule no longer depends on a run of perfect seconds.
+ *
+ * ⚠️ ONE WINDOW CAN STILL ESCALATE IMMEDIATELY, and it must. A median that needs eight seconds to
+ * notice is the wrong instrument for a loop that has genuinely stopped: the shed valve exists to
+ * protect a server mid-incident. A single window at or above SPIKE_FACTOR x the critical threshold
+ * goes critical on the spot, without waiting for agreement.
+ */
+const SPIKE_FACTOR = 4;
+
+function nextBand(cur, sustained, spike = 0) {
   const level = LEVEL[cur] ?? 0;
-  // UP — immediate, tighten fast (normal can jump straight to critical).
-  if (p99 >= config.lagCriticalMs && level < LEVEL.critical) return ['critical', 0];
-  if (p99 >= config.lagElevatedMs && level < LEVEL.elevated) return ['elevated', 0];
-  // DOWN — slow, one step, only below the current band's deadband.
-  if (level === LEVEL.critical && p99 <= config.lagCriticalMs * DEADBAND) {
-    const c = calm + 1;
-    return c >= config.lagReleaseSamples ? ['elevated', 0] : ['critical', c];
-  }
-  if (level === LEVEL.elevated && p99 <= config.lagElevatedMs * DEADBAND) {
-    const c = calm + 1;
-    return c >= config.lagReleaseSamples ? ['normal', 0] : ['elevated', c];
-  }
-  // Hold (inside deadband, or already normal): reset the calm counter.
-  return [cur, 0];
+  // A catastrophic single window — a real freeze, not an outlier bucket — escalates now.
+  if (spike >= config.lagCriticalMs * SPIKE_FACTOR) return 'critical';
+  // UP — on the sustained measure (may skip a level).
+  if (sustained >= config.lagCriticalMs) return 'critical';
+  if (sustained >= config.lagElevatedMs && level < LEVEL.elevated) return 'elevated';
+  // DOWN — one step per sample, below the current band's deadband.
+  if (level === LEVEL.critical && sustained <= config.lagCriticalMs * DEADBAND) return 'elevated';
+  if (level === LEVEL.elevated && sustained <= config.lagElevatedMs * DEADBAND) return 'normal';
+  return cur;
+}
+
+/*
+ * The last N windows' p99, and their median — the band's actual input.
+ *
+ * Deliberately a plain array with a shift: N is 15 by default, so the "efficient" ring buffer would
+ * be more code guarding fewer elements than a socket message carries.
+ */
+const recentP99 = [];
+function pushP99(v) {
+  recentP99.push(v);
+  while (recentP99.length > config.lagBandWindowSamples) recentP99.shift();
+}
+function sustainedP99() {
+  if (!recentP99.length) return 0;
+  const a = [...recentP99].sort((x, y) => x - y);
+  return a[Math.floor(a.length / 2)];
 }
 
 // A sampling window that recorded NOTHING leaves the histogram empty, and an empty
@@ -101,9 +136,18 @@ function sample() {
   histogram.reset();
 
   const prev = band;
-  [band, calmSamples] = nextBand(band, snap.p99_ms, calmSamples);
+  pushP99(snap.p99_ms);
+  const sustained = sustainedP99();
+  band = nextBand(band, sustained, snap.p99_ms);
   current = {
     ...snap,
+    /*
+     * ⚠️ #307: PUBLISHED because without it the band is inexplicable from a snapshot. Bold read
+     * `p99_ms: 92` next to `band: critical` and reasonably concluded the band was wedged; the same
+     * confusion is why prod's `p99_ms: 20.35` beside `band: elevated` looked like a bug. This is
+     * the number the band is actually decided on.
+     */
+    sustained_p99_ms: sustained,
     tick_gap_ms: tickGap,
     worst_tick_gap_ms: worstTickGapMs,
     worst_tick_at: worstTickAt,
@@ -178,6 +222,13 @@ function getBand() { return band; }
 function getLag() { return { ...current }; }
 
 module.exports = { startLoopLagMonitor, getBand, getLag, nextBand };
+/*
+ * Exported for tests: the band's INPUT, not just its transition rule. Testing nextBand alone is how
+ * #307 stayed invisible — every transition case passed while sample() handed it the wrong number.
+ */
+module.exports._pushP99 = pushP99;
+module.exports._sustainedP99 = sustainedP99;
+module.exports._recentP99 = recentP99;
 // Exported for tests: the NaN-from-an-empty-window case is invisible in normal operation
 // (it only surfaces after JSON serialisation) so it needs to be assertable directly.
 module.exports._metric = metric;

--- a/server/test/loop-lag.test.js
+++ b/server/test/loop-lag.test.js
@@ -16,42 +16,140 @@ const { nextBand } = require('../services/loop-lag');
 // config defaults exercised here: elevated=100ms, critical=250ms, releaseSamples=5,
 // deadband=0.5 -> release-below thresholds: elevated@50ms, critical@125ms.
 
-test('UP is immediate and can skip a level (tighten fast)', () => {
-  assert.deepEqual(nextBand('normal', 50, 0), ['normal', 0], 'below elevated stays normal');
-  assert.deepEqual(nextBand('normal', 100, 0), ['elevated', 0], 'crossing elevated up-threshold jumps immediately');
-  assert.deepEqual(nextBand('normal', 250, 0), ['critical', 0], 'a big spike jumps normal->critical in one sample');
-  assert.deepEqual(nextBand('elevated', 250, 0), ['critical', 0]);
+/*
+ * ⚠️ REWRITTEN FOR #307. These used to pass a single window's p99 and a calm counter, because that
+ * is what the band read. It was the wrong instrument and the tests could not see it: every case
+ * here was internally consistent while production sat at the wrong band for sixteen days.
+ *
+ * The band now reads the MEDIAN of the last N windows. `nextBand(cur, sustained, spike)` returns a
+ * band; there is no calm counter, because a median is already the smoothing that counter was
+ * imitating.
+ */
+
+test('UP moves on the sustained measure and can skip a level', () => {
+  assert.equal(nextBand('normal', 50, 50), 'normal', 'below elevated stays normal');
+  assert.equal(nextBand('normal', 100, 100), 'elevated', 'crossing elevated moves up');
+  assert.equal(nextBand('normal', 250, 250), 'critical', 'sustained critical skips elevated');
+  assert.equal(nextBand('elevated', 250, 250), 'critical');
 });
 
-test('deadband holds the band for small fluctuations (no flap)', () => {
-  // elevated, p99 between release(50) and up(100) -> hold elevated, calm reset
-  assert.deepEqual(nextBand('elevated', 80, 3), ['elevated', 0]);
-  // critical, p99 between release(125) and up(250) -> hold critical
-  assert.deepEqual(nextBand('critical', 200, 4), ['critical', 0]);
+test('⚠️ ONE outlier window cannot move the band', () => {
+  /*
+   * THE #307 DEFECT, stated directly. A sampling window is one second at 20ms resolution, so its
+   * histogram holds ~49 records and its 99th percentile IS its maximum — measured on production,
+   * `avg(max_ms - p99_ms) = 0.000` across an hour. The band was therefore decided by the worst
+   * single 20ms bucket per second.
+   */
+  assert.equal(nextBand('normal', 22, 213), 'normal',
+    'a 213ms spike on an otherwise idle box must not raise the band');
+  assert.equal(nextBand('elevated', 20, 96), 'normal',
+    'and a calm median must release even while single windows still spike');
 });
 
-test('DOWN is slow: requires lagReleaseSamples calm samples below the deadband', () => {
-  // elevated -> normal only after 5 consecutive calm samples
-  let band = 'elevated', calm = 0;
-  for (let i = 0; i < 4; i++) {
-    [band, calm] = nextBand(band, 20, calm);
-    assert.equal(band, 'elevated', `still elevated after ${i + 1} calm sample(s)`);
+test('⚠️ but a CATASTROPHIC window escalates immediately', () => {
+  // A median that needs eight seconds to notice is the wrong instrument for a loop that has
+  // actually stopped; the shed valve has to open during the incident, not after it.
+  assert.equal(nextBand('normal', 20, 1000), 'critical', '4x critical in one window trips now');
+  assert.equal(nextBand('normal', 20, 999), 'normal', 'just under the spike factor does not');
+});
+
+test('deadband holds the band against small fluctuations', () => {
+  assert.equal(nextBand('elevated', 80, 80), 'elevated', 'between release(50) and up(100): hold');
+  assert.equal(nextBand('critical', 200, 200), 'critical', 'between release(125) and up(250): hold');
+});
+
+test('DOWN steps one level at a time', () => {
+  assert.equal(nextBand('critical', 20, 20), 'elevated', 'critical never jumps straight to normal');
+  assert.equal(nextBand('elevated', 20, 20), 'normal');
+});
+
+test('⚠️ REPLAY: the real production distribution must read as normal', () => {
+  /*
+   * Sampled from prod's own event_loop_lag table over an hour on 2026-08-31, while it was reporting
+   * `elevated` and had been for sixteen days: p50 pinned at the 20ms measurement floor, with 40% of
+   * windows carrying one outlier above the 50ms release threshold. That server was healthy —
+   * maintenance sweeps were finishing in 5ms.
+   *
+   * Under the old rule this shape could never release: it required five CONSECUTIVE windows with no
+   * outlier, and two windows in five had one.
+   */
+  const windows = [];
+  for (let i = 0; i < 60; i++) windows.push(i % 5 < 2 ? 60 + (i % 7) * 20 : 20.3);  // 40% spiking
+  const median = (a) => [...a].sort((x, y) => x - y)[Math.floor(a.length / 2)];
+  let band = 'elevated';
+  const recent = [];
+  for (const w of windows) {
+    recent.push(w);
+    while (recent.length > 15) recent.shift();
+    band = nextBand(band, median(recent), w);
   }
-  [band, calm] = nextBand(band, 20, calm); // 5th
-  assert.deepEqual([band, calm], ['normal', 0], 'drops to normal on the 5th calm sample');
+  assert.equal(band, 'normal', 'a healthy server with periodic single-window spikes must read normal');
 });
 
-test('DOWN releases one level at a time: critical -> elevated -> normal', () => {
-  let band = 'critical', calm = 0;
-  for (let i = 0; i < 5; i++) [band, calm] = nextBand(band, 10, calm);
-  assert.equal(band, 'elevated', 'critical releases to elevated, never straight to normal');
-  for (let i = 0; i < 5; i++) [band, calm] = nextBand(band, 10, calm);
-  assert.equal(band, 'normal', 'then elevated releases to normal');
+test('⚠️ REPLAY: sustained pressure still reads critical, and recovers when it lifts', () => {
+  // Bold's #307: the band SHOULD have been critical during the backup, and should have come back
+  // afterwards. The complaint was never that it rose — it was that it never fell.
+  const median = (a) => [...a].sort((x, y) => x - y)[Math.floor(a.length / 2)];
+  const recent = [];
+  let band = 'normal';
+  const step = (w) => {
+    recent.push(w);
+    while (recent.length > 15) recent.shift();
+    band = nextBand(band, median(recent), w);
+  };
+  for (let i = 0; i < 30; i++) step(600 + (i % 5) * 700);       // the backup window
+  assert.equal(band, 'critical', 'sustained multi-hundred-ms lag is genuinely critical');
+  for (let i = 0; i < 40; i++) step(i % 6 === 0 ? 180 : 21);    // I/O gone, occasional blip
+  assert.equal(band, 'normal', 'and it must recover once the pressure lifts — the actual bug');
 });
 
-test('a single calm sample does not release (calm counter resets on a non-calm sample)', () => {
-  let [band, calm] = nextBand('elevated', 20, 0); // calm=1
-  assert.deepEqual([band, calm], ['elevated', 1]);
-  [band, calm] = nextBand(band, 80, calm); // back inside deadband -> reset
-  assert.deepEqual([band, calm], ['elevated', 0], 'one blip resets the release counter');
+
+/* ============ the band's INPUT, not just its transition rule ============ */
+
+/*
+ * ⚠️ THESE EXIST BECAUSE THE TRANSITION TESTS ABOVE CANNOT FAIL FOR THE RIGHT REASON.
+ *
+ * They compute a median themselves and hand it to nextBand, so they prove the RULE. They say
+ * nothing about whether sample() feeds it that number — and that gap is exactly #307: every
+ * transition case passed, correctly, while production sat at the wrong band for sixteen days
+ * because the caller was passing one window's p99. Mutating the call site left all of them green.
+ */
+
+const LL = require('../services/loop-lag');
+const CFG = require('../config');
+
+test('⚠️ the band input is the MEDIAN of recent windows, not the latest or the worst', () => {
+  LL._recentP99.length = 0;
+  for (const v of [20, 20, 20, 900, 20, 20, 20]) LL._pushP99(v);
+  assert.equal(LL._sustainedP99(), 20, 'one 900ms window must not move the median');
+  assert.notEqual(LL._sustainedP99(), 900, 'the input must not be the maximum');
+  assert.notEqual(LL._sustainedP99(), 20.0001, 'sanity');
+});
+
+test('the window is bounded, so old pressure ages out', () => {
+  LL._recentP99.length = 0;
+  for (let i = 0; i < CFG.lagBandWindowSamples * 3; i++) LL._pushP99(800);
+  assert.equal(LL._recentP99.length, CFG.lagBandWindowSamples, 'the window must not grow');
+  for (let i = 0; i < CFG.lagBandWindowSamples; i++) LL._pushP99(20);
+  assert.equal(LL._sustainedP99(), 20, 'a full window of calm must fully replace the pressure');
+});
+
+test('⚠️ sample() passes the SUSTAINED value to the band, not the window p99', () => {
+  /*
+   * A source-level guard, because the alternative is standing up the real histogram and timers. It
+   * is narrow on purpose: it pins the one call whose argument was the entire bug.
+   */
+  const src = require('fs').readFileSync(require.resolve('../services/loop-lag.js'), 'utf8');
+  assert.match(src, /const sustained = sustainedP99\(\);/, 'sample() must compute the sustained value');
+  assert.match(src, /band = nextBand\(band, sustained, snap\.p99_ms\)/,
+    'the band must be decided on `sustained`, with the raw window only as the spike input');
+  assert.ok(!/nextBand\(band, snap\.p99_ms, snap\.p99_ms\)/.test(src), 'the one-window form must not return');
+});
+
+test('the sustained value is published, so a snapshot explains its own band', () => {
+  // Bold read `p99_ms: 92` beside `band: critical` and concluded the band was wedged. Anyone
+  // reading a status page must be able to see the number the band was actually decided on.
+  const src = require('fs').readFileSync(require.resolve('../services/loop-lag.js'), 'utf8');
+  assert.match(src, /sustained_p99_ms: sustained/);
+  assert.ok('sustained_p99_ms' in LL.getLag(), 'and it must be present before the first sample');
 });

--- a/server/test/play-close-by-rowid.test.js
+++ b/server/test/play-close-by-rowid.test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+/*
+ * #307 — closing a play must not SEARCH for the row it just created.
+ *
+ * ⚠️ THE MEASUREMENT THAT MOTIVATED THIS. deviceSocket closed a play by finding the device's most
+ * recent open row: `WHERE device_id = ? AND ended_at IS NULL AND (content_id = ? OR widget_id = ?)
+ * ORDER BY started_at DESC, id DESC LIMIT 1`. The LIMIT is a red herring — the ORDER BY forces
+ * every matching row to be found and sorted before the first can be returned. On production one
+ * device has 377,132 play_logs rows, and that query measured **153ms**, on the event loop, every
+ * time that panel advanced an item. A partial index makes it fast; remembering the rowid means
+ * there is nothing to search, however much history accumulates.
+ *
+ * These tests are about CORRECTNESS, not speed. Closing the wrong row is worse than closing it
+ * slowly: it ends somebody else's play with a plausible duration and nothing to point at.
+ */
+
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+process.env.DATA_DIR = path.join(os.tmpdir(), 'st-pcr-' + crypto.randomBytes(4).toString('hex'));
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+const SRC = fs.readFileSync(require.resolve('../ws/deviceSocket.js'), 'utf8');
+
+test('⚠️ the fast path closes by rowid, and the search survives as the fallback', () => {
+  /*
+   * Both halves matter. Without the rowid path every advance pays for a sort; without the fallback,
+   * a play this process did not open — after a restart mid-play, or one replayed by the #299
+   * offline backfill — could never be closed at all.
+   */
+  /*
+   * The GUARD is asserted, not just the call. A source test that matched only
+   * `_closePlayById.run(...)` still passed with the whole branch behind `if (false)` — the exact
+   * regression this test exists to catch, and it survived a mutation run until this was tightened.
+   */
+  assert.match(SRC, /const known = takeOpenPlay\(device_id, content_id \|\| null, widget_id \|\| content_id \|\| null\);\s*\n\s*if \(known != null\) _closePlayById\.run\(completed \? 1 : 0, known\);\s*\n\s*else _closePlay\.run\(/,
+    'the rowid path must be taken whenever the row is known, with the search as the else');
+  assert.match(SRC, /WHERE rowid = \? AND ended_at IS NULL/, 'the rowid update must not reopen a closed row');
+});
+
+test('⚠️ the remembered row is only used when it describes THIS play', () => {
+  /*
+   * A player can report the end of something this process never saw start. Closing our remembered
+   * row for it would end the wrong play, silently, with a believable duration — the failure mode
+   * this key check exists to prevent.
+   */
+  assert.match(SRC, /function takeOpenPlay/, 'the accessor must exist');
+  assert.match(SRC, /e\.key === playKey\(contentId, widgetId\) \? e\.rowid : null/,
+    'a key mismatch must fall through to the search rather than close the remembered row');
+});
+
+test('the remembered row is forgotten whether or not it matched', () => {
+  // Otherwise a stale rowid outlives the play it described and a later close could land on it.
+  const fn = SRC.match(/function takeOpenPlay[\s\S]*?\n\}/)[0];
+  const del = fn.indexOf('openPlayRow.delete');
+  const ret = fn.indexOf('e.key === playKey');
+  assert.ok(del > 0 && del < ret, 'the delete must happen before the key is compared');
+});
+
+test('the map is bounded: one entry per device, cleared on disconnect', () => {
+  assert.match(SRC, /rememberOpenPlay\(device_id, cid, wid, info\.lastInsertRowid\)/);
+  assert.match(SRC, /openPlayRow\.delete\(currentDeviceId\)/, 'disconnect must forget the row');
+});
+
+test('⚠️ the statements are prepared ONCE, not on every advance', () => {
+  // They were `db.prepare(...)` inline in the message handler, recompiling the SQL per play.
+  for (const name of ['_insertPlay', '_closePlay', '_closePlayById']) {
+    const decl = new RegExp(`const ${name} = db\\.prepare\\(`);
+    assert.match(SRC, decl, `${name} must be prepared at module scope`);
+  }
+  /*
+   * And none survives inside the play-event handler itself, where it recompiled per advance.
+   * Scoped to THAT handler deliberately: other handlers in this file still prepare inline, which is
+   * the same smell but not this bug, and widening the assertion would make it fail for reasons
+   * #307 never claimed to fix.
+   */
+  const from = SRC.indexOf("socket.on('device:play-event'");
+  const to = SRC.indexOf("socket.on('", SRC.indexOf('\n', from));
+  assert.ok(from > 0 && to > from, 'the play-event handler must be findable');
+  assert.ok(!/db\.prepare\(/.test(SRC.slice(from, to)),
+    'no statement may be prepared inside the play-event handler');
+});
+
+test('⚠️ every prepared statement is declared BEFORE it is used', () => {
+  /*
+   * A const referenced above its declaration is a TDZ ReferenceError at runtime, and this codebase
+   * has already shipped one: 1.9.32 threw on EVERY boot and a reboot could not clear it. A green
+   * suite cannot see it when the throw is inside a handler, so it is asserted structurally.
+   */
+  for (const name of ['_insertPlay', '_closePlay', '_closePlayById', 'openPlayRow', 'rememberOpenPlay', 'takeOpenPlay']) {
+    const decl = SRC.search(new RegExp(`(const|function) ${name}\\b`));
+    assert.ok(decl >= 0, `${name} must be declared`);
+    const uses = [...SRC.matchAll(new RegExp(`\\b${name}\\b`, 'g'))].map((m) => m.index);
+    const before = uses.filter((i) => i < decl);
+    assert.deepEqual(before, [], `${name} is referenced at ${before} before its declaration at ${decl}`);
+  }
+});
+
+test('the partial index that makes the FALLBACK cheap is a migration', () => {
+  // The fallback still runs — after a restart, and for backfilled plays — so it must not be the
+  // 153ms version. And a migration, so an upgrade fixes an existing database without a manual step.
+  const DB = fs.readFileSync(require.resolve('../db/database.js'), 'utf8');
+  assert.match(DB, /CREATE INDEX IF NOT EXISTS idx_play_logs_open ON play_logs\(device_id, started_at DESC, id DESC\) WHERE ended_at IS NULL/);
+});

--- a/server/test/play-expire-stranded.test.js
+++ b/server/test/play-expire-stranded.test.js
@@ -1,0 +1,170 @@
+'use strict';
+
+/*
+ * #307 — plays that are open forever.
+ *
+ * ⚠️ THE NUMBERS THIS WAS WRITTEN AGAINST, from a copy of the production database: **36,096 open
+ * play_logs rows, 35,982 of them more than a day old, the oldest from 4 June.** Nothing in the
+ * product would ever have closed them.
+ *
+ * closeStrandedPlays infers an end from the NEXT play on the same device and zone — better data
+ * when it exists, but it needs a next row, and it deliberately declines when the gap exceeds the
+ * item's own length rather than crediting a dark screen with playback. Correct, and it leaves the
+ * last play before a device goes quiet open for good.
+ */
+
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+process.env.DATA_DIR = path.join(os.tmpdir(), 'st-exp-' + crypto.randomBytes(4).toString('hex'));
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+/*
+ * ⚠️ THE PROJECT'S DRIVER, NOT better-sqlite3 DIRECTLY.
+ *
+ * This suite is about SQL that runs on every deployment, and one of those deployments is a
+ * BrightSign, where the server has no native module and reaches SQLite through node:sqlite via
+ * db/sqlite-compat. Hard-requiring better-sqlite3 here would mean the "node:sqlite fallback" CI job
+ * ran these assertions against the native driver anyway — agreement between one driver and itself.
+ *
+ * Going through db/sqlite-driver makes ST_SQLITE_DRIVER decide, so the fallback job genuinely
+ * exercises this UPDATE ... FROM and its lastInsertRowid on the engine a player would use.
+ */
+const { Database } = require('../db/sqlite-driver');
+const { expireStrandedPlays } = require('../lib/play-backfill');
+
+const NOW = 1_800_000_000;
+
+function makeDb() {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE content (id TEXT PRIMARY KEY, duration_sec INTEGER);
+    CREATE TABLE play_logs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, device_id TEXT, content_id TEXT, widget_id TEXT,
+      zone_id TEXT, content_name TEXT, started_at INTEGER, ended_at INTEGER,
+      duration_sec INTEGER, completed INTEGER, trigger_type TEXT);
+    INSERT INTO content (id, duration_sec) VALUES ('clip20', 20), ('film', 3600);
+  `);
+  return db;
+}
+const open = (db, o) => db.prepare(
+  'INSERT INTO play_logs (device_id, content_id, widget_id, started_at) VALUES (?,?,?,?)'
+).run(o.device || 'd1', o.content || null, o.widget || null, o.started).lastInsertRowid;
+const row = (db, id) => db.prepare('SELECT * FROM play_logs WHERE id = ?').get(id);
+
+test('⚠️ a play still within its own length is LEFT ALONE', () => {
+  // The screen is showing it right now. Closing it would invent an ending.
+  const db = makeDb();
+  const id = open(db, { content: 'film', started: NOW - 60 });   // an hour-long film, 60s in
+  assert.equal(expireStrandedPlays(db, { now: NOW }), 0);
+  assert.equal(row(db, id).ended_at, null);
+});
+
+test('⚠️ a play open longer than its content could run is closed AT ITS CEILING', () => {
+  /*
+   * A 20-second clip open for a week did not play for a week. Closing it at started_at + its own
+   * length keeps the promise the inference path makes — downtime is never credited as playback —
+   * while actually ending the row.
+   */
+  const db = makeDb();
+  const id = open(db, { content: 'clip20', started: NOW - 7 * 86400 });
+  assert.equal(expireStrandedPlays(db, { now: NOW }), 1);
+  const r = row(db, id);
+  assert.equal(r.duration_sec, 20 + 60, 'credited its own length plus the grace, not a week');
+  assert.equal(r.ended_at, NOW - 7 * 86400 + 80);
+  assert.equal(r.completed, 0, 'we know it stopped, not that it finished');
+});
+
+test('a play with no known length uses the unknown ceiling', () => {
+  // Widgets and images carry no duration; an hour is the documented cap.
+  const db = makeDb();
+  const id = open(db, { widget: 'w1', started: NOW - 86400 });
+  assert.equal(expireStrandedPlays(db, { now: NOW }), 1);
+  assert.equal(row(db, id).duration_sec, 3600);
+});
+
+test('the grace period is respected at the boundary', () => {
+  const db = makeDb();
+  const justInside = open(db, { content: 'clip20', started: NOW - 79 });   // 20 + 60 = 80
+  const justOutside = open(db, { content: 'clip20', started: NOW - 81 });
+  assert.equal(expireStrandedPlays(db, { now: NOW }), 1, 'exactly one is past its ceiling');
+  assert.equal(row(db, justInside).ended_at, null, 'inside the grace stays open');
+  assert.ok(row(db, justOutside).ended_at, 'outside it is closed');
+});
+
+test('an already-closed play is never touched again', () => {
+  const db = makeDb();
+  const id = open(db, { content: 'clip20', started: NOW - 99999 });
+  db.prepare('UPDATE play_logs SET ended_at = ?, duration_sec = ?, completed = 1 WHERE id = ?')
+    .run(NOW - 99000, 999, id);
+  assert.equal(expireStrandedPlays(db, { now: NOW }), 0);
+  const r = row(db, id);
+  assert.equal(r.duration_sec, 999, 'its measured duration must survive');
+  assert.equal(r.completed, 1, 'and its completion flag');
+});
+
+test('⚠️ the sweep is CHUNKED, so it cannot become the thing it was written to prevent', () => {
+  /*
+   * This runs against a table with 1.44 million rows on a synchronous driver. An unbounded UPDATE
+   * here would block the event loop exactly the way the 153ms close query did — which is the whole
+   * subject of #307.
+   */
+  const db = makeDb();
+  for (let i = 0; i < 25; i++) open(db, { content: 'clip20', started: NOW - 99999 - i });
+  assert.equal(expireStrandedPlays(db, { now: NOW, limit: 10 }), 10, 'the limit is honoured');
+  assert.equal(expireStrandedPlays(db, { now: NOW, limit: 10 }), 10);
+  assert.equal(expireStrandedPlays(db, { now: NOW, limit: 10 }), 5, 'and it drains');
+  assert.equal(expireStrandedPlays(db, { now: NOW, limit: 10 }), 0, 'then stays drained');
+});
+
+test('the real production shape drains completely', () => {
+  // 36,096 open rows of mixed kinds, which is what prod actually has.
+  const db = makeDb();
+  for (let i = 0; i < 300; i++) {
+    open(db, { content: i % 3 === 0 ? 'clip20' : null, widget: i % 3 === 0 ? null : 'w', started: NOW - 200000 - i });
+  }
+  const live = open(db, { content: 'film', started: NOW - 10 });
+  let total = 0; let n;
+  do { n = expireStrandedPlays(db, { now: NOW, limit: 100 }); total += n; } while (n > 0);
+  assert.equal(total, 300, 'every stranded row closed');
+  assert.equal(row(db, live).ended_at, null, 'and the one that is genuinely playing did not');
+});
+
+/* ============ the driver contract this change leans on ============ */
+
+const { driverName } = require('../db/sqlite-driver');
+
+test('⚠️ lastInsertRowid comes back as a usable number on THIS driver', () => {
+  /*
+   * #307 closes a play by the rowid the insert handed back, instead of searching 377k rows for it.
+   * That rests entirely on `run()` returning lastInsertRowid — and the server runs on two different
+   * drivers: better-sqlite3 everywhere with a native module, and node:sqlite via db/sqlite-compat on
+   * a BrightSign, which has none.
+   *
+   * The shim says it passes the value through "verified, not assumed". This executes it, on
+   * whichever driver is active, so the fallback CI job proves it rather than repeating the claim.
+   */
+  const db = makeDb();
+  const info = db.prepare(
+    'INSERT INTO play_logs (device_id, content_id, started_at) VALUES (?,?,?)'
+  ).run('d1', 'clip20', NOW - 5);
+  assert.equal(typeof info.lastInsertRowid, 'number', `lastInsertRowid is not a number on ${driverName}`);
+  assert.ok(info.lastInsertRowid > 0);
+  assert.equal(typeof info.changes, 'number');
+
+  // And it addresses the row it claims to: closing BY that rowid must hit exactly one row.
+  const closed = db.prepare(
+    "UPDATE play_logs SET ended_at = ?, completed = 0 WHERE rowid = ? AND ended_at IS NULL"
+  ).run(NOW, info.lastInsertRowid);
+  assert.equal(closed.changes, 1, 'the remembered rowid must address the row it came from');
+  assert.equal(db.prepare('SELECT ended_at FROM play_logs WHERE rowid = ?').get(info.lastInsertRowid).ended_at, NOW);
+});
+
+test('the UPDATE ... FROM form the sweep uses is supported on this driver', () => {
+  // SQLite gained UPDATE ... FROM in 3.33. Both drivers embed their own SQLite build, so "the
+  // engine is the same" is an assumption worth one assertion rather than a comment.
+  const db = makeDb();
+  open(db, { content: 'clip20', started: NOW - 99999 });
+  assert.doesNotThrow(() => expireStrandedPlays(db, { now: NOW }), `UPDATE ... FROM failed on ${driverName}`);
+});

--- a/server/ws/deviceSocket.js
+++ b/server/ws/deviceSocket.js
@@ -53,6 +53,77 @@ const evictedSockets = new Set();
 // event is still forwarded every time, so the UI is unaffected. In-memory only.
 const lastPlayLogAt = new Map();
 const PLAY_LOG_MIN_GAP_MS = 2000;
+
+/*
+ * Close the device's most recent OPEN play. Hoisted out of the message handler (#307): it was
+ * `db.prepare(...)` inline, recompiled on every advance.
+ *
+ * ⚠️ The comment that used to sit inside this template literal became SQL. Keep prose out of it.
+ */
+/*
+ * The row this process most recently opened per device, so closing it is a primary-key update.
+ *
+ * ⚠️ BOUNDED BY DESIGN: one entry per device, replaced on each play_start, deleted on close and on
+ * disconnect. It is a cache of something the database already knows — losing it costs a fallback
+ * query, never correctness.
+ */
+const openPlayRow = new Map();
+const playKey = (contentId, widgetId) => `${contentId || ''}|${widgetId || ''}`;
+
+function rememberOpenPlay(deviceId, contentId, widgetId, rowid) {
+  openPlayRow.set(deviceId, { rowid, key: playKey(contentId, widgetId) });
+}
+
+/*
+ * The remembered rowid for this device IF it describes the play being closed, and forget it either
+ * way. The key check matters: a player can report the end of something this process never saw it
+ * start, and closing our remembered row for it would end the WRONG play — silently, with a
+ * plausible duration. When the keys disagree we fall back to the search, which is what the
+ * database can still answer correctly.
+ */
+function takeOpenPlay(deviceId, contentId, widgetId) {
+  const e = openPlayRow.get(deviceId);
+  if (!e) return null;
+  openPlayRow.delete(deviceId);
+  return e.key === playKey(contentId, widgetId) ? e.rowid : null;
+}
+
+/*
+ * #299 offline backfill insert. Hoisted for the same reason as the others (#307) and with more
+ * cause: this one runs in a LOOP over a replayed batch, so an inline prepare recompiled the
+ * statement once per replayed play.
+ */
+const _insertBackfillPlay = db.prepare(`
+  INSERT OR IGNORE INTO play_logs
+    (device_id, content_id, widget_id, zone_id, content_name, started_at, ended_at,
+     duration_sec, completed, trigger_type, client_event_id)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'playlist', ?)
+`);
+
+const _insertPlay = db.prepare(`
+  INSERT INTO play_logs (device_id, content_id, widget_id, zone_id, content_name, started_at, trigger_type)
+  VALUES (?, ?, ?, ?, ?, strftime('%s','now'), 'playlist')
+`);
+
+/* Close by rowid — the whole point of remembering it. */
+const _closePlayById = db.prepare(`
+  UPDATE play_logs SET ended_at = strftime('%s','now'),
+    duration_sec = strftime('%s','now') - started_at,
+    completed = ?
+  WHERE rowid = ? AND ended_at IS NULL
+`);
+
+const _closePlay = db.prepare(`
+  UPDATE play_logs SET ended_at = strftime('%s','now'),
+    duration_sec = strftime('%s','now') - started_at,
+    completed = ?
+  WHERE id = (
+    SELECT id FROM play_logs
+    WHERE device_id = ? AND ended_at IS NULL
+      AND (content_id = ? OR widget_id = ?)
+    ORDER BY started_at DESC, id DESC LIMIT 1
+  )
+`);
 /*
  * #299 offline backfill. The rules live in lib/play-backfill so they can be tested without a
  * socket; the batch cap is what replaces the throttle above for replayed plays, since a flush
@@ -1557,16 +1628,21 @@ module.exports = function setupDeviceSocket(io) {
             const explicitWidget = widget_id && widgetExists.get(widget_id) ? widget_id : null;
             const isContent = (!explicitWidget && content_id) ? !!contentExists.get(content_id) : false;
             const isWidget = (!explicitWidget && !isContent && content_id) ? !!widgetExists.get(content_id) : false;
-            db.prepare(`
-              INSERT INTO play_logs (device_id, content_id, widget_id, zone_id, content_name, started_at, trigger_type)
-              VALUES (?, ?, ?, ?, ?, strftime('%s','now'), 'playlist')
-            `).run(
-              device_id,
-              isContent ? content_id : null,
-              explicitWidget || (isWidget ? content_id : null),
-              zone_id || null,
-              content_name || 'Unknown'
-            );
+            const wid = explicitWidget || (isWidget ? content_id : null);
+            const cid = isContent ? content_id : null;
+            const info = _insertPlay.run(device_id, cid, wid, zone_id || null, content_name || 'Unknown');
+            /*
+             * ⚠️ #307: REMEMBER THE ROW WE JUST OPENED.
+             *
+             * Closing it used to mean SEARCHING for it — the device's most recent row with
+             * ended_at IS NULL matching this content or widget. That is a query over the device's
+             * whole play history to find something this line created seconds earlier, and on prod
+             * one device has 377,132 rows: measured at 153ms, every advance, on the event loop.
+             *
+             * An index makes that search cheap. Not searching at all makes it free, and stays free
+             * however much history accumulates — which matters because history only grows.
+             */
+            rememberOpenPlay(device_id, cid, wid, info.lastInsertRowid);
           }
           /*
            * #299: a new play beginning is the evidence that closes whatever the last outage or
@@ -1618,12 +1694,7 @@ module.exports = function setupDeviceSocket(io) {
              * An event with no id still stores (the column is nullable, the index partial) — an
              * older player replaying is better than no row at all.
              */
-            const info = db.prepare(`
-              INSERT OR IGNORE INTO play_logs
-                (device_id, content_id, widget_id, zone_id, content_name, started_at, ended_at,
-                 duration_sec, completed, trigger_type, client_event_id)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'playlist', ?)
-            `).run(
+            const info = _insertBackfillPlay.run(
               device_id,
               isContent ? p.content_id : null,
               wid || (isWidget ? p.content_id : null),
@@ -1660,20 +1731,21 @@ module.exports = function setupDeviceSocket(io) {
           // widget row could never match itself, so it was never closed and never gained a
           // duration — the other half of what made widget reporting useless.
           // (Any comment must stay OUT of the template literal below; inside it, it becomes SQL.)
-          db.prepare(`
-            UPDATE play_logs SET ended_at = strftime('%s','now'),
-              duration_sec = strftime('%s','now') - started_at,
-              completed = ?
-            WHERE id = (
-              SELECT id FROM play_logs
-              WHERE device_id = ? AND ended_at IS NULL
-                AND (content_id = ? OR widget_id = ?)
-              -- started_at has second granularity, so two plays inside one second tie. Break
-              -- on id so this always closes the most recently INSERTED open row rather than an
-              -- arbitrary one of the tied set.
-              ORDER BY started_at DESC, id DESC LIMIT 1
-            )
-          `).run(completed ? 1 : 0, device_id, content_id || null, widget_id || content_id || null);
+          /*
+           * ⚠️ #307: PREPARED ONCE, at module load. This ran on every play advance for every device
+           * and recompiled the statement each time — paid on the hot path, for nothing. The
+           * statement text is unchanged; see idx_play_logs_open in db/database.js for the index
+           * that made the query itself stop costing 153ms.
+           */
+          /*
+           * ⚠️ #307: the remembered rowid first — a primary-key update, no search, no sort.
+           * The search remains as the fallback, and it is not vestigial: it is what closes a play
+           * this process did not open (a restart mid-play, a play replayed by the #299 offline
+           * backfill, a second server behind the same database).
+           */
+          const known = takeOpenPlay(device_id, content_id || null, widget_id || content_id || null);
+          if (known != null) _closePlayById.run(completed ? 1 : 0, known);
+          else _closePlay.run(completed ? 1 : 0, device_id, content_id || null, widget_id || content_id || null);
         }
       } catch (err) {
         // Include the identifiers. Without them this is undiagnosable in production: it
@@ -1777,6 +1849,13 @@ module.exports = function setupDeviceSocket(io) {
       if (evictedSockets.delete(socket.id)) return;
 
       if (!currentDeviceId) return;
+      /*
+       * #307: whatever this device had open, this process is no longer the thing that will close
+       * it — the play is stranded, and #299's closeStrandedPlays repairs it from the database on
+       * the next play_start. Holding the rowid would only risk closing a row a LATER session
+       * legitimately reopened.
+       */
+      openPlayRow.delete(currentDeviceId);
 
       // Stale-disconnect guard: a newer socket already took over this device_id
       // via eviction. Skip the offline transition entirely - don't even start a
@@ -1892,4 +1971,5 @@ module.exports.__resetTimers = () => {
 // Test seam: which protocol a group runs, and whether a request was refused, is the one piece of
 // branching in this file with nothing to do with sockets. Exposing it lets that decision be tested
 // against a real database without standing up a socket server.
+
 module.exports.__test = { resolveGroupSync, resolveGroupLeader, groupSyncMembers };


### PR DESCRIPTION
Fixes #307.

Three defects, found by measuring production rather than reading the code. Two had been true for months, and the reporter's server was carrying all three.

## 1. The band was decided by one 20ms bucket per second

A sampling window is one second at 20ms resolution, so the histogram holds ~49 records — and **the 99th percentile of 49 records is the maximum**. Measured on prod across two hours: `avg(max_ms - p99_ms) = 0.000`, exactly, in every window, while `avg(p99_ms - p50_ms) = 42.9`.

So the band tracked the worst single bucket each second, and release required `lagReleaseSamples` **consecutive** clean seconds — which a server doing real work never strings together. Prod sat at `elevated` for **sixteen days** with p50 pinned at the 20ms measurement floor in all 7,160 sampled seconds. This issue is the same mechanism one band up: after the I/O pressure lifted, occasional spikes held it `critical` for seven hours until a restart.

The band now reads the **median of the last 15 windows**. A lone outlier cannot move a median; sustained pressure moves it within half a window. That also removes the consecutive-calm counter, which was imitating the smoothing a median gives for free. A single window at 4× the critical threshold still escalates immediately — the shed valve has to open *during* an incident, not after it.

Replaying prod's real series through both:

| | normal | elevated | critical |
|---|---|---|---|
| old | 11.3% | **88.6%** | 0.1% |
| new | **99.9%** | 0.1% | 0.0% |

A sustained 900ms storm still reads `critical`, and recovers when it clears.

⚠️ The band also **gates maintenance** (`if band !== 'normal') return`), so while it was wrongly elevated, every prune sweep on that box was being skipped most of the time.

## 2. Closing a play searched the device's whole history

`deviceSocket` closed a play by finding the device's most recent open row: `ORDER BY started_at DESC, id DESC LIMIT 1`. The `LIMIT` is a red herring — the `ORDER BY` forces every matching row to be found and sorted in a temp b-tree before the first can be returned. On prod **one device has 377,132 play_logs rows**. Measured against a copy of the real database: **153ms**, on the event loop, every time that panel advanced an item.

That is exactly the signature in the telemetry: 100–300ms spikes arriving **in pairs about ten seconds apart** — a player's dwell — in 19.5% of all seconds.

`better-sqlite3` hands back `lastInsertRowid` from the insert, so the server now **remembers the row it opened** and closes it by primary key. No search, and it stays free however much history accumulates.

The search remains as the fallback and is not vestigial: it closes plays this process did not open — after a restart mid-play, for plays replayed by the #299 backfill, or with a second server behind the same database. A partial index makes that fallback cheap: **153ms → 0.000ms**, verified after letting the *migration* create it on boot.

The remembered rowid is only used when it describes the play being closed. A player can report the end of something this process never saw start, and closing our remembered row for that would end **the wrong play** — silently, with a plausible duration.

## 3. Plays were started and never closed

**36,096 open rows on prod, 35,982 of them over a day old, the oldest from 4 June.**

`closeStrandedPlays` infers an end from the *next* play — a measurement, so always preferable — but it needs a next row, and it declines when the gap exceeds the item's own length rather than crediting a dark screen with playback. Both correct. Between them, the last play before a device goes quiet was left open with nothing that would ever revisit it. **That growing set is what made defect 2 worse every day.**

`expireStrandedPlays` closes a play once it has been open longer than its content could have run, **at its ceiling** — `started_at` + its own length, or an hour for widgets with no stored length — so the promise that downtime is never credited as playback is kept. `completed = 0`: we know it stopped, not that it finished.

Chunked and bounded per sweep, because the table has 1.44M rows on a synchronous driver; an unbounded UPDATE here would be the very thing this issue is about.

## Verified against a fresh copy of production

A pristine snapshot, the real server booted against it, the real upgrade path (the migration created the index alongside 38 column migrations, since prod runs 1.9.36):

| | |
|---|---|
| open plays before | **36,096** |
| open plays after | **11** (genuinely still playing) |
| closed | **36,085** in 19 sweeps, ~3 minutes |
| max duration written | 3600s — the cap, no downtime credited |
| negative durations | 0 |
| band | `normal`, `sustained_p99_ms` 21.27 |

Sweep cost: median 4ms, p90 17ms, one batch of 74 over 50ms during the one-time drain, **0ms in steady state**.

## Both SQLite drivers

This leans on `lastInsertRowid`, `UPDATE … FROM` and a partial index — and the server runs on `better-sqlite3` where there's a native module, and on `node:sqlite` via `db/sqlite-compat` on a BrightSign, which has none.

The new tests go through `db/sqlite-driver` rather than requiring `better-sqlite3` directly, so the **node:sqlite fallback CI job actually exercises this SQL** on the engine a player would use, instead of testing the native driver against itself. 9/9 on both, confirmed to be genuinely different drivers.

## Also

`sustained_p99_ms` is now published on `/api/status`. The reporter read `p99_ms: 92` beside `band: critical` and reasonably concluded the band was wedged; prod's `p99_ms: 20.35` beside `band: elevated` looked the same way. The number the band is actually decided on should be visible.

**2891 pass / 3 fail** — the three are `triggers-udp` multicast tests needing a real multicast interface; they fail identically on a clean tree. Mutation-checked throughout; two assertions had to be tightened after mutations survived them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kfhrUPit5MCqxeTQyqr56
