### PR TITLE
Make the trigger form a real dialog, and stop offering playlists that cannot fire

### DIFF
--- a/frontend/css/main.css
+++ b/frontend/css/main.css
@@ -1678,3 +1678,70 @@ body {
   .content-grid { grid-template-columns: 1fr; }
   .assign-content-grid { grid-template-columns: 1fr 1fr; }
 }
+
+
+/* ===================== TRIGGERS DIALOG =====================
+ *
+ * ⚠️ This form used `.modal-backdrop`, which is defined nowhere — so it rendered unstyled and
+ * un-positioned at the end of the page. It now uses the same .modal-overlay/.modal/.modal-header/
+ * .modal-body/.modal-footer skeleton as every other dialog; what follows is only the extra it
+ * genuinely needs, which is a wider shell and the two-column assignment grid.
+ */
+
+/* Wider than the 440px default: this form has paired numeric fields and a two-column assignment
+   grid, and at 440px both wrap into a single column of forty rows. */
+.modal.tg-modal { width: 640px; }
+
+.tg-section { padding-bottom: 4px; margin-bottom: 18px; border-bottom: 1px solid var(--border); }
+.tg-section:last-child { border-bottom: 0; margin-bottom: 0; }
+
+.tg-legend {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin: 0 0 10px;
+}
+
+.tg-blurb { font-size: 12px; color: var(--text-secondary); margin: -4px 0 12px; }
+.tg-hint { font-size: 11.5px; color: var(--text-muted); margin-top: 5px; line-height: 1.45; }
+
+/* Paired fields (max duration + lease) sit side by side; they are read together. */
+.tg-row { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+
+.tg-sources { display: flex; gap: 18px; margin-top: 2px; }
+
+.tg-check { display: inline-flex; align-items: center; gap: 7px; font-size: 13px; cursor: pointer; }
+.tg-check input { margin: 0; }
+
+/* Enabled belongs beside Save, not lost in the middle of the form: it is the one control that
+   decides whether any of the rest happens. margin-right:auto pushes the buttons right. */
+.tg-enabled { margin-right: auto; color: var(--text-secondary); }
+
+.tg-empty {
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  background: var(--bg-input);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+  padding: 12px 14px;
+}
+
+.tg-col { font-size: 12px; font-weight: 600; color: var(--text-secondary); margin: 0 0 8px; }
+
+.assign-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+
+/* The assignment lists can be long — a hundred screens is normal — so each column scrolls rather
+   than pushing Save out of reach. */
+.assign-grid > div { max-height: 210px; overflow-y: auto; padding-right: 4px; }
+.assign-grid label {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 13px; padding: 4px 0; cursor: pointer;
+}
+.assign-grid label input { margin: 0; flex-shrink: 0; }
+
+@media (max-width: 700px) {
+  .tg-row, .assign-grid { grid-template-columns: 1fr; }
+}

--- a/frontend/js/i18n/en.js
+++ b/frontend/js/i18n/en.js
@@ -2082,6 +2082,18 @@ export default {
   'trigger.enabled': 'Enabled',
   'trigger.disabled': 'Disabled',
   'trigger.assign': 'Screens',
+  /* Section headings for the trigger dialog. It is a long form — identity, what fires it, what it
+     shows, how it behaves, and who gets it — and without headings it reads as one undifferentiated
+     stack of twelve fields. */
+  'trigger.sec_identity': 'Trigger',
+  'trigger.sec_match': 'What fires it',
+  'trigger.sec_shows': 'What it shows',
+  'trigger.sec_behaviour': 'How it behaves',
+  'trigger.no_published': 'No published playlist to show. A trigger plays a playlist that screens have already downloaded, so publish one first — an unpublished playlist would render nothing.',
+  /* Plural via tn(): the codebase has a helper for count-varying strings precisely so nobody
+     ships "playlist(s)". tn auto-injects {n}. */
+  'trigger.unpublished_hidden_one': '{n} unpublished playlist is not listed: a trigger can only show one that screens have already downloaded.',
+  'trigger.unpublished_hidden_other': '{n} unpublished playlists are not listed: a trigger can only show one that screens have already downloaded.',
   'trigger.assign_hint': 'Assigning a trigger is what makes a screen download and keep its playlist. An unassigned trigger never fires.',
   'trigger.assigned': 'Screens',
   'trigger.unassigned': 'Not assigned',

--- a/frontend/js/views/triggers.js
+++ b/frontend/js/views/triggers.js
@@ -1,7 +1,7 @@
 import { api } from '../api.js';
 import { showToast } from '../components/toast.js';
 import { esc } from '../utils.js';
-import { t } from '../i18n.js';
+import { t, tn } from '../i18n.js';
 
 /*
  * Triggers — externally-fired interrupt content. docs/triggers-design.md.
@@ -71,6 +71,24 @@ function formHtml(tr) {
   const isNew = !tr.id;
   const opt = (list, sel) => list.map(x =>
     `<option value="${esc(x.id)}"${x.id === sel ? ' selected' : ''}>${esc(x.name)}</option>`).join('');
+
+  /*
+   * ⚠️ ONLY PLAYLISTS THAT CAN ACTUALLY FIRE.
+   *
+   * The server refuses to save a trigger pointing at a playlist with no published snapshot, and it
+   * is right to: deviceSocket uses the same guard, so such a trigger would sync with `items: []`
+   * and render nothing, forever, silently. But the dropdown offered every playlist, so the normal
+   * way to meet that rule was to fill the whole form, press Save, and be told no.
+   *
+   * Offering a choice the server will reject is the wrong order. An unpublished playlist is not a
+   * valid answer to "what should this show", so it is not in the list.
+   *
+   * ⚠️ EXCEPT the one already saved on THIS trigger. A playlist can be unpublished after a trigger
+   * was pointed at it, and dropping it from the list would silently re-point that trigger at
+   * whatever happens to be first the next time somebody opens the form to change its name.
+   */
+  const firable = cache.playlists.filter((x) => x.published_snapshot || x.id === tr.target_ref);
+  const unpublishedCount = cache.playlists.length - firable.length;
   const assigned = new Set((tr.assignments || []).map(a => `${a.target_type}:${a.target_id}`));
   const checks = (list, type) => list.map(x => `
       <label class="check">
@@ -78,56 +96,99 @@ function formHtml(tr) {
                ${assigned.has(`${type}:${x.id}`) ? 'checked' : ''}> ${esc(x.name)}
       </label>`).join('') || `<p class="muted">${esc(t('trigger.none_available'))}</p>`;
 
+  /*
+   * ⚠️ `.modal-overlay`, NOT `.modal-backdrop`. This dialog spent its whole life using a class name
+   * that is not defined anywhere in main.css, so it got no fixed positioning, no centering and no
+   * dimming — it rendered as a bare stack of labels appended to the end of the page. Nothing
+   * errored, and every field worked, which is why it survived: it looked like an unfinished feature
+   * rather than one wrong word.
+   */
+  const field = (id, label, control, hint, hintId) =>
+    `<div class="form-group">
+       <label for="${id}">${esc(label)}</label>
+       ${control}
+       ${hint ? `<div class="tg-hint"${hintId ? ` id="${hintId}"` : ''}>${esc(hint)}</div>` : ''}
+     </div>`;
+
+  const section = (title, inner, blurb) =>
+    `<section class="tg-section">
+       <h4 class="tg-legend">${esc(title)}</h4>
+       ${blurb ? `<p class="tg-blurb">${esc(blurb)}</p>` : ''}
+       ${inner}
+     </section>`;
+
   return `
-  <div class="modal-backdrop" id="trigModal">
-    <div class="modal">
-      <h2>${esc(isNew ? t('trigger.new') : t('trigger.edit'))}</h2>
-
-      <label>${esc(t('trigger.name'))}
-        <input id="tgName" value="${esc(tr.name || '')}" maxlength="200"></label>
-
-      <label>${esc(t('trigger.match_token'))}
-        <input id="tgToken" value="${esc(tr.match_token || '')}" maxlength="64"></label>
-      <p class="hint">${esc(t('trigger.token_hint'))}</p>
-
-      <label>${esc(t('trigger.clear_token'))}
-        <input id="tgClear" value="${esc(tr.clear_token || '')}" maxlength="64"></label>
-
-      <label>${esc(t('trigger.target'))}
-        <select id="tgTarget">${opt(cache.playlists, tr.target_ref)}</select></label>
-      <p class="hint">${esc(t('trigger.target_hint'))}</p>
-
-      <label>${esc(t('trigger.mode'))}
-        <select id="tgMode">
-          <option value="once"${tr.mode === 'once' ? ' selected' : ''}>${esc(t('trigger.mode_once'))}</option>
-          <option value="until_cleared"${tr.mode === 'until_cleared' ? ' selected' : ''}>${esc(t('trigger.mode_until_cleared'))}</option>
-        </select></label>
-
-      <label>${esc(t('trigger.max_duration'))}
-        <input id="tgMaxDur" type="number" min="0" max="86400" value="${tr.max_duration_sec || 0}"></label>
-      <p class="hint">${esc(t('trigger.max_duration_hint'))}</p>
-
-      <label>${esc(t('trigger.lease'))}
-        <input id="tgLease" type="number" min="5" max="86400" value="${tr.lease_sec == null ? '' : tr.lease_sec}"></label>
-      <p class="hint" id="tgLeaseHint">${esc(t('trigger.lease_hint'))}</p>
-
-      <label>${esc(t('trigger.priority'))}
-        <input id="tgPriority" type="number" min="-1000" max="1000" value="${tr.priority || 0}"></label>
-
-      <label class="check"><input type="checkbox" id="tgHttp" ${tr.source_http === false ? '' : 'checked'}> HTTP</label>
-      <label class="check"><input type="checkbox" id="tgUdp" ${tr.source_udp ? 'checked' : ''}> UDP</label>
-      <label class="check"><input type="checkbox" id="tgEnabled" ${tr.enabled === 0 ? '' : 'checked'}> ${esc(t('trigger.enabled'))}</label>
-
-      <h3>${esc(t('trigger.assign'))}</h3>
-      <p class="hint">${esc(t('trigger.assign_hint'))}</p>
-      <div class="assign-grid">
-        <div><h4>${esc(t('nav.displays'))}</h4>${checks(cache.devices, 'device')}</div>
-        <div><h4>${esc(t('trigger.groups'))}</h4>${checks(cache.groups, 'group')}</div>
+  <div class="modal-overlay" id="trigModal">
+    <div class="modal tg-modal">
+      <div class="modal-header">
+        <h3>${esc(isNew ? t('trigger.new') : t('trigger.edit'))}</h3>
+        <button class="btn-icon" type="button" id="tgClose" aria-label="${esc(t('common.close'))}">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+          </svg>
+        </button>
       </div>
 
-      <div class="modal-actions">
-        <button class="btn" id="tgCancel">${esc(t('common.cancel'))}</button>
-        <button class="btn btn-primary" id="tgSave">${esc(t('common.save'))}</button>
+      <div class="modal-body">
+        ${section(t('trigger.sec_identity'),
+          field('tgName', t('trigger.name'),
+            `<input class="input" id="tgName" value="${esc(tr.name || '')}" maxlength="200">`))}
+
+        ${section(t('trigger.sec_match'),
+          field('tgToken', t('trigger.match_token'),
+            `<input class="input" id="tgToken" value="${esc(tr.match_token || '')}" maxlength="64">`,
+            t('trigger.token_hint'))
+          + field('tgClear', t('trigger.clear_token'),
+            `<input class="input" id="tgClear" value="${esc(tr.clear_token || '')}" maxlength="64">`)
+          + `<div class="tg-sources">
+               <label class="tg-check"><input type="checkbox" id="tgHttp" ${tr.source_http === false ? '' : 'checked'}> HTTP</label>
+               <label class="tg-check"><input type="checkbox" id="tgUdp" ${tr.source_udp ? 'checked' : ''}> UDP</label>
+             </div>`)}
+
+        ${section(t('trigger.sec_shows'),
+          (firable.length
+            ? field('tgTarget', t('trigger.target'),
+                `<select class="input" id="tgTarget">${opt(firable, tr.target_ref)}</select>`,
+                t('trigger.target_hint'))
+            /*
+             * A disabled empty select with a hint underneath reads as a broken form. If nothing can
+             * be chosen, say why and what to do — the operator has playlists, they are just not
+             * published yet, and nothing else on this screen would tell them that.
+             */
+            : `<div class="tg-empty">${esc(t('trigger.no_published'))}</div>`)
+          + (unpublishedCount > 0 && firable.length
+            ? `<div class="tg-hint">${esc(tn('trigger.unpublished_hidden', unpublishedCount))}</div>`
+            : ''))}
+
+        ${section(t('trigger.sec_behaviour'),
+          field('tgMode', t('trigger.mode'),
+            `<select class="input" id="tgMode">
+               <option value="once"${tr.mode === 'once' ? ' selected' : ''}>${esc(t('trigger.mode_once'))}</option>
+               <option value="until_cleared"${tr.mode === 'until_cleared' ? ' selected' : ''}>${esc(t('trigger.mode_until_cleared'))}</option>
+             </select>`)
+          + `<div class="tg-row">
+               ${field('tgMaxDur', t('trigger.max_duration'),
+                 `<input class="input" id="tgMaxDur" type="number" min="0" max="86400" value="${tr.max_duration_sec || 0}">`,
+                 t('trigger.max_duration_hint'))}
+               ${field('tgLease', t('trigger.lease'),
+                 `<input class="input" id="tgLease" type="number" min="5" max="86400" value="${tr.lease_sec == null ? '' : tr.lease_sec}">`,
+                 t('trigger.lease_hint'), 'tgLeaseHint')}
+             </div>`
+          + field('tgPriority', t('trigger.priority'),
+            `<input class="input" id="tgPriority" type="number" min="-1000" max="1000" value="${tr.priority || 0}">`))}
+
+        ${section(t('trigger.assign'),
+          `<div class="assign-grid">
+             <div><h5 class="tg-col">${esc(t('nav.displays'))}</h5>${checks(cache.devices, 'device')}</div>
+             <div><h5 class="tg-col">${esc(t('trigger.groups'))}</h5>${checks(cache.groups, 'group')}</div>
+           </div>`,
+          t('trigger.assign_hint'))}
+      </div>
+
+      <div class="modal-footer">
+        <label class="tg-check tg-enabled"><input type="checkbox" id="tgEnabled" ${tr.enabled === 0 ? '' : 'checked'}> ${esc(t('trigger.enabled'))}</label>
+        <button class="btn btn-secondary" type="button" id="tgCancel">${esc(t('common.cancel'))}</button>
+        <button class="btn btn-primary" type="button" id="tgSave">${esc(t('common.save'))}</button>
       </div>
     </div>
   </div>`;
@@ -147,7 +208,13 @@ function collect() {
     match_token: document.getElementById('tgToken').value.trim(),
     clear_token: document.getElementById('tgClear').value.trim() || null,
     target_kind: 'playlist',
-    target_ref: document.getElementById('tgTarget').value,
+    /*
+     * ⚠️ The select is ABSENT when no playlist is publishable — see formHtml. Reading `.value` off
+     * null here would throw inside the click handler, which a green suite cannot see: the button
+     * would simply do nothing, with the operator watching a form that will not save and no error.
+     * Save is disabled in that state; this is the second lock on the same door.
+     */
+    target_ref: document.getElementById('tgTarget')?.value || null,
     mode,
     max_duration_sec: Number(document.getElementById('tgMaxDur').value) || 0,
     // Sent only when it applies; the server refuses lease_sec on a `once` trigger rather than
@@ -186,7 +253,37 @@ function openForm(app, tr) {
   lease.addEventListener('input', syncLease);
   syncLease();
 
-  const close = () => host.remove();
+  /*
+   * ⚠️ EVERY WAY OUT, and the listener is removed with the dialog.
+   *
+   * Cancel was the only exit: no close button (there was no header to put one in), no Escape, and
+   * clicking the backdrop did nothing because there was no backdrop. The keydown is on document, so
+   * it MUST be detached in close() — a dialog opened and dismissed twenty times otherwise leaves
+   * twenty handlers behind, and the last one closes a dialog that is no longer on screen.
+   */
+  const onKey = (ev) => { if (ev.key === 'Escape') close(); };
+  const close = () => {
+    document.removeEventListener('keydown', onKey);
+    host.remove();
+  };
+  document.addEventListener('keydown', onKey);
+  document.getElementById('tgClose').addEventListener('click', close);
+  // The overlay itself, but not a click that started inside the dialog — otherwise selecting text
+  // in a field and releasing outside it closes the form and discards the edit.
+  document.getElementById('trigModal').addEventListener('mousedown', (ev) => {
+    if (ev.target.id === 'trigModal') close();
+  });
+  /*
+   * Nothing publishable to point at: Save cannot succeed, so it does not invite the attempt. The
+   * server would refuse anyway — this just puts the refusal before the work rather than after it.
+   */
+  const targetSel = document.getElementById('tgTarget');
+  if (!targetSel) {
+    const save = document.getElementById('tgSave');
+    save.disabled = true;
+    save.title = t('trigger.no_published');
+  }
+
   document.getElementById('tgCancel').addEventListener('click', close);
   document.getElementById('tgSave').addEventListener('click', async () => {
     const body = collect();


### PR DESCRIPTION
The trigger form has never been styled, and the cause turned out to be **one word**.

## `.modal-backdrop` is not a class

It's `.modal-overlay` everywhere else in `main.css`. So the dialog got no fixed positioning, no centering, no dimming and no card — it appended a stack of bare labels to the end of the page.

Nothing errored, and every field worked. That's exactly why it survived: it read as an unfinished feature rather than as a typo.

It also never used the form classes, so inputs had no styling, and with no `.modal-header` / `.modal-body` / `.modal-footer` there was no scroll region and nowhere to put a close button.

## Rebuilt on the skeleton every other dialog uses

Grouped into five sections — **Trigger**, **What fires it**, **What it shows**, **How it behaves**, **Screens**. Twelve fields in one undifferentiated column was most of why it felt bolted on.

- HTTP/UDP moved next to the token they qualify, instead of floating loose after Priority
- Max length and Auto-clear paired side by side — they're read together
- **Enabled** moved into the footer beside Save, since it's the one control that decides whether any of the rest happens
- 640px (at the 440px default the assignment grid collapsed into one column of forty rows), assignment lists scroll so Save stays reachable with a hundred screens, single column under 700px

## Every way out now works

Cancel was the only exit: no close button (there was no header to hold one), no Escape, and clicking the backdrop did nothing **because there was no backdrop**.

The keydown listener is removed with the dialog — twenty opens would otherwise leave twenty handlers behind — and a click that *starts* inside doesn't close, so selecting text in a field and releasing outside no longer discards the edit.

## The dropdown no longer offers what the server will reject

`routes/triggers` refuses a trigger pointing at a playlist with no published snapshot, and it's right to: `deviceSocket` uses the same guard, so such a trigger syncs with `items: []` and renders nothing, forever, silently. But the dropdown listed **every** playlist — so the normal way to meet that rule was to fill in the whole form, press Save, and be told no.

| situation | behaviour |
|---|---|
| mixed | only publishable ones listed, plus "*2 unpublished playlists are not listed…*" |
| nothing publishable | select replaced by an explanation, **Save disabled** with the same text as its tooltip |
| this trigger's own target since unpublished | **still listed** |

⚠️ That last row matters. Dropping it would silently re-point an existing trigger at whatever happened to be first, the next time somebody opened the form just to rename it.

⚠️ `collect()` would have thrown on the empty state — `getElementById('tgTarget').value` with no select, inside a click handler, so Save would have done nothing at all with no error anywhere. Optional-chained *and* the button disabled.

## Verified in a browser against a real server

- Overlay `fixed` and centred, modal 640px, header and footer present, five sections, 8 styled inputs
- Every field round-trips on **edit**: mode `until_cleared`, lease 90 (enabled), priority 75, both sources checked, target selected
- Escape / close button / backdrop / Cancel all dismiss; a click starting inside does not
- Save posts correctly and surfaces the server's own rule as a toast with the dialog held open
- Dropdown filtering checked against the database: one playlist had a snapshot, two didn't, and exactly those two were hidden
- Clicking the disabled Save in the empty state throws nothing
- No console errors

Also uses `tn()` for the hidden-count line — the codebase has a plural helper precisely so nobody ships "playlist(s)", which my first version did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kfhrUPit5MCqxeTQyqr56
