### PR TITLE
Email a receipt when a Stripe payment succeeds

### DIFF
--- a/server/db/database.js
+++ b/server/db/database.js
@@ -1543,6 +1543,26 @@ const migrations = [
    * work — the leak is a separate fix, and this index stops it costing the whole fleet meanwhile.
    */
   'CREATE INDEX IF NOT EXISTS idx_play_logs_open ON play_logs(device_id, started_at DESC, id DESC) WHERE ended_at IS NULL',
+  /*
+   * One row per Stripe invoice we have emailed a receipt for.
+   *
+   * ⚠️ THE POINT IS "ONCE", AND STRIPE MAKES THAT NON-TRIVIAL. Webhooks are retried until they get
+   * a 2xx, and the same event can be delivered more than once even after one — so a send sitting
+   * directly in the handler mails a paying customer a fresh receipt on every delivery. There is no
+   * dedup anywhere in routes/stripe.js today; every other handler happens to survive it because
+   * they are UPDATEs to a target state, which a repeat simply reapplies. An email is not.
+   *
+   * Keyed on the INVOICE id rather than the event id: an invoice is the payment, and that is the
+   * thing a customer should hear about once. Two different events about one invoice must still
+   * produce one email.
+   */
+  `CREATE TABLE IF NOT EXISTS billing_receipts (
+     invoice_id  TEXT PRIMARY KEY,
+     user_id     TEXT,
+     amount      INTEGER,
+     currency    TEXT,
+     sent_at     INTEGER NOT NULL
+   )`,
 ];
 // Apply each ALTER idempotently. A "duplicate column name" / "already exists"
 // error means the column is already present (expected on a migrated DB) - benign.

--- a/server/routes/stripe.js
+++ b/server/routes/stripe.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const { db } = require('../db/database');
+const { sendPaymentReceipt } = require('../services/billingEmails');
 const { requireAuth } = require('../middleware/auth');
 const config = require('../config');
 
