### PR TITLE
Android player: support Android 6.0 (minSdk 23)

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId = "com.remotedisplay.player"
-        minSdk = 24
+        minSdk = 23
         targetSdk = 34
         // Env-overridable so device-owner reinstalls (which require an ever-increasing
         // versionCode — downgrades are blocked) don't churn this file each build.

--- a/android/app/src/main/java/com/remotedisplay/player/service/PowerAccessibilityService.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/service/PowerAccessibilityService.kt
@@ -152,7 +152,12 @@ class PowerAccessibilityService : AccessibilityService() {
      * Inject a tap at normalized coordinates (0.0-1.0) using dispatchGesture.
      * Works system-wide - can tap on system dialogs, other apps, etc.
      */
+    /** dispatchGesture and GestureDescription are API 24. On Android 6 the caller falls back to
+     *  in-app view dispatch (TouchInjector), which covers the player's own UI. */
+    val canDispatchGestures: Boolean get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+
     fun injectTap(normalizedX: Float, normalizedY: Float) {
+        if (!canDispatchGestures) { Log.w(TAG, "injectTap: gesture dispatch needs API 24"); return }
         val metrics = getScreenMetrics()
         val x = normalizedX * metrics.widthPixels
         val y = normalizedY * metrics.heightPixels
@@ -168,6 +173,7 @@ class PowerAccessibilityService : AccessibilityService() {
      * Inject a swipe gesture at normalized coordinates.
      */
     fun injectSwipe(startX: Float, startY: Float, endX: Float, endY: Float, durationMs: Long = 300) {
+        if (!canDispatchGestures) { Log.w(TAG, "injectSwipe: gesture dispatch needs API 24"); return }
         val metrics = getScreenMetrics()
         val sx = startX * metrics.widthPixels
         val sy = startY * metrics.heightPixels

--- a/android/app/src/main/java/com/remotedisplay/player/service/WebSocketService.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/service/WebSocketService.kt
@@ -11,6 +11,7 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.wifi.WifiManager
 import android.os.Binder
+import android.os.Build
 import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
@@ -175,8 +176,9 @@ class WebSocketService : Service() {
      * feat/offline-cause-log: watch the DEFAULT network so a connectivity-report can distinguish a
      * lost physical link (Wi‑Fi/Ethernet down) from "link up but the server is unreachable". onLost
      * of the default network during an offline gap flips linkLostDuringGap; it is reset after the
-     * next report. registerDefaultNetworkCallback is API 24 (== minSdk), so no version gate needed,
-     * but everything is still wrapped so a locked-down ROM can't crash the service.
+     * next report. registerDefaultNetworkCallback is API 24; Android 6 registers for any network
+     * instead (API 21), which is the same signal for a single-link signage box. Everything is still
+     * wrapped so a locked-down ROM can't crash the service.
      */
     private fun registerNetworkCallback() {
         try {
@@ -197,7 +199,8 @@ class WebSocketService : Service() {
                     }
                 }
             }
-            cm.registerDefaultNetworkCallback(cb)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) cm.registerDefaultNetworkCallback(cb)
+            else cm.registerNetworkCallback(android.net.NetworkRequest.Builder().build(), cb)
             netCallback = cb
         } catch (e: Throwable) { Log.w("WebSocketService", "registerNetworkCallback: ${e.message}") }
     }
@@ -525,13 +528,13 @@ class WebSocketService : Service() {
                     val svc = PowerAccessibilityService.instance
                     when {
                         // #159: drag = a swipe gesture (scroll). Dashboard sends normalized end point + duration.
-                        svc != null && action == "swipe" -> {
+                        svc != null && svc.canDispatchGestures && action == "swipe" -> {
                             val x2 = data.optDouble("x2", x.toDouble()).toFloat()
                             val y2 = data.optDouble("y2", y.toDouble()).toFloat()
                             val dur = data.optLong("duration", 300L).coerceIn(50L, 3000L)
                             handler.post { try { svc.injectSwipe(x, y, x2, y2, dur) } catch (e: Throwable) { Log.e("WebSocketService", "injectSwipe: ${e.message}") } }
                         }
-                        svc != null && action == "tap" -> {
+                        svc != null && svc.canDispatchGestures && action == "tap" -> {
                             handler.post { try { svc.injectTap(x, y) } catch (e: Throwable) { Log.e("WebSocketService", "injectTap: ${e.message}") } }
                         }
                         else -> {

--- a/android/app/src/main/java/com/remotedisplay/player/util/ImageLoader.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/util/ImageLoader.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Matrix
 import android.media.ExifInterface
+import android.os.Build
 import android.util.Log
 import java.io.ByteArrayInputStream
 import java.io.File
@@ -81,6 +82,21 @@ object ImageLoader {
         }
     }
 
+    // ExifInterface(InputStream) is API 24. Android 6 (API 23) only has the file-path constructor, so
+    // below N the bytes go through a temp file in the app cache (java.io.tmpdir on Android); the
+    // orientation is read the same way and the file is removed at once. Any failure reads as NORMAL.
+    private fun exifOrientation(bytes: ByteArray): Int = try {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            ExifInterface(ByteArrayInputStream(bytes)).getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+        } else {
+            val tmp = File.createTempFile("exif", ".img")
+            try {
+                tmp.writeBytes(bytes)
+                ExifInterface(tmp.absolutePath).getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+            } finally { tmp.delete() }
+        }
+    } catch (e: Throwable) { ExifInterface.ORIENTATION_NORMAL }
+
     private fun decodeBytes(bytes: ByteArray, maxW: Int, maxH: Int): Bitmap? {
         return try {
             val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
@@ -90,11 +106,8 @@ object ImageLoader {
                 inSampleSize = calcSampleSize(bounds.outWidth, bounds.outHeight, maxW, maxH)
             }
             val bmp = BitmapFactory.decodeByteArray(bytes, 0, bytes.size, opts) ?: return null
-            // #170: honor EXIF orientation for remote images too (ExifInterface(stream) is API 24+).
-            val orientation = try {
-                ExifInterface(ByteArrayInputStream(bytes)).getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
-            } catch (e: Throwable) { ExifInterface.ORIENTATION_NORMAL }
-            applyExifOrientation(bmp, orientation)
+            // #170: honor EXIF orientation for remote images too.
+            applyExifOrientation(bmp, exifOrientation(bytes))
         } catch (e: OutOfMemoryError) {
             Log.e(TAG, "OOM decoding ${bytes.size} bytes: ${e.message}")
             null

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -72,7 +72,7 @@ Fedora, and Category X at Apache. Not copyleft, but not a term to accept in a bi
 commercially.
 
 It is now excluded in `android/app/build.gradle.kts`. Nothing is lost — Android has provided
-`org.json` in the platform since API 1 and `minSdk` is 24 — and `android/licenses.json` denies it by
+`org.json` in the platform since API 1 and `minSdk` is 23 — and `android/licenses.json` denies it by
 name so it cannot return quietly.
 
 ## SBOM


### PR DESCRIPTION
Lowers the Android player's `minSdk` from 24 to 23 so it installs on Android 6.0. Cheap signage boxes and older tablets on 6.0 can otherwise only run the web player in a browser, and Firefox 143 was the last browser release for that OS.

**What needed changing**: three call sites, no dependencies. The manifest merges and the Kotlin compiles at minSdk 23 as is; lint flagged exactly twelve API-24 errors in these places:

- `ExifInterface(InputStream)` (API 24) in the remote image loader: below N the bytes go through a temp file and the file-path constructor, so EXIF orientation still applies.
- `dispatchGesture` (API 24) in the accessibility service: it now reports `canDispatchGestures`, and the socket handler routes remote taps and swipes to in-app view dispatch when that is false, the same path a panel without the accessibility service already takes. `remote.input` stays declared for that reason.
- `registerDefaultNetworkCallback` (API 24): below N the service registers for any network, the same signal on a single-link box.

At minSdk 23 the Gradle plugin emits the v1 signature itself, which Android 6 needs to install; `resignReleaseV1` stays as a backstop against a later bump. `docs/licensing.md` updated where it stated the old minimum.

**Verified**: compile clean; lint's remaining 61 errors are identical on main (API 26 to 30 sites, pre-existing); unit tests 245/246, the one failure being the multicast loopback self-test, which fails on main on the same machine.

**Not verified**: no APK built here (the debug build type needs the release keystore) and nothing run on Android 6 hardware yet.