@@ -108,6 +109,9 @@ router.post('/webhook', express.raw({ type: 'application/json' }), async (req, r
 
   console.log(`Stripe webhook: ${event.type}`);
 
+  // Set by the payment_succeeded case; sent after the response. See that case for why.
+  let pendingReceipt = null;
+
   try {
     switch (event.type) {
       case 'checkout.session.completed': {
@@ -155,6 +159,28 @@ router.post('/webhook', express.raw({ type: 'application/json' }), async (req, r
         break;
       }
 
+      /*
+       * ⚠️ invoice.payment_succeeded, NOT checkout.session.completed.
+       *
+       * Checkout fires once, for the first payment made through the hosted page. Every renewal
+       * after that, and every payment made from the billing portal or after a card is fixed, is an
+       * invoice — so a receipt hung off checkout would arrive for a customer's first month and
+       * never again. This event covers all of them, which is also why the send has to be idempotent
+       * rather than merely rare.
+       */
+      case 'invoice.payment_succeeded': {
+        /*
+         * ⚠️ DEFERRED UNTIL AFTER THE 200, not awaited here. Stripe's own guidance is to acknowledge
+         * quickly and do the work afterwards, and this send is a network round trip to Graph or
+         * SMTP with NO TIMEOUT anywhere in services/email.js — a hung transport would hold the
+         * webhook open until Stripe gave up and retried, and enough of those pile up as open
+         * requests. Deferring is safe precisely because the send is idempotent: a retry that
+         * arrives while the first is still sending is refused by the invoice claim, not by luck.
+         */
+        pendingReceipt = event.data.object;
+        break;
+      }
+
       case 'invoice.payment_failed': {
         const invoice = event.data.object;
         const subId = invoice.subscription;
@@ -173,6 +199,22 @@ router.post('/webhook', express.raw({ type: 'application/json' }), async (req, r
   }
 
   res.json({ received: true });
+
+  /*
+   * After the acknowledgement, and deliberately not awaited by the request. Errors cannot reach the
+   * response any more, so sendPaymentReceipt logs its own — it returns a result for every path
+   * including its own bugs, and the .catch is the belt to that braces.
+   */
+  if (pendingReceipt) {
+    sendPaymentReceipt(pendingReceipt)
+      .then((r) => {
+        if (r.sent) console.log(`Payment receipt emailed for invoice ${pendingReceipt.id}`);
+        else if (r.reason !== 'already_sent') {
+          console.log(`No payment receipt for invoice ${pendingReceipt.id}: ${r.reason}`);
+        }
+      })
+      .catch((e) => console.error('[billing] receipt dispatch failed:', e && e.message));
+  }
 });
 
 module.exports = router;

--- a/server/services/billingEmails.js
+++ b/server/services/billingEmails.js
@@ -1,0 +1,176 @@
+'use strict';
+
+/*
+ * The receipt a customer gets when a payment succeeds.
+ *
+ * ⚠️ SEPARATE FROM routes/stripe.js ON PURPOSE. A webhook handler has one job it must not fail at:
+ * answer Stripe quickly and with a 2xx. Composing and sending mail is neither quick nor reliable —
+ * it talks to Graph or SMTP over the network — so the rule here is that nothing in this file can
+ * make the webhook slow, throw, or return anything but 200. sendEmail already returns a result
+ * rather than throwing; this adds the same discipline to everything around it.
+ */
+
+const { db } = require('../db/database');
+const emailService = require('./email');
+
+/** Stripe amounts are in the currency's minor unit — cents, pence, yen (which has none). */
+const ZERO_DECIMAL = new Set(['bif', 'clp', 'djf', 'gnf', 'jpy', 'kmf', 'krw', 'mga', 'pyg', 'rwf', 'ugx', 'vnd', 'vuv', 'xaf', 'xof', 'xpf']);
+
+function formatAmount(minor, currency) {
+  const cur = String(currency || 'usd').toLowerCase();
+  const amount = ZERO_DECIMAL.has(cur) ? minor : minor / 100;
+  try {
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency: cur.toUpperCase() }).format(amount);
+  } catch (e) {
+    // An unknown or malformed currency code must not lose the customer their receipt.
+    return `${amount} ${cur.toUpperCase()}`;
+  }
+}
+
+/**
+ * Claim the right to send exactly one receipt for this invoice.
+ *
+ * ⚠️ THE CLAIM IS THE INSERT, and it happens BEFORE the send. Stripe retries a webhook until it
+ * gets a 2xx and can deliver the same event more than once regardless, so "check then send then
+ * record" leaves a window where two deliveries both pass the check. INSERT OR IGNORE is atomic:
+ * whoever creates the row owns the send, and everyone else is told no.
+ *
+ * The cost of that ordering is that a send which fails after the claim is not retried — the
+ * customer gets no receipt rather than two. That is the right way round for money mail, and the
+ * failure is logged where the alternative is silent.
+ */
+function claimReceipt({ invoiceId, userId, amount, currency }) {
+  try {
+    const info = db.prepare(
+      'INSERT OR IGNORE INTO billing_receipts (invoice_id, user_id, amount, currency, sent_at) VALUES (?, ?, ?, ?, strftime(\'%s\',\'now\'))'
+    ).run(invoiceId, userId || null, amount == null ? null : amount, currency || null);
+    return info.changes === 1;
+  } catch (e) {
+    /*
+     * The table is missing or the write failed. Refusing to claim means no email — deliberately.
+     * The alternative is emailing without a record of having done so, which on a retry is a second
+     * receipt for the same payment.
+     */
+    console.error('[billing] could not claim receipt for', invoiceId, '-', e.message);
+    return false;
+  }
+}
+
+function receiptText({ name, amountLabel, planName, periodEnd, invoiceUrl }) {
+  const lines = [
+    `Hi${name ? ' ' + name : ''},`,
+    '',
+    `Your payment of ${amountLabel} went through — thank you.`,
+    '',
+    planName ? `Plan: ${planName}` : null,
+    periodEnd ? `Your next renewal is ${periodEnd}.` : null,
+    invoiceUrl ? `Invoice: ${invoiceUrl}` : null,
+    '',
+    'Your screens carry on as they are — nothing needs doing.',
+    '',
+    'ScreenTinker',
+  ];
+  return lines.filter((l) => l !== null).join('\n');
+}
+
+function receiptHtml({ name, amountLabel, planName, periodEnd, invoiceUrl }) {
+  const esc = (s) => String(s == null ? '' : s)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  /*
+   * ⚠️ Everything interpolated here is escaped, including values that came from Stripe. They are
+   * not operator input, but they are not ours either, and a plan name is a string somebody typed
+   * into a dashboard.
+   */
+  const row = (k, v) => (v
+    ? `<tr><td style="padding:4px 12px 4px 0;color:#666">${esc(k)}</td><td style="padding:4px 0"><strong>${esc(v)}</strong></td></tr>`
+    : '');
+  return `<div style="font-family:-apple-system,Segoe UI,Roboto,sans-serif;font-size:15px;line-height:1.55;color:#222">
+  <p>Hi${name ? ' ' + esc(name) : ''},</p>
+  <p>Your payment of <strong>${esc(amountLabel)}</strong> went through — thank you.</p>
+  <table style="border-collapse:collapse;margin:16px 0">
+    ${row('Plan', planName)}
+    ${row('Next renewal', periodEnd)}
+  </table>
+  ${invoiceUrl ? `<p><a href="${esc(invoiceUrl)}" style="color:#3b82f6">View your invoice</a></p>` : ''}
+  <p style="color:#666">Your screens carry on as they are — nothing needs doing.</p>
+  <p style="color:#666">ScreenTinker</p>
+</div>`;
+}
+
+/**
+ * Send the receipt for a paid invoice, at most once ever.
+ *
+ * Returns a result rather than throwing, so a webhook can await it without a try/catch and still be
+ * guaranteed to reach its res.json.
+ */
+async function sendPaymentReceipt(invoice, deps = {}) {
+  /*
+   * ⚠️ RESOLVED PER CALL, not destructured at module load. A receipt is money mail whose whole
+   * contract is "exactly once", and the tests that prove that have to be able to count sends
+   * without one going out. Capturing `sendEmail` at import made it unstubbable — the module held
+   * the original reference, so a test could replace the export and still hit the real transport.
+   */
+  const send = deps.sendEmail || emailService.sendEmail;
+  try {
+    const invoiceId = invoice && invoice.id;
+    if (!invoiceId) return { sent: false, reason: 'no_invoice_id' };
+
+    const amount = invoice.amount_paid;
+    /*
+     * ⚠️ A ZERO-AMOUNT INVOICE IS NOT A PAYMENT. Stripe raises them for trials, full-coupon periods
+     * and proration credits, and they fire payment_succeeded like any other. "You paid $0.00, thank
+     * you" is a support ticket, not a receipt.
+     */
+    if (!(amount > 0)) return { sent: false, reason: 'zero_amount' };
+
+    // Who paid. The subscription is the reliable link; the customer id is the fallback for an
+    // invoice raised outside a subscription.
+    const subId = invoice.subscription || null;
+    const custId = invoice.customer || null;
+    const user = (subId && db.prepare('SELECT id, email, name, plan_id FROM users WHERE stripe_subscription_id = ?').get(subId))
+      || (custId && db.prepare('SELECT id, email, name, plan_id FROM users WHERE stripe_customer_id = ?').get(custId))
+      || null;
+
+    /*
+     * ⚠️ NO GUESSING AT THE RECIPIENT. Stripe puts an address on the invoice, but sending a receipt
+     * for THIS instance's plan to an address we cannot tie to an account is how a receipt reaches
+     * the wrong person after a customer record is merged or deleted. If we cannot identify the
+     * user, the payment is still recorded by the other handlers; only the mail is skipped.
+     */
+    if (!user || !user.email) return { sent: false, reason: 'no_user' };
+
+    if (!claimReceipt({ invoiceId, userId: user.id, amount, currency: invoice.currency })) {
+      return { sent: false, reason: 'already_sent' };
+    }
+
+    const plan = user.plan_id
+      ? db.prepare('SELECT name FROM plans WHERE id = ?').get(user.plan_id)
+      : null;
+    const periodEnd = invoice.lines?.data?.[0]?.period?.end || null;
+
+    const fields = {
+      name: user.name || '',
+      amountLabel: formatAmount(amount, invoice.currency),
+      planName: plan?.name || user.plan_id || '',
+      periodEnd: periodEnd ? new Date(periodEnd * 1000).toISOString().slice(0, 10) : '',
+      invoiceUrl: invoice.hosted_invoice_url || '',
+    };
+
+    const res = await send({
+      to: user.email,
+      rawSubject: true,
+      subject: `Payment received — ${fields.amountLabel}`,
+      text: receiptText(fields),
+      html: receiptHtml(fields),
+    });
+    if (!res.sent) console.warn('[billing] receipt not delivered for', invoiceId, '-', res.reason);
+    return { sent: !!res.sent, reason: res.reason, userId: user.id };
+  } catch (e) {
+    // A webhook must answer 200 whatever happens in here.
+    console.error('[billing] receipt failed:', e && e.message);
+    return { sent: false, reason: 'error' };
+  }
+}
+
+module.exports = { sendPaymentReceipt, claimReceipt, formatAmount, receiptText, receiptHtml };

--- a/server/test/billing-receipt.test.js
+++ b/server/test/billing-receipt.test.js
@@ -1,0 +1,247 @@
+'use strict';
+
+/*
+ * The receipt email for a successful Stripe payment.
+ *
+ * ⚠️ THE WORD THAT MATTERS IN THE REQUIREMENT IS "ONCE". Stripe retries a webhook until it gets a
+ * 2xx and can deliver the same event more than once regardless — so a send sitting directly in the
+ * handler mails a paying customer a fresh receipt on every delivery. Nothing in routes/stripe.js
+ * dedups today; the other handlers survive it only because they are UPDATEs to a target state,
+ * which a repeat harmlessly reapplies. An email is not like that.
+ *
+ * These tests are mostly about the ways this can send the WRONG number of emails, or the right
+ * number to the wrong person.
+ */
+
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+process.env.DATA_DIR = path.join(os.tmpdir(), 'st-receipt-' + crypto.randomBytes(4).toString('hex'));
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { db } = require('../db/database');
+const email = require('../services/email');
+const { sendPaymentReceipt, formatAmount, claimReceipt } = require('../services/billingEmails');
+
+/*
+ * Capture sends instead of making them, by INJECTION rather than monkey-patching.
+ * ⚠️ The first version replaced `email.sendEmail` and the tests all failed while the code was
+ * correct: billingEmails had destructured it at import, so it still held the original reference.
+ * A test that cannot observe the thing it is asserting about is worse than no test.
+ */
+let sent = [];
+let sendResult = { sent: true };
+function stubEmail(result = { sent: true }) { sent = []; sendResult = result; }
+const deps = { sendEmail: async (msg) => { sent.push(msg); return sendResult; } };
+function restoreEmail() { /* nothing to restore: nothing was patched */ }
+
+let n = 0;
+function makeUser(over = {}) {
+  const id = 'u' + (++n);
+  db.prepare(`INSERT INTO users (id, email, password_hash, name, role, created_at)
+              VALUES (?, ?, 'x', ?, 'user', strftime('%s','now'))`)
+    .run(id, over.email || `${id}@example.com`, over.name || 'Pat');
+  db.prepare('UPDATE users SET stripe_subscription_id = ?, stripe_customer_id = ?, plan_id = ? WHERE id = ?')
+    .run(over.sub || `sub_${id}`, over.cust || `cus_${id}`, over.plan || 'starter', id);
+  return db.prepare('SELECT * FROM users WHERE id = ?').get(id);
+}
+const invoice = (over = {}) => ({
+  id: over.id || 'in_' + crypto.randomBytes(4).toString('hex'),
+  amount_paid: over.amount_paid === undefined ? 2900 : over.amount_paid,
+  currency: over.currency || 'usd',
+  subscription: over.subscription,
+  customer: over.customer,
+  hosted_invoice_url: over.url,
+  lines: over.periodEnd ? { data: [{ period: { end: over.periodEnd } }] } : undefined,
+});
+
+/* ============ sending exactly once ============ */
+
+test('a successful payment sends one receipt to the paying user', async () => {
+  stubEmail();
+  const u = makeUser({ email: 'payer@example.com', name: 'Sam' });
+  const r = await sendPaymentReceipt(invoice({ subscription: u.stripe_subscription_id, amount_paid: 2900 }), deps);
+  restoreEmail();
+  assert.equal(r.sent, true);
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].to, 'payer@example.com');
+  assert.match(sent[0].subject, /\$29\.00/);
+  assert.match(sent[0].text, /Sam/);
+});
+
+test('⚠️ a REDELIVERED webhook does not send a second receipt', async () => {
+  /*
+   * The defect this whole design exists to prevent. Stripe retries until it gets a 2xx, so the same
+   * invoice arrives again routinely — not as an edge case.
+   */
+  stubEmail();
+  const u = makeUser();
+  const inv = invoice({ subscription: u.stripe_subscription_id });
+  const first = await sendPaymentReceipt(inv, deps);
+  const second = await sendPaymentReceipt(inv, deps);
+  const third = await sendPaymentReceipt({ ...inv }, deps);   // a fresh object, same invoice id
+  restoreEmail();
+  assert.equal(first.sent, true);
+  assert.equal(second.sent, false);
+  assert.equal(second.reason, 'already_sent');
+  assert.equal(third.reason, 'already_sent');
+  assert.equal(sent.length, 1, 'exactly one email for one invoice');
+});
+
+test('⚠️ the claim is taken BEFORE the send, so a slow send cannot be double-claimed', async () => {
+  /*
+   * "check, then send, then record" leaves a window where two deliveries both pass the check. The
+   * INSERT is the claim, and it is atomic. Simulated by claiming while a send is still in flight.
+   */
+  let release;
+  const gate = new Promise((r) => { release = r; });
+  sent = [];
+  const slowDeps = { sendEmail: async (msg) => { sent.push(msg); await gate; return { sent: true }; } };
+  const u = makeUser();
+  const inv = invoice({ subscription: u.stripe_subscription_id });
+  const inFlight = sendPaymentReceipt(inv, slowDeps);
+  const duringFlight = await sendPaymentReceipt(inv, slowDeps);   // arrives while the first is still sending
+  release();
+  await inFlight;
+  restoreEmail();
+  assert.equal(duringFlight.reason, 'already_sent', 'the second delivery must be refused mid-send');
+  assert.equal(sent.length, 1);
+});
+
+test('different invoices for the same user each get a receipt', async () => {
+  // Renewals are the normal case; deduping on the user would silence every month after the first.
+  stubEmail();
+  const u = makeUser();
+  await sendPaymentReceipt(invoice({ subscription: u.stripe_subscription_id }), deps);
+  await sendPaymentReceipt(invoice({ subscription: u.stripe_subscription_id }), deps);
+  restoreEmail();
+  assert.equal(sent.length, 2);
+});
+
+/* ============ when NOT to send ============ */
+
+test('⚠️ a zero-amount invoice is not a payment', async () => {
+  // Stripe raises these for trials, full-coupon periods and proration credits, and they fire
+  // payment_succeeded like any other. "You paid $0.00, thank you" is a support ticket.
+  stubEmail();
+  const u = makeUser();
+  const r = await sendPaymentReceipt(invoice({ subscription: u.stripe_subscription_id, amount_paid: 0 }), deps);
+  restoreEmail();
+  assert.equal(r.reason, 'zero_amount');
+  assert.equal(sent.length, 0);
+});
+
+test('⚠️ an invoice we cannot tie to an account sends nothing', async () => {
+  /*
+   * Stripe puts an address on the invoice and it is tempting to use it. Sending this instance's
+   * receipt to an address we cannot tie to a user is how a receipt reaches the wrong person after a
+   * customer record is merged or deleted.
+   */
+  stubEmail();
+  const r = await sendPaymentReceipt(invoice({ subscription: 'sub_nobody', customer: 'cus_nobody' }), deps);
+  restoreEmail();
+  assert.equal(r.reason, 'no_user');
+  assert.equal(sent.length, 0);
+});
+
+test('the customer id is the fallback link when there is no subscription', async () => {
+  stubEmail();
+  const u = makeUser();
+  const r = await sendPaymentReceipt(invoice({ customer: u.stripe_customer_id, subscription: null }), deps);
+  restoreEmail();
+  assert.equal(r.sent, true);
+  assert.equal(sent[0].to, u.email);
+});
+
+test('a malformed invoice never throws — a webhook must still answer 200', async () => {
+  stubEmail();
+  for (const bad of [undefined, null, {}, { id: null }, { id: 'in_x' }]) {
+    const r = await sendPaymentReceipt(bad, deps);
+    assert.equal(typeof r.sent, 'boolean', `threw or returned junk for ${JSON.stringify(bad)}`);
+  }
+  restoreEmail();
+  assert.equal(sent.length, 0);
+});
+
+test('an email transport failure is reported, not thrown', async () => {
+  stubEmail({ sent: false, reason: 'smtp_error' });
+  const u = makeUser();
+  const r = await sendPaymentReceipt(invoice({ subscription: u.stripe_subscription_id }), deps);
+  restoreEmail();
+  assert.equal(r.sent, false);
+  assert.equal(r.reason, 'smtp_error');
+});
+
+/* ============ the money ============ */
+
+test('⚠️ amounts are minor units, and not every currency has cents', async () => {
+  /*
+   * Stripe sends 2900 for $29.00. Printing it raw is a receipt for twenty-nine hundred dollars.
+   * And yen has no minor unit at all: 2900 JPY is 2900 yen, not 29.
+   */
+  assert.equal(formatAmount(2900, 'usd'), '$29.00');
+  assert.equal(formatAmount(2900, 'gbp'), '£29.00');
+  assert.equal(formatAmount(2900, 'jpy'), '¥2,900');
+  assert.equal(formatAmount(99, 'usd'), '$0.99');
+});
+
+test('an unknown currency still produces a readable amount', () => {
+  // A receipt that throws on an odd currency code is worse than one that reads plainly.
+  assert.doesNotThrow(() => formatAmount(1234, 'zzz'));
+  assert.match(formatAmount(1234, 'zzz'), /12\.34|ZZZ/);
+});
+
+test('⚠️ values from Stripe are escaped into the HTML', async () => {
+  // A plan name is a string somebody typed into a dashboard. Not operator input, but not ours.
+  stubEmail();
+  const u = makeUser({ name: '<img src=x onerror=alert(1)>' });
+  await sendPaymentReceipt(invoice({ subscription: u.stripe_subscription_id, url: 'https://x/"><script>' }), deps);
+  restoreEmail();
+  assert.ok(!sent[0].html.includes('<img src=x'), 'markup breakout through the name');
+  assert.ok(!sent[0].html.includes('"><script>'), 'markup breakout through the invoice url');
+  assert.ok(sent[0].html.includes('&lt;img'), 'the value survives as escaped text');
+});
+
+test('claimReceipt is the gate, and it refuses rather than guessing', () => {
+  const id = 'in_claim_' + crypto.randomBytes(3).toString('hex');
+  assert.equal(claimReceipt({ invoiceId: id, userId: 'u', amount: 1, currency: 'usd' }), true);
+  assert.equal(claimReceipt({ invoiceId: id, userId: 'u', amount: 1, currency: 'usd' }), false);
+});
+
+/* ============ the webhook must acknowledge before it sends ============ */
+
+test('⚠️ the receipt is sent AFTER the 200, not before it', () => {
+  /*
+   * services/email.js has no timeout on either transport, so awaiting the send inside the handler
+   * means a hung Graph or SMTP connection holds the webhook open until Stripe gives up — and enough
+   * of those pile up as open requests. Stripe's own guidance is to acknowledge quickly and do the
+   * work afterwards.
+   *
+   * Deferring is only safe because the send is idempotent: the retry Stripe issues after a timeout
+   * is refused by the invoice claim rather than by timing.
+   */
+  const src = require('fs').readFileSync(require.resolve('../routes/stripe.js'), 'utf8');
+  const ack = src.indexOf('res.json({ received: true })');
+  const dispatch = src.indexOf('sendPaymentReceipt(pendingReceipt)');
+  assert.ok(ack > 0 && dispatch > 0, 'both the acknowledgement and the dispatch must be present');
+  assert.ok(dispatch > ack, 'the send must come after the response');
+  assert.ok(!/await sendPaymentReceipt/.test(src), 'the request must not await the send');
+});
+
+test('the handler subscribes to invoice.payment_succeeded, not checkout only', () => {
+  /*
+   * checkout.session.completed fires once, for the first payment through the hosted page. Every
+   * renewal, and every payment made from the billing portal or after a card is fixed, is an
+   * invoice — so a receipt hung off checkout would arrive for month one and never again.
+   */
+  const src = require('fs').readFileSync(require.resolve('../routes/stripe.js'), 'utf8');
+  assert.match(src, /case 'invoice\.payment_succeeded':/);
+});
+
+test('the dedup table is a migration, so an existing install gets it on upgrade', () => {
+  const DB = require('fs').readFileSync(require.resolve('../db/database.js'), 'utf8');
+  assert.match(DB, /CREATE TABLE IF NOT EXISTS billing_receipts/);
+  assert.match(DB, /invoice_id\s+TEXT PRIMARY KEY/, 'the invoice id must be the key that enforces once');
+});


### PR DESCRIPTION
Sends the customer a receipt when a Stripe payment succeeds.

## It hangs off `invoice.payment_succeeded`, not checkout

`checkout.session.completed` fires **once**, for the first payment made through the hosted page. Every renewal after that — and every payment made from the billing portal, or after a customer fixes a declined card — is an invoice. A receipt hung off checkout would arrive for month one and never again.

## "Once" is the hard part, and nothing here deduped before

Stripe retries a webhook until it gets a 2xx, and can deliver the same event more than once regardless. **`routes/stripe.js` has no dedup anywhere.** The existing handlers survive that only because they're `UPDATE`s to a target state, which a repeat harmlessly reapplies — an email is not like that. A redelivery is a second receipt for one payment, sent to a paying customer.

So `billing_receipts` is keyed on the **invoice id**, and the `INSERT OR IGNORE` **is** the claim, taken **before** the send. "Check, then send, then record" leaves a window where two deliveries both pass the check.

The cost of that ordering is that a send failing *after* the claim isn't retried — the customer gets no receipt rather than two. That's the right way round for money mail, and it's logged rather than silent.

## Sent after the 200, not awaited by the request

`services/email.js` has **no timeout** on either transport, so awaiting the send inside the handler means a hung Graph or SMTP connection holds the webhook open until Stripe gives up — and enough of those pile up as open requests. Stripe's own guidance is to acknowledge quickly and do the work afterwards.

Deferring is safe *only* because the send is idempotent: the retry that follows a timeout is refused by the invoice claim rather than by timing.

## What it deliberately will not do

- **A zero-amount invoice is not a payment.** Stripe raises them for trials, full-coupon periods and proration credits, and they fire `payment_succeeded` like any other. "You paid $0.00, thank you" is a support ticket.
- **An invoice it can't tie to a user account sends nothing.** Stripe puts an address on the invoice and it's tempting to use it — sending this instance's receipt to an address we can't tie to an account is how a receipt reaches the wrong person after a customer record is merged or deleted.

## Details worth having right

**Amounts are minor units.** Stripe sends `2900` for $29.00; printing it raw is a receipt for twenty-nine hundred dollars. And yen has no minor unit at all, so `2900` JPY is ¥2,900 and not ¥29.

**Everything interpolated into the HTML is escaped**, including values that came from Stripe. They aren't operator input, but they aren't ours either — a plan name is a string somebody typed into a dashboard.

**The sender is injected rather than imported**, so the "exactly once" tests can count sends without one going out.

## Tests

**16 tests.** Five mutations applied — no dedup, claim taken after the send, zero-amount allowed through, minor units printed raw, HTML unescaped — **all caught**.

Worth recording: the first version of these tests failed against *correct* code, because they monkey-patched `email.sendEmail` while `billingEmails` had destructured it at import and still held the original reference. A test that can't observe the thing it's asserting about is worse than no test.

**2907 pass / 3 fail** — the three are `triggers-udp` multicast tests needing a real multicast interface; they fail identically on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kfhrUPit5MCqxeTQyqr56
