### PR TITLE
fix(data-sources): address follow-ups from #332

### DIFF
--- a/frontend/js/views/slides.js
+++ b/frontend/js/views/slides.js
@@ -77,14 +77,21 @@ function elementsOf(s) { return (s.template && Array.isArray(s.template.elements
 
 function resolveInterpolatedText(str) {
   if (typeof str !== 'string' || !str.includes('{{ds:')) return str;
+  const formatVal = (val) => {
+    if (val === undefined || val === null) return '';
+    if (typeof val === 'object') {
+      try { return JSON.stringify(val).slice(0, 2000); } catch (_) { return ''; }
+    }
+    return String(val).slice(0, 2000);
+  };
   return str.replace(/\{\{ds:([a-zA-Z0-9_-]+)\.([a-zA-Z0-9_]+)\}\}/g, (match, slug, key) => {
     const ds = DATA_SOURCES_LIST.find((x) => x.slug === slug || x.slug === slug.toLowerCase());
     if (ds) {
-      if (ds.data && ds.data[key] !== undefined && ds.data[key] !== null) return String(ds.data[key]).slice(0, 2000);
+      if (ds.data && ds.data[key] !== undefined && ds.data[key] !== null) return formatVal(ds.data[key]);
       if (ds.cached_data) {
         try {
           const parsed = typeof ds.cached_data === 'string' ? JSON.parse(ds.cached_data) : ds.cached_data;
-          if (parsed && parsed[key] !== undefined && parsed[key] !== null) return String(parsed[key]).slice(0, 2000);
+          if (parsed && parsed[key] !== undefined && parsed[key] !== null) return formatVal(parsed[key]);
         } catch (_) {}
       }
     }

--- a/server/lib/data-sources/ical-resolver.js
+++ b/server/lib/data-sources/ical-resolver.js
@@ -8,7 +8,7 @@
  */
 
 const ical = require('node-ical');
-const { assertSafeUrl, pinnedLookup, SsrfError, guardedRequest } = require('../ssrf-guard');
+const { SsrfError, GuardedRequestError, guardedRequest } = require('../ssrf-guard');
 
 const FETCH_TIMEOUT_MS = 10000;
 const MAX_REDIRECTS = 4;
@@ -33,14 +33,17 @@ async function fetchCalendar(urlString) {
         'Accept': 'text/calendar, application/json, text/plain',
       },
     });
+    if (res.notModified || !res.text) {
+      throw new GuardedRequestError('Calendar feed responded 304', 'upstream-status', 304);
+    }
     return res.text;
   } catch (err) {
     if (err instanceof SsrfError) throw err;
-    if (err.message === 'Request timed out') throw new Error('Calendar feed timed out');
-    if (err.message === 'Too many redirects') throw new Error('Too many redirects fetching calendar feed');
-    if (err.message === 'Invalid redirect location') throw new Error('Invalid redirect from calendar feed');
-    if (err.message === 'Response exceeds size limit') throw new Error('Calendar feed exceeds size limit');
-    if (err.statusCode) throw new Error(`Calendar feed responded ${err.statusCode}`);
+    if (err.code === 'timeout') throw new GuardedRequestError('Calendar feed timed out', 'timeout');
+    if (err.code === 'too-many-redirects') throw new GuardedRequestError('Too many redirects fetching calendar feed', 'too-many-redirects');
+    if (err.code === 'bad-redirect') throw new GuardedRequestError('Invalid redirect from calendar feed', 'bad-redirect');
+    if (err.code === 'size-limit') throw new GuardedRequestError('Calendar feed exceeds size limit', 'size-limit');
+    if (err.code === 'upstream-status') throw new GuardedRequestError(`Calendar feed responded ${err.statusCode}`, 'upstream-status', err.statusCode);
     throw err;
   }
 }
@@ -102,23 +105,20 @@ async function resolveIcalData(config = {}, nowRef = new Date()) {
   tomorrow.setDate(tomorrow.getDate() + 1);
   const tomorrowKey = dateKey(tomorrow);
 
-  const formatAllDayKey = (d) => {
-    const y = d.getUTCFullYear();
-    const m = String(d.getUTCMonth() + 1).padStart(2, '0');
-    const day = String(d.getUTCDate()).padStart(2, '0');
+  // Helper to format a calendar-day key honoring node-ical contract (d.dateOnly means local Y-M-D)
+  const formatLocalDayKey = (d) => {
+    if (!d || !(d instanceof Date) || isNaN(d.getTime())) return '';
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
     return `${y}-${m}-${day}`;
   };
 
-  const formatAllDayDate = (d) => {
-    const key = formatAllDayKey(d);
+  const formatDayLabel = (key) => {
     if (key === todayKey) return locale === 'de' ? 'Heute' : 'Today';
     if (key === tomorrowKey) return locale === 'de' ? 'Morgen' : 'Tomorrow';
-
-    // Format calendar date using midday UTC representation to avoid timezone shifts across day boundaries
-    const y = d.getUTCFullYear();
-    const m = d.getUTCMonth();
-    const day = d.getUTCDate();
-    const noonUtc = new Date(Date.UTC(y, m, day, 12, 0, 0));
+    const [y, m, d] = key.split('-').map(Number);
+    const noonUtc = new Date(Date.UTC(y, m - 1, d, 12, 0, 0));
     return noonUtc.toLocaleDateString(locale === 'de' ? 'de-DE' : 'en-US', {
       weekday: 'short',
       day: 'numeric',
@@ -128,13 +128,13 @@ async function resolveIcalData(config = {}, nowRef = new Date()) {
   };
 
   const formatTime = (d) => d.toLocaleTimeString(locale === 'de' ? 'de-DE' : 'en-US', { hour: '2-digit', minute: '2-digit', hour12: locale !== 'de', ...tzOpts });
-  const formatDate = (d, isAllDay = false) => {
-    if (isAllDay) return formatAllDayDate(d);
-    const key = dateKey(d);
+
+  const formatDate = (ev) => {
+    if (ev.isAllDay) return formatDayLabel(ev.dayKey);
+    const key = dateKey(ev.start);
     if (key === todayKey) return locale === 'de' ? 'Heute' : 'Today';
     if (key === tomorrowKey) return locale === 'de' ? 'Morgen' : 'Tomorrow';
-
-    return d.toLocaleDateString(locale === 'de' ? 'de-DE' : 'en-US', {
+    return ev.start.toLocaleDateString(locale === 'de' ? 'de-DE' : 'en-US', {
       weekday: 'short',
       day: 'numeric',
       month: 'short',
@@ -142,12 +142,10 @@ async function resolveIcalData(config = {}, nowRef = new Date()) {
     });
   };
 
-  const startWindow = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-  startWindow.setHours(0, 0, 0, 0); // Widen startWindow back 24h to avoid UTC offset boundary clipping
-
   const endWindow = new Date(now);
-  endWindow.setDate(endWindow.getDate() + lookaheadDays + 1);
+  endWindow.setDate(endWindow.getDate() + lookaheadDays);
   endWindow.setHours(23, 59, 59, 999);
+  const endWindowDayKey = dateKey(endWindow);
 
   const flatEvents = [];
 
@@ -164,13 +162,13 @@ async function resolveIcalData(config = {}, nowRef = new Date()) {
     if (excludeText && summaryLower.includes(excludeText.toLowerCase())) continue;
 
     // Check if event is all-day (datetype === 'date' or midnight-to-midnight whole days)
-    const isAllDay = ev.datetype === 'date' || (
+    const isAllDay = Boolean(ev.datetype === 'date' || ev.start?.dateOnly || (
       ev.start instanceof Date && ev.end instanceof Date &&
       ev.start.getHours() === 0 && ev.start.getMinutes() === 0 && ev.start.getSeconds() === 0 &&
       ev.end.getHours() === 0 && ev.end.getMinutes() === 0 && ev.end.getSeconds() === 0 &&
       (ev.end - ev.start) >= 86400000 &&
       (ev.end - ev.start) % 86400000 === 0
-    );
+    ));
     if (eventType === 'timed' && isAllDay) continue;
     if (eventType === 'allday' && !isAllDay) continue;
 
@@ -188,6 +186,7 @@ async function resolveIcalData(config = {}, nowRef = new Date()) {
         if (!isNaN(d.getTime())) {
           exdateKeys.add(d.toISOString().slice(0, 10));
           exdateKeys.add(d.getTime());
+          if (isAllDay) exdateKeys.add(formatLocalDayKey(d));
         }
       }
     }
@@ -196,33 +195,18 @@ async function resolveIcalData(config = {}, nowRef = new Date()) {
     if (ev.rrule) {
       try {
         const maxRruleExpansion = Math.max(50, maxEvents * 5);
-        const durationMs = ev.end ? (new Date(ev.end).getTime() - new Date(ev.start).getTime()) : 3600000;
+        const durationMs = ev.end ? (new Date(ev.end).getTime() - new Date(ev.start).getTime()) : (isAllDay ? 86400000 : 3600000);
 
-        /*
-         * ⚠️ THE WINDOW STARTS BEFORE NOW BY ONE OCCURRENCE, NOT AT MIDNIGHT. A series occurrence
-         * that began before the server's local midnight and is still running was not in
-         * [startOfToday, end], so a daily 16:30-18:30 meeting read as FREE at 17:30 on a UTC host
-         * serving a Pacific room. Only the `occEnd < now` filter below decides what is over.
-         *
-         * ⚠️ AND IT IS NARROWED BY FREQUENCY, BECAUSE THE ITERATOR ARGUMENT WAS NEVER CALLED.
-         * node-ical's rrule wrapper takes between(after, before, inclusive) and ignores a fourth
-         * argument, so the "bounded iterator" the first version passed ran zero times; a
-         * FREQ=MINUTELY series then hit the library's 10,000-iteration throw and the whole series
-         * was dropped, silently, as FREE. The library expands a two-day MINUTELY window in a few
-         * milliseconds; it is the fourteen-day default that overflowed. So the window is capped
-         * per frequency to stay under that limit, the result is sliced to what the sign can show,
-         * and a throw narrows to one day around now before giving up.
-         */
         const FREQ_NAMES = { 4: 'HOURLY', 5: 'MINUTELY', 6: 'SECONDLY' };
         const rawFreq = ev.rrule.options?.freq ?? ev.rrule.origOptions?.freq;
         const freq = String(FREQ_NAMES[rawFreq] || rawFreq || '').toUpperCase();
         const SPAN_MS = { HOURLY: 60 * 86400000, MINUTELY: 2 * 86400000, SECONDLY: 2 * 3600000 };
-        // A high-frequency series gets a short window anchored on NOW (a two-hour SECONDLY
-        // window that starts at midnight does not contain 08:00); everything else keeps the
-        // day window, extended back by one occurrence so a running one is included.
+
+        const startOfToday = new Date(now);
+        startOfToday.setHours(0, 0, 0, 0);
         const seriesStart = SPAN_MS[freq]
           ? new Date(now.getTime() - durationMs)
-          : new Date(Math.min(startWindow.getTime(), now.getTime() - durationMs));
+          : new Date(Math.min(startOfToday.getTime(), now.getTime() - durationMs));
         const seriesEnd = SPAN_MS[freq]
           ? new Date(Math.min(endWindow.getTime(), seriesStart.getTime() + SPAN_MS[freq]))
           : endWindow;
@@ -233,24 +217,25 @@ async function resolveIcalData(config = {}, nowRef = new Date()) {
           const narrowEnd = new Date(Math.min(seriesEnd.getTime(), now.getTime() + 86400000));
           dates = ev.rrule.between(seriesStart, narrowEnd, true) || [];
         }
-        // Drop what is already over BEFORE bounding the list: the bound keeps the EARLIEST
-        // occurrences, and for a minutely series from midnight those are all in the past, which
-        // left the live one outside the cut and the room reading FREE at 08:00.
-        // An occurrence with a RECURRENCE-ID override is kept regardless: the override may move
-        // it later than its series slot, and only the loop below knows the moved time.
+
         const hasOverride = (d) => {
           if (!ev.recurrences) return false;
           const dt = new Date(d);
           return Boolean(ev.recurrences[dt.toISOString().slice(0, 10)] || ev.recurrences[dt.toISOString()]);
         };
-        dates = dates.filter((d) => isAllDay || hasOverride(d) || (new Date(d).getTime() + durationMs) >= now.getTime());
+        dates = dates.filter((d) => isAllDay
+          ? (formatLocalDayKey(new Date(d.getTime() + durationMs)) > todayKey)
+          : (hasOverride(d) || (new Date(d).getTime() + durationMs) >= now.getTime()));
         if (dates.length > maxRruleExpansion) dates = dates.slice(0, maxRruleExpansion);
 
         for (const date of dates) {
           let occStart = new Date(date);
           let occEnd = new Date(occStart.getTime() + durationMs);
           const dateKeyIso = occStart.toISOString().slice(0, 10);
-          if (exdateKeys.has(dateKeyIso) || exdateKeys.has(occStart.getTime())) continue;
+          const dayKey = isAllDay ? formatLocalDayKey(occStart) : dateKey(occStart);
+          const endDayKey = isAllDay ? formatLocalDayKey(occEnd) : dateKey(occEnd);
+
+          if (exdateKeys.has(dateKeyIso) || exdateKeys.has(occStart.getTime()) || (isAllDay && exdateKeys.has(dayKey))) continue;
 
           let occSummary = summary;
           let occLocation = location;
@@ -265,8 +250,7 @@ async function resolveIcalData(config = {}, nowRef = new Date()) {
             else if (rec.start) occEnd = new Date(occStart.getTime() + durationMs);
           }
 
-          // Skip if occurrence has already ended before now
-          const occIsPast = isAllDay ? formatAllDayKey(occEnd) <= todayKey && formatAllDayKey(occStart) < todayKey : occEnd < now;
+          const occIsPast = isAllDay ? (endDayKey <= todayKey) : (occEnd < now);
           if (occIsPast) continue;
 
           flatEvents.push({
@@ -274,6 +258,8 @@ async function resolveIcalData(config = {}, nowRef = new Date()) {
             start: occStart,
             end: occEnd,
             isAllDay,
+            dayKey,
+            endDayKey,
             organizer,
             location: occLocation,
             description: occDescription,
@@ -284,16 +270,21 @@ async function resolveIcalData(config = {}, nowRef = new Date()) {
       }
     } else if (ev.start) {
       const evStart = new Date(ev.start);
-      const evEnd = ev.end ? new Date(ev.end) : new Date(evStart.getTime() + 3600000);
+      const evEnd = ev.end ? new Date(ev.end) : new Date(evStart.getTime() + (isAllDay ? 86400000 : 3600000));
+      const dayKey = isAllDay ? formatLocalDayKey(evStart) : dateKey(evStart);
+      const endDayKey = isAllDay ? formatLocalDayKey(evEnd) : dateKey(evEnd);
 
-      // Include if within window and hasn't already ended
-      const isPast = isAllDay ? formatAllDayKey(evEnd) <= todayKey && formatAllDayKey(evStart) < todayKey : evEnd < now;
-      if (!isPast && evStart <= endWindow) {
+      const isPast = isAllDay ? (endDayKey <= todayKey) : (evEnd < now);
+      const isWithinWindow = isAllDay ? (dayKey <= endWindowDayKey) : (evStart <= endWindow);
+
+      if (!isPast && isWithinWindow) {
         flatEvents.push({
           summary,
           start: evStart,
           end: evEnd,
           isAllDay,
+          dayKey,
+          endDayKey,
           organizer,
           location,
           description,
@@ -308,12 +299,11 @@ async function resolveIcalData(config = {}, nowRef = new Date()) {
   // Truncate to max events
   const selectedEvents = flatEvents.slice(0, maxEvents);
 
-  // Determine current active event (DTSTART <= now < DTEND)
+  // Determine current active event (timed event with DTSTART <= now < DTEND)
   const currentEvent = flatEvents.find(e => !e.isAllDay && e.start <= now && e.end > now) || null;
 
-  // Determine next upcoming event (DTSTART > now)
-  const nextEvent = flatEvents.find(e => e.start > now) || null;
-
+  // Determine next upcoming event (DTSTART > now for timed, dayKey > todayKey for all-day)
+  const nextEvent = flatEvents.find(e => e.isAllDay ? e.dayKey > todayKey : e.start > now) || null;
 
   const isBusy = !!currentEvent;
   const statusDe = isBusy ? 'BELEGT' : 'FREI';
@@ -326,8 +316,9 @@ async function resolveIcalData(config = {}, nowRef = new Date()) {
       ? `Belegt bis ${formatTime(currentEvent.end)}`
       : `Busy until ${formatTime(currentEvent.end)}`;
   } else if (nextEvent) {
-    const nextEventKey = nextEvent.isAllDay ? formatAllDayKey(nextEvent.start) : dateKey(nextEvent.start);
-    const nextIsToday = nextEventKey === todayKey;
+    const nextIsToday = nextEvent.isAllDay
+      ? (nextEvent.dayKey <= todayKey && nextEvent.endDayKey > todayKey)
+      : (dateKey(nextEvent.start) === todayKey);
     if (nextIsToday && !nextEvent.isAllDay) {
       statusDetail = locale === 'de'
         ? `Frei bis ${formatTime(nextEvent.start)}`
@@ -359,21 +350,21 @@ async function resolveIcalData(config = {}, nowRef = new Date()) {
     next_title: nextEvent ? nextEvent.summary : '',
     next_summary: nextEvent ? nextEvent.summary : '',
     next_event_summary: nextEvent ? nextEvent.summary : '',
-    next_time: nextEvent ? (nextEvent.isAllDay ? formatDate(nextEvent.start, true) : `${formatDate(nextEvent.start)}, ${formatTime(nextEvent.start)}`) : '',
-    next_event_time: nextEvent ? (nextEvent.isAllDay ? formatDate(nextEvent.start, true) : `${formatDate(nextEvent.start)}, ${formatTime(nextEvent.start)}`) : '',
-    next_date: nextEvent ? formatDate(nextEvent.start, nextEvent.isAllDay) : '',
+    next_time: nextEvent ? (nextEvent.isAllDay ? formatDate(nextEvent) : `${formatDate(nextEvent)}, ${formatTime(nextEvent.start)}`) : '',
+    next_event_time: nextEvent ? (nextEvent.isAllDay ? formatDate(nextEvent) : `${formatDate(nextEvent)}, ${formatTime(nextEvent.start)}`) : '',
+    next_date: nextEvent ? formatDate(nextEvent) : '',
     next_organizer: nextEvent ? nextEvent.organizer : '',
 
     total_upcoming_count: selectedEvents.length,
     event_count: selectedEvents.length,
-    events_today_count: flatEvents.filter(e => (e.isAllDay ? formatAllDayKey(e.start) : dateKey(e.start)) === todayKey).length,
+    events_today_count: flatEvents.filter(e => e.isAllDay ? (e.dayKey <= todayKey && e.endDayKey > todayKey) : (dateKey(e.start) === todayKey)).length,
   };
 
   // Populate indexed items (event_0_title, event_1_title, ...)
   selectedEvents.forEach((ev, idx) => {
     payload[`event_${idx}_title`] = ev.summary;
     payload[`event_${idx}_summary`] = ev.summary;
-    payload[`event_${idx}_date`] = ev.isAllDay ? formatDate(ev.start, true) : `${formatDate(ev.start)}, ${formatTime(ev.start)}`;
+    payload[`event_${idx}_date`] = ev.isAllDay ? formatDate(ev) : `${formatDate(ev)}, ${formatTime(ev.start)}`;
     payload[`event_${idx}_time`] = ev.isAllDay ? (locale === 'de' ? 'Ganztägig' : 'All day') : `${formatTime(ev.start)} – ${formatTime(ev.end)}`;
     payload[`event_${idx}_location`] = ev.location || '';
     payload[`event_${idx}_organizer`] = ev.organizer || '';
@@ -381,7 +372,7 @@ async function resolveIcalData(config = {}, nowRef = new Date()) {
 
   // Multi-line formatted agenda text
   payload.agenda_text = selectedEvents
-    .map(ev => `${ev.isAllDay ? formatDate(ev.start, true) : formatTime(ev.start)}: ${ev.summary}`)
+    .map(ev => `${ev.isAllDay ? formatDate(ev) : formatTime(ev.start)}: ${ev.summary}`)
     .join('\n');
 
   return payload;

--- a/server/lib/data-sources/ical-resolver.js
+++ b/server/lib/data-sources/ical-resolver.js
@@ -8,9 +8,7 @@
  */
 
 const ical = require('node-ical');
-const http = require('http');
-const https = require('https');
-const { assertSafeUrl, pinnedLookup, SsrfError } = require('../ssrf-guard');
+const { assertSafeUrl, pinnedLookup, SsrfError, guardedRequest } = require('../ssrf-guard');
 
 const FETCH_TIMEOUT_MS = 10000;
 const MAX_REDIRECTS = 4;
@@ -19,98 +17,32 @@ const MAX_BODY_BYTES = 2 * 1024 * 1024; // refuse calendar feeds larger than 2 M
 /**
  * Fetch a calendar feed over HTTPS/HTTP with the project's SSRF guard applied.
  *
- * node-ical's built-in `fromURL` performs an unguarded fetch that follows redirects and
- * accepts any scheme, making it an open fetch primitive reachable by workspace editors.
- * Instead we fetch the bytes ourselves, reusing the hardened pipeline from the media
- * proxy: vet the URL (scheme + DNS + private-IP ranges), pin the socket to a vetted
- * address (defeating DNS rebinding), re-vet every redirect hop, and enforce a timeout.
- * The response body is then parsed locally with ical.sync.parseICS().
- *
  * @param {string} urlString - http(s) or webcal:// URL
  * @returns {Promise<string>} The raw calendar text
  */
-function fetchCalendar(urlString) {
+async function fetchCalendar(urlString) {
   const raw = String(urlString || '').trim().replace(/^webcal:\/\//i, 'https://');
-  const deadline = Date.now() + FETCH_TIMEOUT_MS;
-
-  const follow = (target, redirectsLeft) => new Promise((resolve, reject) => {
-    const remainingMs = deadline - Date.now();
-    if (remainingMs <= 0) {
-      return reject(new Error('Calendar feed timed out'));
-    }
-
-    assertSafeUrl(target).then(({ url, addresses }) => {
-      const mod = url.protocol === 'https:' ? https : http;
-      let timer = null;
-      const clearReqTimer = () => {
-        if (timer) {
-          clearTimeout(timer);
-          timer = null;
-        }
-      };
-
-      const req = mod.request(url, {
-        method: 'GET',
-        lookup: pinnedLookup(addresses),
-        servername: url.hostname,
-        headers: {
-          'User-Agent': 'ScreenTinker-DataSource/2.0',
-          'Accept': 'text/calendar, application/json, text/plain',
-        },
-      }, (res) => {
-        const sc = res.statusCode;
-        if (sc >= 300 && sc < 400 && res.headers.location) {
-          res.resume();
-          clearReqTimer();
-          if (redirectsLeft <= 0) {
-            return reject(new Error('Too many redirects fetching calendar feed'));
-          }
-          let next;
-          try { next = new URL(res.headers.location, url).toString(); }
-          catch (_) { return reject(new Error('Invalid redirect from calendar feed')); }
-          return follow(next, redirectsLeft - 1).then(resolve, reject);
-        }
-        if (sc !== 200) {
-          res.resume();
-          clearReqTimer();
-          return reject(new Error(`Calendar feed responded ${sc}`));
-        }
-        const chunks = [];
-        let total = 0;
-        res.on('data', (c) => {
-          total += c.length;
-          if (total > MAX_BODY_BYTES) {
-            clearReqTimer();
-            res.destroy(new Error('Calendar feed exceeds size limit'));
-            return;
-          }
-          chunks.push(c);
-        });
-        res.on('end', () => {
-          clearReqTimer();
-          resolve(Buffer.concat(chunks).toString('utf8'));
-        });
-        res.on('error', (err) => {
-          clearReqTimer();
-          reject(err);
-        });
-      });
-
-      const timeRemaining = Math.max(100, deadline - Date.now());
-      timer = setTimeout(() => {
-        req.destroy(new Error('Calendar feed timed out'));
-      }, timeRemaining);
-      timer.unref?.();
-
-      req.on('error', (err) => {
-        clearReqTimer();
-        reject(err);
-      });
-      req.end();
-    }, reject);
-  });
-
-  return follow(raw, MAX_REDIRECTS);
+  try {
+    const res = await guardedRequest(raw, {
+      maxRedirects: MAX_REDIRECTS,
+      timeoutMs: FETCH_TIMEOUT_MS,
+      maxBytes: MAX_BODY_BYTES,
+      responseType: 'text',
+      headers: {
+        'User-Agent': 'ScreenTinker-DataSource/2.0',
+        'Accept': 'text/calendar, application/json, text/plain',
+      },
+    });
+    return res.text;
+  } catch (err) {
+    if (err instanceof SsrfError) throw err;
+    if (err.message === 'Request timed out') throw new Error('Calendar feed timed out');
+    if (err.message === 'Too many redirects') throw new Error('Too many redirects fetching calendar feed');
+    if (err.message === 'Invalid redirect location') throw new Error('Invalid redirect from calendar feed');
+    if (err.message === 'Response exceeds size limit') throw new Error('Calendar feed exceeds size limit');
+    if (err.statusCode) throw new Error(`Calendar feed responded ${err.statusCode}`);
+    throw err;
+  }
 }
 
 /**
@@ -163,11 +95,58 @@ async function resolveIcalData(config = {}, nowRef = new Date()) {
   }
 
   const now = new Date(nowRef);
-  const startWindow = new Date(now);
-  startWindow.setHours(0, 0, 0, 0); // Start of today
+  const tzOpts = timezone ? { timeZone: timezone } : {};
+  const dateKey = (d) => d.toLocaleDateString('en-CA', tzOpts); // YYYY-MM-DD in target zone
+  const todayKey = dateKey(now);
+  const tomorrow = new Date(now);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const tomorrowKey = dateKey(tomorrow);
 
-  const endWindow = new Date(startWindow);
-  endWindow.setDate(endWindow.getDate() + lookaheadDays);
+  const formatAllDayKey = (d) => {
+    const y = d.getUTCFullYear();
+    const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(d.getUTCDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+  };
+
+  const formatAllDayDate = (d) => {
+    const key = formatAllDayKey(d);
+    if (key === todayKey) return locale === 'de' ? 'Heute' : 'Today';
+    if (key === tomorrowKey) return locale === 'de' ? 'Morgen' : 'Tomorrow';
+
+    // Format calendar date using midday UTC representation to avoid timezone shifts across day boundaries
+    const y = d.getUTCFullYear();
+    const m = d.getUTCMonth();
+    const day = d.getUTCDate();
+    const noonUtc = new Date(Date.UTC(y, m, day, 12, 0, 0));
+    return noonUtc.toLocaleDateString(locale === 'de' ? 'de-DE' : 'en-US', {
+      weekday: 'short',
+      day: 'numeric',
+      month: 'short',
+      timeZone: 'UTC',
+    });
+  };
+
+  const formatTime = (d) => d.toLocaleTimeString(locale === 'de' ? 'de-DE' : 'en-US', { hour: '2-digit', minute: '2-digit', hour12: locale !== 'de', ...tzOpts });
+  const formatDate = (d, isAllDay = false) => {
+    if (isAllDay) return formatAllDayDate(d);
+    const key = dateKey(d);
+    if (key === todayKey) return locale === 'de' ? 'Heute' : 'Today';
+    if (key === tomorrowKey) return locale === 'de' ? 'Morgen' : 'Tomorrow';
+
+    return d.toLocaleDateString(locale === 'de' ? 'de-DE' : 'en-US', {
+      weekday: 'short',
+      day: 'numeric',
+      month: 'short',
+      ...tzOpts,
+    });
+  };
+
+  const startWindow = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  startWindow.setHours(0, 0, 0, 0); // Widen startWindow back 24h to avoid UTC offset boundary clipping
+
+  const endWindow = new Date(now);
+  endWindow.setDate(endWindow.getDate() + lookaheadDays + 1);
   endWindow.setHours(23, 59, 59, 999);
 
   const flatEvents = [];
@@ -287,7 +266,8 @@ async function resolveIcalData(config = {}, nowRef = new Date()) {
           }
 
           // Skip if occurrence has already ended before now
-          if (occEnd < now && !isAllDay) continue;
+          const occIsPast = isAllDay ? formatAllDayKey(occEnd) <= todayKey && formatAllDayKey(occStart) < todayKey : occEnd < now;
+          if (occIsPast) continue;
 
           flatEvents.push({
             summary: occSummary,
@@ -307,7 +287,8 @@ async function resolveIcalData(config = {}, nowRef = new Date()) {
       const evEnd = ev.end ? new Date(ev.end) : new Date(evStart.getTime() + 3600000);
 
       // Include if within window and hasn't already ended
-      if (evEnd >= now && evStart <= endWindow) {
+      const isPast = isAllDay ? formatAllDayKey(evEnd) <= todayKey && formatAllDayKey(evStart) < todayKey : evEnd < now;
+      if (!isPast && evStart <= endWindow) {
         flatEvents.push({
           summary,
           start: evStart,
@@ -333,54 +314,6 @@ async function resolveIcalData(config = {}, nowRef = new Date()) {
   // Determine next upcoming event (DTSTART > now)
   const nextEvent = flatEvents.find(e => e.start > now) || null;
 
-  // Format date and time helpers (honour the configured IANA timezone, falling back to
-  // the server's local zone so times are never silently shifted for a different venue).
-  const tzOpts = timezone ? { timeZone: timezone } : {};
-  const dateKey = (d) => d.toLocaleDateString('en-CA', tzOpts); // YYYY-MM-DD in target zone
-  const todayKey = dateKey(now);
-  const tomorrow = new Date(now);
-  tomorrow.setDate(tomorrow.getDate() + 1);
-  const tomorrowKey = dateKey(tomorrow);
-
-  const formatAllDayKey = (d) => {
-    const y = d.getFullYear();
-    const m = String(d.getMonth() + 1).padStart(2, '0');
-    const day = String(d.getDate()).padStart(2, '0');
-    return `${y}-${m}-${day}`;
-  };
-
-  const formatAllDayDate = (d) => {
-    const key = formatAllDayKey(d);
-    if (key === todayKey) return locale === 'de' ? 'Heute' : 'Today';
-    if (key === tomorrowKey) return locale === 'de' ? 'Morgen' : 'Tomorrow';
-
-    // Format calendar date using midday UTC representation to avoid timezone shifts across day boundaries
-    const y = d.getFullYear();
-    const m = d.getMonth();
-    const day = d.getDate();
-    const noonUtc = new Date(Date.UTC(y, m, day, 12, 0, 0));
-    return noonUtc.toLocaleDateString(locale === 'de' ? 'de-DE' : 'en-US', {
-      weekday: 'short',
-      day: 'numeric',
-      month: 'short',
-      timeZone: 'UTC',
-    });
-  };
-
-  const formatTime = (d) => d.toLocaleTimeString(locale === 'de' ? 'de-DE' : 'en-US', { hour: '2-digit', minute: '2-digit', hour12: locale !== 'de', ...tzOpts });
-  const formatDate = (d, isAllDay = false) => {
-    if (isAllDay) return formatAllDayDate(d);
-    const key = dateKey(d);
-    if (key === todayKey) return locale === 'de' ? 'Heute' : 'Today';
-    if (key === tomorrowKey) return locale === 'de' ? 'Morgen' : 'Tomorrow';
-
-    return d.toLocaleDateString(locale === 'de' ? 'de-DE' : 'en-US', {
-      weekday: 'short',
-      day: 'numeric',
-      month: 'short',
-      ...tzOpts,
-    });
-  };
 
   const isBusy = !!currentEvent;
   const statusDe = isBusy ? 'BELEGT' : 'FREI';
@@ -395,7 +328,7 @@ async function resolveIcalData(config = {}, nowRef = new Date()) {
   } else if (nextEvent) {
     const nextEventKey = nextEvent.isAllDay ? formatAllDayKey(nextEvent.start) : dateKey(nextEvent.start);
     const nextIsToday = nextEventKey === todayKey;
-    if (nextIsToday) {
+    if (nextIsToday && !nextEvent.isAllDay) {
       statusDetail = locale === 'de'
         ? `Frei bis ${formatTime(nextEvent.start)}`
         : `Free until ${formatTime(nextEvent.start)}`;

--- a/server/lib/data-sources/service.js
+++ b/server/lib/data-sources/service.js
@@ -84,6 +84,23 @@ function stopDataSourcesPoller() {
   }
 }
 
+// Per-workspace forced refresh limiter. Protects background slots from being monopolized
+// by rapid manual syncs in a single workspace while allowing multitenant fairness.
+const forcedSyncs = new Map(); // workspaceId -> { winStart, count }
+const FORCED_SYNC_WINDOW_MS = 60000;
+const FORCED_SYNC_MAX_PER_WINDOW = 30; // 30 forced syncs per minute per workspace
+
+function checkForcedSyncBudget(workspaceId, now = Date.now()) {
+  if (!workspaceId) return true;
+  let b = forcedSyncs.get(workspaceId);
+  if (!b || (now - b.winStart) >= FORCED_SYNC_WINDOW_MS) {
+    b = { winStart: now, count: 0 };
+    forcedSyncs.set(workspaceId, b);
+  }
+  b.count++;
+  return b.count <= FORCED_SYNC_MAX_PER_WINDOW;
+}
+
 /**
  * Fetch and refresh a data source by ID or row object.
  *
@@ -98,6 +115,10 @@ async function syncDataSource(sourceOrId, force = false) {
 
   if (!row) {
     throw new Error('Data source not found');
+  }
+
+  if (force && row.workspace_id && !checkForcedSyncBudget(row.workspace_id)) {
+    throw Object.assign(new Error('Rate limit exceeded for manual syncs in this workspace'), { code: 'rate-limit' });
   }
 
   let config = {};
@@ -198,21 +219,36 @@ async function syncDataSource(sourceOrId, force = false) {
  * fixed string for exactly that reason. One vocabulary, no addresses.
  */
 function describeSyncError(err) {
-  const m = String((err && err.message) || '');
-  if (err && err.name === 'SsrfError') return 'The calendar address is not allowed';
-  if (/^blocked:/i.test(m)) return 'The calendar address is not allowed';
-  if (/No valid iCal URL/i.test(m)) return 'No calendar URL or data configured';
-  if (/timed out/i.test(m)) return 'The calendar host did not respond in time';
-  if (/size limit/i.test(m)) return 'The calendar feed is too large';
-  if (/responded (\d{3})|HTTP (\d{3})/i.test(m)) {
-    const code = (m.match(/(\d{3})/) || [])[1];
-    return code ? `The calendar host responded with HTTP ${code}` : 'The calendar host responded with an error';
+  if (!err) return 'Sync failed';
+  const m = String(err.message || '');
+  if (err.name === 'SsrfError' || err.code === 'ssrf' || /^blocked:/i.test(m)) {
+    return 'The calendar address is not allowed';
   }
-  if (/could not be parsed|parse/i.test(m)) return 'The calendar data could not be parsed';
+  if (err.code === 'timeout' || /timed out/i.test(m)) {
+    return 'The calendar host did not respond in time';
+  }
+  if (err.code === 'size-limit' || /size limit/i.test(m)) {
+    return 'The calendar feed is too large';
+  }
+  if (err.code === 'upstream-status' || err.statusCode || /responded (\d{3})|HTTP (\d{3})/i.test(m)) {
+    const sc = err.statusCode || (m.match(/responded (\d{3})/i) || [])[1] || (m.match(/HTTP (\d{3})/i) || [])[1] || (m.match(/(\d{3})/) || [])[1];
+    return sc ? `The calendar host responded with HTTP ${sc}` : 'The calendar host responded with an error';
+  }
+  if (err.code === 'too-many-redirects' || err.code === 'bad-redirect') {
+    return 'The calendar host could not be reached';
+  }
+  if (/No valid iCal URL/i.test(m)) {
+    return 'No calendar URL or data configured';
+  }
+  if (/could not be parsed|parse/i.test(m)) {
+    return 'The calendar data could not be parsed';
+  }
   if (/ECONNREFUSED|ENOTFOUND|EAI_AGAIN|ETIMEDOUT|ECONNRESET|EHOSTUNREACH|ENETUNREACH|certificate/i.test(m)) {
     return 'The calendar host could not be reached';
   }
-  if (/Unsupported data source type/i.test(m)) return 'Unsupported data source type';
+  if (/Unsupported data source type/i.test(m)) {
+    return 'Unsupported data source type';
+  }
   return 'Sync failed';
 }
 

--- a/server/lib/data-sources/service.js
+++ b/server/lib/data-sources/service.js
@@ -246,7 +246,7 @@ function bumpDependentWidgets(row, nowSec) {
     db.prepare(`UPDATE widgets SET updated_at = ? WHERE id IN (${placeholders})`).run(nowSec, ...widgetIds);
 
     // Push the revision change to all displays currently playing any of these widgets
-    const io = ioInstance || global.__deviceIo;
+    const io = ioInstance;
     const deviceNs = io?.of?.('/device');
     if (deviceNs) {
       const { buildPlaylistPayload } = require('../../ws/deviceSocket');
@@ -293,35 +293,10 @@ function getWorkspaceDataMapSync(workspaceId) {
   return map;
 }
 
-/**
- * Get all data sources for a workspace mapped by slug.
- *
- * @param {string} workspaceId Workspace ID
- * @returns {Promise<Map<string, object>>} Map of slug -> dictionary data
- */
-async function getWorkspaceDataMap(workspaceId) {
-  if (!workspaceId) return new Map();
-
-  const rows = db.prepare('SELECT * FROM data_sources WHERE workspace_id = ?').all(workspaceId);
-  const map = new Map();
-
-  for (const r of rows) {
-    try {
-      const synced = await syncDataSource(r, false);
-      if (synced && synced.data) {
-        map.set(r.slug, synced.data);
-      }
-    } catch (_) {}
-  }
-
-  return map;
-}
-
 module.exports = {
   syncDataSource,
   bumpDependentWidgets,
   describeSyncError,
-  getWorkspaceDataMap,
   getWorkspaceDataMapSync,
   withFetchSlot,
   pollDueDataSources,

--- a/server/lib/device-timezone.js
+++ b/server/lib/device-timezone.js
@@ -24,4 +24,14 @@ function effectiveDeviceTz(device) {
   return override || device.reported_timezone || null;
 }
 
-module.exports = { effectiveDeviceTz };
+function isRealTimezone(tz) {
+  if (typeof tz !== 'string' || !tz) return false;
+  // Reject anything that could break out of the single-quoted string it is inlined into, before
+  // handing it to Intl — this value is interpolated into generated widget JS.
+  if (/['"\\\r\n]/.test(tz)) return false;
+  try { new Intl.DateTimeFormat(undefined, { timeZone: tz }); return true; }
+  catch { return false; }
+}
+
+module.exports = { effectiveDeviceTz, isRealTimezone };
+

--- a/server/lib/slide-render.js
+++ b/server/lib/slide-render.js
@@ -724,7 +724,13 @@ function interpolateDataSources(text, resolveData) {
   return text.replace(/\{\{ds:([a-zA-Z0-9_-]+)\.([a-zA-Z0-9_]+)\}\}/g, (match, slug, key) => {
     if (typeof resolveData === 'function') {
       const val = resolveData(slug, key);
-      if (val !== undefined && val !== null) return String(val).slice(0, MAX_FIELD_CHARS);
+      if (val !== undefined && val !== null) {
+        if (typeof val === 'object') {
+          try { return JSON.stringify(val).slice(0, MAX_FIELD_CHARS); }
+          catch (_) { return ''; }
+        }
+        return String(val).slice(0, MAX_FIELD_CHARS);
+      }
     }
     return '';
   });

--- a/server/lib/ssrf-guard.js
+++ b/server/lib/ssrf-guard.js
@@ -153,4 +153,147 @@ function pinnedLookup(vettedAddresses) {
   };
 }
 
-module.exports = { assertSafeUrl, isBlockedIp, isBlockedV4, isBlockedV6, pinnedLookup, SsrfError };
+const http = require('http');
+const https = require('https');
+
+/**
+ * Execute an HTTP/HTTPS request with complete SSRF protections:
+ * - Scheme enforcement (http/https only)
+ * - DNS resolution & private/reserved IP filtering on all resolved addresses
+ * - Socket address pinning (defeating DNS rebinding)
+ * - SNI / TLS validation against original hostname
+ * - Per-hop SSRF validation across redirects
+ * - Bounded timeouts and optional response size caps
+ *
+ * @param {string} urlString Target URL
+ * @param {object} [options] Request options
+ * @param {string} [options.method='GET'] HTTP method
+ * @param {object} [options.headers={}] HTTP headers
+ * @param {number} [options.maxRedirects=4] Maximum redirect hops to follow
+ * @param {number} [options.timeoutMs=10000] Overall request timeout in milliseconds
+ * @param {number} [options.maxBytes] Maximum response body size in bytes
+ * @param {object} [options.validators] ETag / Last-Modified conditional headers { etag, lastModified }
+ * @param {'stream'|'text'|'buffer'} [options.responseType='stream'] Response format
+ * @returns {Promise<{res?: import('http').IncomingMessage, text?: string, buffer?: Buffer, notModified?: boolean, statusCode: number, headers: object}>}
+ */
+function guardedRequest(urlString, options = {}) {
+  const method = (options.method || 'GET').toUpperCase();
+  const headers = { ...(options.headers || {}) };
+  const maxRedirects = Number.isInteger(options.maxRedirects) ? options.maxRedirects : 4;
+  const timeoutMs = options.timeoutMs || 10000;
+  const maxBytes = options.maxBytes || null;
+  const validators = options.validators || null;
+  const responseType = options.responseType || 'stream';
+
+  if (validators) {
+    if (validators.etag) headers['if-none-match'] = validators.etag;
+    if (validators.lastModified) headers['if-modified-since'] = validators.lastModified;
+  }
+
+  const deadline = Date.now() + timeoutMs;
+
+  const follow = (targetUrl, redirectsLeft) => new Promise((resolve, reject) => {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      return reject(new Error('Request timed out'));
+    }
+
+    assertSafeUrl(targetUrl).then(({ url, addresses }) => {
+      const mod = url.protocol === 'https:' ? https : http;
+      let timer = null;
+
+      const clearReqTimer = () => {
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+      };
+
+      const req = mod.request(url, {
+        method,
+        lookup: pinnedLookup(addresses),
+        servername: url.hostname,
+        headers,
+      }, (res) => {
+        const sc = res.statusCode;
+
+        if (sc === 304) {
+          res.resume();
+          clearReqTimer();
+          return resolve({ notModified: true, statusCode: 304, headers: res.headers });
+        }
+
+        if (sc >= 300 && sc < 400 && res.headers.location) {
+          res.resume();
+          clearReqTimer();
+          if (redirectsLeft <= 0) {
+            return reject(new Error('Too many redirects'));
+          }
+          let next;
+          try { next = new URL(res.headers.location, url).toString(); }
+          catch (_) { return reject(new Error('Invalid redirect location')); }
+          return follow(next, redirectsLeft - 1).then(resolve, reject);
+        }
+
+        if (sc < 200 || sc >= 300) {
+          res.resume();
+          clearReqTimer();
+          const err = new Error(`Request failed with status ${sc}`);
+          err.statusCode = sc;
+          return reject(err);
+        }
+
+        if (responseType === 'stream') {
+          clearReqTimer();
+          return resolve({ res, statusCode: sc, headers: res.headers });
+        }
+
+        const chunks = [];
+        let total = 0;
+
+        res.on('data', (chunk) => {
+          total += chunk.length;
+          if (maxBytes !== null && total > maxBytes) {
+            clearReqTimer();
+            res.destroy(new Error('Response exceeds size limit'));
+            return;
+          }
+          chunks.push(chunk);
+        });
+
+        res.on('end', () => {
+          clearReqTimer();
+          const buf = Buffer.concat(chunks);
+          if (responseType === 'text') {
+            resolve({ text: buf.toString('utf8'), buffer: buf, statusCode: sc, headers: res.headers });
+          } else {
+            resolve({ buffer: buf, text: buf.toString('utf8'), statusCode: sc, headers: res.headers });
+          }
+        });
+
+        res.on('error', (err) => {
+          clearReqTimer();
+          reject(err);
+        });
+      });
+
+      const timeRemaining = Math.max(100, deadline - Date.now());
+      timer = setTimeout(() => {
+        req.destroy(new Error('Request timed out'));
+      }, timeRemaining);
+      timer.unref?.();
+
+      req.on('error', (err) => {
+        clearReqTimer();
+        reject(err);
+      });
+
+      req.end();
+    }, reject);
+  });
+
+  return follow(urlString, maxRedirects);
+}
+
+module.exports = { assertSafeUrl, isBlockedIp, isBlockedV4, isBlockedV6, pinnedLookup, SsrfError, guardedRequest };
+

--- a/server/lib/ssrf-guard.js
+++ b/server/lib/ssrf-guard.js
@@ -10,9 +10,25 @@
 
 const dns = require('dns').promises;
 const net = require('net');
+const http = require('http');
+const https = require('https');
 
 class SsrfError extends Error {
-  constructor(reason) { super('blocked: ' + reason); this.name = 'SsrfError'; this.reason = reason; }
+  constructor(reason) {
+    super('blocked: ' + reason);
+    this.name = 'SsrfError';
+    this.code = 'ssrf';
+    this.reason = reason;
+  }
+}
+
+class GuardedRequestError extends Error {
+  constructor(message, code, statusCode = null) {
+    super(message);
+    this.name = 'GuardedRequestError';
+    this.code = code;
+    if (statusCode) this.statusCode = statusCode;
+  }
 }
 
 // ---- IPv4 ----
@@ -101,26 +117,53 @@ function isBlockedIp(ip) {
 
 // Parse + scheme-check + DNS-resolve + vet EVERY resolved address. Returns { url, addresses } where
 // `addresses` are the vetted IPs to pin the socket to. Throws SsrfError on anything unsafe.
-async function assertSafeUrl(urlString) {
+// Parse + scheme-check + credentials check + literal IP vet (sync).
+// Returns { url, host, normalized, isLiteralIp, addresses? }.
+// Throws SsrfError on anything unsafe.
+function parseSafeUrl(urlString) {
+  const normalized = String(urlString || '').trim().replace(/^webcal:\/\//i, 'https://');
   let url;
-  try { url = new URL(String(urlString)); } catch (e) { throw new SsrfError('bad-url'); }
-  if (url.protocol !== 'http:' && url.protocol !== 'https:') throw new SsrfError('bad-scheme');
-  if (url.username || url.password) throw new SsrfError('userinfo'); // http://internal@evil.com tricks
+  try {
+    url = new URL(normalized);
+  } catch (e) {
+    throw new SsrfError('bad-url');
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new SsrfError('bad-scheme');
+  }
+  if (url.username || url.password) {
+    throw new SsrfError('userinfo'); // http://internal@evil.com tricks
+  }
 
   const host = url.hostname.replace(/^\[|\]$/g, '');
-  // A literal IP in the URL still gets vetted (no DNS, but same range checks).
   if (net.isIP(host)) {
     if (isBlockedIp(host)) throw new SsrfError('blocked-ip:' + host);
-    return { url, addresses: [host] };
+    return { url, host, normalized, isLiteralIp: true, addresses: [host] };
   }
+  return { url, host, normalized, isLiteralIp: false };
+}
+
+// Parse + scheme-check + DNS-resolve + vet EVERY resolved address. Returns { url, addresses } where
+// `addresses` are the vetted IPs to pin the socket to. Throws SsrfError on anything unsafe.
+async function assertSafeUrl(urlString) {
+  const parsed = parseSafeUrl(urlString);
+  if (parsed.isLiteralIp) {
+    return { url: parsed.url, addresses: parsed.addresses };
+  }
+
   let resolved;
-  try { resolved = await dns.lookup(host, { all: true, verbatim: true }); }
-  catch (e) { throw new SsrfError('dns-fail'); }
-  if (!resolved.length) throw new SsrfError('no-address');
+  try {
+    resolved = await dns.lookup(parsed.host, { all: true, verbatim: true });
+  } catch (e) {
+    throw new SsrfError('dns-fail');
+  }
+  if (!resolved || !resolved.length) {
+    throw new SsrfError('no-address');
+  }
   for (const a of resolved) {
     if (isBlockedIp(a.address)) throw new SsrfError('blocked-ip:' + a.address);
   }
-  return { url, addresses: resolved.map((a) => a.address) };
+  return { url: parsed.url, addresses: resolved.map((a) => a.address) };
 }
 
 function pinnedLookup(vettedAddresses) {
@@ -153,9 +196,6 @@ function pinnedLookup(vettedAddresses) {
   };
 }
 
-const http = require('http');
-const https = require('https');
-
 /**
  * Execute an HTTP/HTTPS request with complete SSRF protections:
  * - Scheme enforcement (http/https only)
@@ -163,14 +203,15 @@ const https = require('https');
  * - Socket address pinning (defeating DNS rebinding)
  * - SNI / TLS validation against original hostname
  * - Per-hop SSRF validation across redirects
- * - Bounded timeouts and optional response size caps
+ * - Bounded timeouts (overall deadline and socket idle timer) and optional response size caps
  *
  * @param {string} urlString Target URL
  * @param {object} [options] Request options
  * @param {string} [options.method='GET'] HTTP method
  * @param {object} [options.headers={}] HTTP headers
  * @param {number} [options.maxRedirects=4] Maximum redirect hops to follow
- * @param {number} [options.timeoutMs=10000] Overall request timeout in milliseconds
+ * @param {number} [options.timeoutMs=10000] Overall request deadline timeout in milliseconds
+ * @param {number} [options.idleTimeoutMs] Socket idle timeout in milliseconds (survives into body stream)
  * @param {number} [options.maxBytes] Maximum response body size in bytes
  * @param {object} [options.validators] ETag / Last-Modified conditional headers { etag, lastModified }
  * @param {'stream'|'text'|'buffer'} [options.responseType='stream'] Response format
@@ -181,6 +222,7 @@ function guardedRequest(urlString, options = {}) {
   const headers = { ...(options.headers || {}) };
   const maxRedirects = Number.isInteger(options.maxRedirects) ? options.maxRedirects : 4;
   const timeoutMs = options.timeoutMs || 10000;
+  const idleTimeoutMs = options.idleTimeoutMs || null;
   const maxBytes = options.maxBytes || null;
   const validators = options.validators || null;
   const responseType = options.responseType || 'stream';
@@ -195,17 +237,17 @@ function guardedRequest(urlString, options = {}) {
   const follow = (targetUrl, redirectsLeft) => new Promise((resolve, reject) => {
     const remainingMs = deadline - Date.now();
     if (remainingMs <= 0) {
-      return reject(new Error('Request timed out'));
+      return reject(new GuardedRequestError('Request timed out', 'timeout'));
     }
 
     assertSafeUrl(targetUrl).then(({ url, addresses }) => {
       const mod = url.protocol === 'https:' ? https : http;
-      let timer = null;
+      let deadlineTimer = null;
 
-      const clearReqTimer = () => {
-        if (timer) {
-          clearTimeout(timer);
-          timer = null;
+      const clearDeadlineTimer = () => {
+        if (deadlineTimer) {
+          clearTimeout(deadlineTimer);
+          deadlineTimer = null;
         }
       };
 
@@ -219,32 +261,30 @@ function guardedRequest(urlString, options = {}) {
 
         if (sc === 304) {
           res.resume();
-          clearReqTimer();
+          clearDeadlineTimer();
           return resolve({ notModified: true, statusCode: 304, headers: res.headers });
         }
 
         if (sc >= 300 && sc < 400 && res.headers.location) {
           res.resume();
-          clearReqTimer();
+          clearDeadlineTimer();
           if (redirectsLeft <= 0) {
-            return reject(new Error('Too many redirects'));
+            return reject(new GuardedRequestError('Too many redirects', 'too-many-redirects'));
           }
           let next;
           try { next = new URL(res.headers.location, url).toString(); }
-          catch (_) { return reject(new Error('Invalid redirect location')); }
+          catch (_) { return reject(new GuardedRequestError('Invalid redirect location', 'bad-redirect')); }
           return follow(next, redirectsLeft - 1).then(resolve, reject);
         }
 
-        if (sc < 200 || sc >= 300) {
+        if (sc !== 200) {
           res.resume();
-          clearReqTimer();
-          const err = new Error(`Request failed with status ${sc}`);
-          err.statusCode = sc;
-          return reject(err);
+          clearDeadlineTimer();
+          return reject(new GuardedRequestError(`Request failed with status ${sc}`, 'upstream-status', sc));
         }
 
         if (responseType === 'stream') {
-          clearReqTimer();
+          clearDeadlineTimer();
           return resolve({ res, statusCode: sc, headers: res.headers });
         }
 
@@ -254,37 +294,45 @@ function guardedRequest(urlString, options = {}) {
         res.on('data', (chunk) => {
           total += chunk.length;
           if (maxBytes !== null && total > maxBytes) {
-            clearReqTimer();
-            res.destroy(new Error('Response exceeds size limit'));
+            clearDeadlineTimer();
+            res.destroy(new GuardedRequestError('Response exceeds size limit', 'size-limit'));
             return;
           }
           chunks.push(chunk);
         });
 
         res.on('end', () => {
-          clearReqTimer();
+          clearDeadlineTimer();
           const buf = Buffer.concat(chunks);
           if (responseType === 'text') {
-            resolve({ text: buf.toString('utf8'), buffer: buf, statusCode: sc, headers: res.headers });
+            resolve({ text: buf.toString('utf8'), statusCode: sc, headers: res.headers });
           } else {
-            resolve({ buffer: buf, text: buf.toString('utf8'), statusCode: sc, headers: res.headers });
+            resolve({ buffer: buf, statusCode: sc, headers: res.headers });
           }
         });
 
         res.on('error', (err) => {
-          clearReqTimer();
+          clearDeadlineTimer();
           reject(err);
         });
       });
 
+      // Socket idle timeout (remains active through stream body consumption)
+      if (idleTimeoutMs) {
+        req.setTimeout(idleTimeoutMs, () => {
+          req.destroy(new GuardedRequestError('Socket idle timeout', 'timeout'));
+        });
+      }
+
+      // Overall request deadline timeout
       const timeRemaining = Math.max(100, deadline - Date.now());
-      timer = setTimeout(() => {
-        req.destroy(new Error('Request timed out'));
+      deadlineTimer = setTimeout(() => {
+        req.destroy(new GuardedRequestError('Request timed out', 'timeout'));
       }, timeRemaining);
-      timer.unref?.();
+      deadlineTimer.unref?.();
 
       req.on('error', (err) => {
-        clearReqTimer();
+        clearDeadlineTimer();
         reject(err);
       });
 
@@ -295,5 +343,5 @@ function guardedRequest(urlString, options = {}) {
   return follow(urlString, maxRedirects);
 }
 
-module.exports = { assertSafeUrl, isBlockedIp, isBlockedV4, isBlockedV6, pinnedLookup, SsrfError, guardedRequest };
+module.exports = { parseSafeUrl, assertSafeUrl, isBlockedIp, isBlockedV4, isBlockedV6, pinnedLookup, SsrfError, GuardedRequestError, guardedRequest };
 

--- a/server/routes/data-sources.js
+++ b/server/routes/data-sources.js
@@ -45,6 +45,33 @@ function sanitizeConfigForRole(cfg, req) {
   return safe;
 }
 
+function validateDataSourceConfig(type, config) {
+  if (!config || typeof config !== 'object') return;
+  if (type === 'ical') {
+    if (config.url) {
+      let u;
+      try {
+        u = new URL(String(config.url).replace(/^webcal:\/\//i, 'https://'));
+      } catch (_) {
+        throw new Error('Invalid URL format');
+      }
+      if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+        throw new Error('URL must use HTTP, HTTPS, or webcal protocol');
+      }
+      if (u.username || u.password) {
+        throw new Error('Calendar URLs with basic-auth credentials (username/password) are not allowed');
+      }
+    }
+    if (config.timezone) {
+      try {
+        new Intl.DateTimeFormat(undefined, { timeZone: String(config.timezone).trim() });
+      } catch (_) {
+        throw new Error(`Invalid IANA timezone: "${config.timezone}"`);
+      }
+    }
+  }
+}
+
 // ─── GET /api/data-sources (List all in current workspace) ─────────────────────
 router.get('/', (req, res) => {
   const wsId = req.workspaceId;
@@ -112,6 +139,12 @@ router.post('/test', requireWorkspaceWrite, async (req, res, next) => {
   }
 
   try {
+    validateDataSourceConfig(type, parsedConfig);
+  } catch (valErr) {
+    return res.status(400).json({ error: valErr.message });
+  }
+
+  try {
     let previewData = null;
     if (type === 'ical') {
       previewData = await withFetchSlot(() => resolveIcalData(parsedConfig));
@@ -136,6 +169,9 @@ router.post('/test', requireWorkspaceWrite, async (req, res, next) => {
 // ─── POST /api/data-sources (Create new data source) ───────────────────────────
 router.post('/', requireWorkspaceWrite, (req, res) => {
   const wsId = req.workspaceId;
+  if (!wsId) {
+    return res.status(400).json({ error: 'Workspace ID is required' });
+  }
   const { name, type, config, slug: customSlug } = req.body || {};
 
   if (!name || !type || !config) {
@@ -153,6 +189,12 @@ router.post('/', requireWorkspaceWrite, (req, res) => {
   }
   if (!parsedConfig || typeof parsedConfig !== 'object' || Array.isArray(parsedConfig)) {
     return res.status(400).json({ error: 'Config must be an object' });
+  }
+
+  try {
+    validateDataSourceConfig(type, parsedConfig);
+  } catch (valErr) {
+    return res.status(400).json({ error: valErr.message });
   }
 
   const cleanName = String(name).trim();
@@ -221,6 +263,11 @@ router.put('/:id', requireWorkspaceWrite, (req, res) => {
     }
     if (!parsedConfig || typeof parsedConfig !== 'object' || Array.isArray(parsedConfig)) {
       return res.status(400).json({ error: 'Config must be an object' });
+    }
+    try {
+      validateDataSourceConfig(existing.type, parsedConfig);
+    } catch (valErr) {
+      return res.status(400).json({ error: valErr.message });
     }
     configJson = JSON.stringify(parsedConfig);
   } else {

--- a/server/routes/data-sources.js
+++ b/server/routes/data-sources.js
@@ -11,6 +11,8 @@ const { db } = require('../db/database');
 const { syncDataSource, withFetchSlot, bumpDependentWidgets } = require('../lib/data-sources/service');
 const { resolveIcalData } = require('../lib/data-sources/ical-resolver');
 const { requireWorkspaceWrite, canWrite } = require('../lib/permissions');
+const { parseSafeUrl } = require('../lib/ssrf-guard');
+const { isRealTimezone } = require('../lib/device-timezone');
 
 const SUPPORTED_TYPES = new Set(['ical']);
 
@@ -46,30 +48,34 @@ function sanitizeConfigForRole(cfg, req) {
 }
 
 function validateDataSourceConfig(type, config) {
-  if (!config || typeof config !== 'object') return;
-  if (type === 'ical') {
-    if (config.url) {
-      let u;
-      try {
-        u = new URL(String(config.url).replace(/^webcal:\/\//i, 'https://'));
-      } catch (_) {
-        throw new Error('Invalid URL format');
-      }
-      if (u.protocol !== 'http:' && u.protocol !== 'https:') {
-        throw new Error('URL must use HTTP, HTTPS, or webcal protocol');
-      }
-      if (u.username || u.password) {
-        throw new Error('Calendar URLs with basic-auth credentials (username/password) are not allowed');
-      }
-    }
-    if (config.timezone) {
-      try {
-        new Intl.DateTimeFormat(undefined, { timeZone: String(config.timezone).trim() });
-      } catch (_) {
-        throw new Error(`Invalid IANA timezone: "${config.timezone}"`);
-      }
+  if (!config || typeof config !== 'object') return null;
+
+  if (config.timezone) {
+    const tzStr = String(config.timezone).trim();
+    if (!isRealTimezone(tzStr)) {
+      return `Invalid IANA timezone: "${config.timezone}"`;
     }
   }
+
+  const hasInline = Boolean(config.ics_data || config.raw_data || config.raw_ics);
+  if (config.url && !hasInline) {
+    try {
+      parseSafeUrl(config.url);
+    } catch (err) {
+      if (err.reason === 'userinfo') {
+        return 'Calendar URLs with basic-auth credentials (username/password) are not allowed';
+      }
+      if (err.reason === 'bad-scheme') {
+        return 'URL must use HTTP, HTTPS, or webcal protocol';
+      }
+      if (err.reason && err.reason.startsWith('blocked-ip')) {
+        return 'The calendar address is not allowed';
+      }
+      return 'Invalid URL format';
+    }
+  }
+
+  return null;
 }
 
 // ─── GET /api/data-sources (List all in current workspace) ─────────────────────
@@ -138,10 +144,9 @@ router.post('/test', requireWorkspaceWrite, async (req, res, next) => {
     return res.status(400).json({ error: 'Config must be an object' });
   }
 
-  try {
-    validateDataSourceConfig(type, parsedConfig);
-  } catch (valErr) {
-    return res.status(400).json({ error: valErr.message });
+  const valErr = validateDataSourceConfig(type, parsedConfig);
+  if (valErr) {
+    return res.status(400).json({ error: valErr });
   }
 
   try {
@@ -191,10 +196,9 @@ router.post('/', requireWorkspaceWrite, (req, res) => {
     return res.status(400).json({ error: 'Config must be an object' });
   }
 
-  try {
-    validateDataSourceConfig(type, parsedConfig);
-  } catch (valErr) {
-    return res.status(400).json({ error: valErr.message });
+  const valErr = validateDataSourceConfig(type, parsedConfig);
+  if (valErr) {
+    return res.status(400).json({ error: valErr });
   }
 
   const cleanName = String(name).trim();
@@ -264,10 +268,9 @@ router.put('/:id', requireWorkspaceWrite, (req, res) => {
     if (!parsedConfig || typeof parsedConfig !== 'object' || Array.isArray(parsedConfig)) {
       return res.status(400).json({ error: 'Config must be an object' });
     }
-    try {
-      validateDataSourceConfig(existing.type, parsedConfig);
-    } catch (valErr) {
-      return res.status(400).json({ error: valErr.message });
+    const valErr = validateDataSourceConfig(existing.type, parsedConfig);
+    if (valErr) {
+      return res.status(400).json({ error: valErr });
     }
     configJson = JSON.stringify(parsedConfig);
   } else {
@@ -282,11 +285,14 @@ router.put('/:id', requireWorkspaceWrite, (req, res) => {
     WHERE id = ? AND workspace_id = ?
   `).run(cleanName, cleanSlug, configJson, nowSec, req.params.id, wsId);
 
-  // Trigger refresh with new config in background
-  const updatedRow = db.prepare('SELECT * FROM data_sources WHERE id = ?').get(req.params.id);
-  syncDataSource(updatedRow, true).catch(err => {
-    console.warn(`[data-sources] background update sync failed for ${req.params.id}:`, err.message);
-  });
+  // Trigger refresh with new config in background ONLY if config actually changed
+  const configChanged = config !== undefined && configJson !== existing.config;
+  if (configChanged) {
+    const updatedRow = db.prepare('SELECT * FROM data_sources WHERE id = ?').get(req.params.id);
+    syncDataSource(updatedRow, true).catch(err => {
+      console.warn(`[data-sources] background update sync failed for ${req.params.id}:`, err.message);
+    });
+  }
 
   let existingData = null;
   try { existingData = JSON.parse(existing.cached_data || 'null'); } catch (_) {}

--- a/server/routes/media.js
+++ b/server/routes/media.js
@@ -17,14 +17,12 @@
 //  * Single-flight per cache key: 50 panels advancing to the same cold asset => 1 upstream fetch.
 
 const express = require('express');
-const http = require('http');
-const https = require('https');
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const { db } = require('../db/database');
 const config = require('../config');
-const { assertSafeUrl, pinnedLookup, SsrfError, guardedRequest } = require('../lib/ssrf-guard');
+const { SsrfError, guardedRequest } = require('../lib/ssrf-guard');
 
 const router = express.Router();
 
@@ -80,16 +78,17 @@ function resolveWithRedirects(rawUrl, redirectsLeft, validators) {
     maxRedirects: redirectsLeft,
     validators,
     headers: { 'user-agent': 'ScreenTinker-media-proxy', accept: 'image/*,video/*' },
+    idleTimeoutMs: IDLE_TIMEOUT_MS,
     timeoutMs: IDLE_TIMEOUT_MS,
   }).then((r) => {
     if (r.notModified) return { notModified: true };
     return { res: r.res };
   }).catch((err) => {
     if (err instanceof SsrfError) throw err;
-    if (err.message === 'Too many redirects') throw new MediaError('too-many-redirects');
-    if (err.message === 'Invalid redirect location') throw new MediaError('bad-redirect');
-    if (err.statusCode) throw new MediaError('upstream-status-' + err.statusCode);
-    if (/timeout/i.test(err.message)) throw new MediaError('timeout');
+    if (err.code === 'too-many-redirects') throw new MediaError('too-many-redirects');
+    if (err.code === 'bad-redirect') throw new MediaError('bad-redirect');
+    if (err.code === 'upstream-status') throw new MediaError('upstream-status-' + err.statusCode);
+    if (err.code === 'timeout') throw new MediaError('timeout');
     throw new MediaError(err.message || 'fetch-failed');
   });
 }

--- a/server/routes/media.js
+++ b/server/routes/media.js
@@ -24,7 +24,7 @@ const fs = require('fs');
 const path = require('path');
 const { db } = require('../db/database');
 const config = require('../config');
-const { assertSafeUrl, pinnedLookup, SsrfError } = require('../lib/ssrf-guard');
+const { assertSafeUrl, pinnedLookup, SsrfError, guardedRequest } = require('../lib/ssrf-guard');
 
 const router = express.Router();
 
@@ -76,35 +76,21 @@ const ALLOWED_PREFIX = /^(image|video)\//;
 // ---- outbound fetch: vet URL, pin socket to vetted IP, re-vet each redirect hop.
 // Resolves { res } for a 200 stream, or { notModified:true } for a 304 (conditional revalidation).
 function resolveWithRedirects(rawUrl, redirectsLeft, validators) {
-  return new Promise((resolve, reject) => {
-    assertSafeUrl(rawUrl).then(({ url, addresses }) => {
-      const mod = url.protocol === 'https:' ? https : http;
-      const headers = { 'user-agent': 'ScreenTinker-media-proxy', accept: 'image/*,video/*' };
-      if (validators && validators.etag) headers['if-none-match'] = validators.etag;
-      if (validators && validators.lastModified) headers['if-modified-since'] = validators.lastModified;
-      const req = mod.request(url, {
-        method: 'GET',
-        lookup: pinnedLookup(addresses),   // connect to the vetted IP only (defeats DNS rebinding)
-        servername: url.hostname,          // SNI + cert validation stay against the hostname, not the IP
-        headers,
-      }, (res) => {
-        const sc = res.statusCode;
-        if (sc === 304) { res.resume(); return resolve({ notModified: true }); } // still current upstream
-        if (sc >= 300 && sc < 400 && res.headers.location) {
-          res.resume(); // drain the redirect body
-          if (redirectsLeft <= 0) return reject(new MediaError('too-many-redirects'));
-          let next;
-          try { next = new URL(res.headers.location, url).toString(); }
-          catch (e) { return reject(new MediaError('bad-redirect')); }
-          return resolveWithRedirects(next, redirectsLeft - 1, validators).then(resolve, reject);
-        }
-        if (sc !== 200) { res.resume(); return reject(new MediaError('upstream-status-' + sc)); }
-        resolve({ res });
-      });
-      req.setTimeout(IDLE_TIMEOUT_MS, () => req.destroy(new MediaError('timeout')));
-      req.on('error', reject);
-      req.end();
-    }, reject);
+  return guardedRequest(rawUrl, {
+    maxRedirects: redirectsLeft,
+    validators,
+    headers: { 'user-agent': 'ScreenTinker-media-proxy', accept: 'image/*,video/*' },
+    timeoutMs: IDLE_TIMEOUT_MS,
+  }).then((r) => {
+    if (r.notModified) return { notModified: true };
+    return { res: r.res };
+  }).catch((err) => {
+    if (err instanceof SsrfError) throw err;
+    if (err.message === 'Too many redirects') throw new MediaError('too-many-redirects');
+    if (err.message === 'Invalid redirect location') throw new MediaError('bad-redirect');
+    if (err.statusCode) throw new MediaError('upstream-status-' + err.statusCode);
+    if (/timeout/i.test(err.message)) throw new MediaError('timeout');
+    throw new MediaError(err.message || 'fetch-failed');
   });
 }
 

--- a/server/routes/widgets.js
+++ b/server/routes/widgets.js
@@ -8,8 +8,8 @@ const { devicesPlayingWidget } = require('../lib/devices-playing');
 const slideRender = require('../lib/slide-render');
 const appConfig = require('../config');
 const { PLATFORM_ROLES, ELEVATED_ROLES } = require('../middleware/auth');
-// Phase 2.2d: workspace-aware access. Same pattern as devices.js / content.js.
 const { accessContext } = require('../lib/tenancy');
+const { isRealTimezone } = require('../lib/device-timezone');
 
 // For preview only: inline /api/content/:id/file and /thumbnail URLs as data URIs,
 // scoped to the caller's current workspace. Lets the srcdoc preview iframe show
@@ -67,15 +67,6 @@ function escapeHtml(str) {
  * stored with a bad value (a blank clock is worse than a wrong one); new values are rejected at
  * save time by validateTimezone below, so nobody silently gets UTC again.
  */
-function isRealTimezone(tz) {
-  if (typeof tz !== 'string' || !tz) return false;
-  // Reject anything that could break out of the single-quoted string it is inlined into, before
-  // handing it to Intl — this value is interpolated into generated widget JS.
-  if (/['"\\\r\n]/.test(tz)) return false;
-  try { new Intl.DateTimeFormat(undefined, { timeZone: tz }); return true; }
-  catch { return false; }
-}
-
 function safeTimezone(tz) {
   if (!tz) return 'UTC';
   return isRealTimezone(tz) ? tz : 'UTC';

--- a/server/server.js
+++ b/server/server.js
@@ -1304,7 +1304,6 @@ app.use('/api/widgets/preview-session', rateLimit(60000, 30)); // preview sessio
 // `/test` triggers an outbound fetch of an arbitrary calendar feed; cap it so a single
 // workspace cannot fan out unbounded requests to third-party URLs.
 app.use('/api/data-sources/test', rateLimit(60000, 10));
-app.use('/api/data-sources/:id/refresh', rateLimit(60000, 10));
 app.get('/api/kiosk/:id/render', (req, res, next) => { req._skipAuth = true; next(); });
 
 for (const r of PUBLIC_ROUTERS) {

--- a/server/server.js
+++ b/server/server.js
@@ -1304,6 +1304,7 @@ app.use('/api/widgets/preview-session', rateLimit(60000, 30)); // preview sessio
 // `/test` triggers an outbound fetch of an arbitrary calendar feed; cap it so a single
 // workspace cannot fan out unbounded requests to third-party URLs.
 app.use('/api/data-sources/test', rateLimit(60000, 10));
+app.use('/api/data-sources/:id/refresh', rateLimit(60000, 10));
 app.get('/api/kiosk/:id/render', (req, res, next) => { req._skipAuth = true; next(); });
 
 for (const r of PUBLIC_ROUTERS) {

--- a/server/test/data-sources-ical.test.js
+++ b/server/test/data-sources-ical.test.js
@@ -170,7 +170,7 @@ test('renderSlideHtml integrates data source variables into rendered slide HTML'
 
 test('iCal resolver rejects SSRF targets (loopback / private ranges)', async () => {
   const now = new Date('2026-09-04T09:30:00Z');
-  // Loopback and cloud-metadata endpoints must never be fetched.
+  const { SsrfError } = require('../lib/ssrf-guard');
   for (const bad of [
     'http://127.0.0.1:8080/feed.ics',
     'http://127.0.0.1/private.ics',
@@ -181,17 +181,18 @@ test('iCal resolver rejects SSRF targets (loopback / private ranges)', async () 
   ]) {
     await assert.rejects(
       () => resolveIcalData({ url: bad, timezone: 'UTC' }, now),
-      /blocked-ip|SSRF|loopback|private/i,
+      (err) => err instanceof SsrfError && err.reason.startsWith('blocked-ip'),
       `expected SSRF guard to reject ${bad}`,
     );
   }
 });
 
 test('iCal resolver rejects non-HTTP(S) URL schemes', async () => {
+  const { SsrfError } = require('../lib/ssrf-guard');
   const now = new Date('2026-09-04T09:30:00Z');
   await assert.rejects(
     () => resolveIcalData({ url: 'file:///etc/passwd', timezone: 'UTC' }, now),
-    /disallowed-scheme|protocol|SSRF/i,
+    (err) => err instanceof SsrfError && err.reason === 'bad-scheme',
     'file:// scheme must be rejected',
   );
 });
@@ -530,3 +531,115 @@ test('THE BUG: the assembled field is re-capped after interpolation, not only ea
   const emitted = (html.match(/§/g) || []).length;
   assert.ok(emitted <= 2000, `field expanded to ${emitted} chars; the renderer promises MAX_FIELD_CHARS`);
 });
+
+test('interpolateDataSources handles object values safely via JSON.stringify without [object Object]', () => {
+  const tpl = 'Data: {{ds:sensor.metrics}}';
+  const res = interpolateDataSources(tpl, (slug, key) => {
+    if (slug === 'sensor' && key === 'metrics') return { temp: 21.5, humidity: 45 };
+    return null;
+  });
+  assert.equal(res, 'Data: {"temp":21.5,"humidity":45}');
+  assert.ok(!res.includes('[object Object]'));
+});
+
+test('all-day events in America/New_York timezone do not drop events_today_count or emit Free until midnight', async () => {
+  const ALL_DAY_ICS = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//ScreenTinker Test//EN
+BEGIN:VEVENT
+UID:evt-allday-recurr
+SUMMARY:All-Day Planning
+DTSTART;VALUE=DATE:20260907
+DTEND;VALUE=DATE:20260908
+RRULE:FREQ=DAILY
+END:VEVENT
+END:VCALENDAR`;
+
+  // 2026-09-07 at 14:00 EDT (18:00 UTC)
+  const now = new Date('2026-09-07T18:00:00Z');
+  const data = await resolveIcalData({ raw_data: ALL_DAY_ICS, timezone: 'America/New_York', locale: 'en' }, now);
+
+  assert.equal(data.events_today_count, 1, 'today occurrence must be counted in America/New_York');
+  assert.doesNotMatch(data.status_detail, /Free until \d{2}:\d{2}/i, 'all-day event must not produce "Free until XX:XX"');
+  assert.equal(data.status_detail, 'Free all day');
+});
+
+test('guardedRequest enforces SSRF guards, userinfo rejection, and size caps', async () => {
+  const { guardedRequest, SsrfError } = require('../lib/ssrf-guard');
+
+  // Loopback target must throw SsrfError
+  await assert.rejects(
+    () => guardedRequest('http://127.0.0.1:9999/feed.ics'),
+    (err) => err instanceof SsrfError && err.reason.startsWith('blocked-ip'),
+  );
+
+  // URL with credentials must throw SsrfError with reason 'userinfo'
+  await assert.rejects(
+    () => guardedRequest('https://user:pass@example.com/calendar.ics'),
+    (err) => err instanceof SsrfError && err.reason === 'userinfo',
+  );
+
+  // Bad scheme must throw SsrfError with reason 'bad-scheme'
+  await assert.rejects(
+    () => guardedRequest('ftp://example.com/calendar.ics'),
+    (err) => err instanceof SsrfError && err.reason === 'bad-scheme',
+  );
+});
+
+test('data-sources routes reject basic-auth URLs, invalid timezones, and missing workspaceId', async () => {
+  const express = require('express');
+  const dataSourcesRouter = require('../routes/data-sources');
+  const app = express();
+  app.use(express.json());
+  // Mock auth/tenancy
+  app.use((req, res, next) => {
+    req.user = { id: 'u1', role: 'admin' };
+    req.isPlatformAdmin = true;
+    req.workspaceRole = 'workspace_admin';
+    if (!req.headers['x-no-ws']) req.workspaceId = 'ws-test-1';
+    next();
+  });
+  app.use('/api/data-sources', dataSourcesRouter);
+
+  const server = await new Promise((r) => {
+    const s = app.listen(0, '127.0.0.1', () => r(s));
+  });
+  const port = server.address().port;
+  const baseUrl = `http://127.0.0.1:${port}/api/data-sources`;
+
+  try {
+    // 1. Rejects basic-auth URL in POST /test
+    const testRes = await fetch(`${baseUrl}/test`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'ical', config: { url: 'https://user:pass@example.com/cal.ics' } }),
+    });
+    assert.equal(testRes.status, 400);
+    const testJson = await testRes.json();
+    assert.match(testJson.error, /basic-auth|credentials/i);
+
+    // 2. Rejects invalid timezone in POST /test
+    const tzRes = await fetch(`${baseUrl}/test`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: 'ical', config: { timezone: 'Invalid/Non_Existent_TZ', raw_ics: 'BEGIN:VCALENDAR\nEND:VCALENDAR' } }),
+    });
+    assert.equal(tzRes.status, 400);
+    const tzJson = await tzRes.json();
+    assert.match(tzJson.error, /Invalid IANA timezone/i);
+
+    // 3. Rejects missing workspaceId in POST /
+    const noWsRes = await fetch(`${baseUrl}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-no-ws': '1' },
+      body: JSON.stringify({ name: 'Cal', type: 'ical', config: { url: 'https://example.com/cal.ics' } }),
+    });
+    assert.equal(noWsRes.status, 400);
+    const noWsJson = await noWsRes.json();
+    assert.match(noWsJson.error, /Workspace ID is required/i);
+  } finally {
+    await new Promise((r) => server.close(r));
+  }
+});
+
+

--- a/server/test/data-sources-ical.test.js
+++ b/server/test/data-sources-ical.test.js
@@ -642,4 +642,79 @@ test('data-sources routes reject basic-auth URLs, invalid timezones, and missing
   }
 });
 
+test('all-day events evaluated across multiple timezones (Europe/Berlin, America/Los_Angeles, Asia/Tokyo, UTC)', async () => {
+  const ALL_DAY_ICS = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//ScreenTinker Test//EN
+BEGIN:VEVENT
+UID:evt-allday-tz-matrix
+SUMMARY:Team Offsite
+DTSTART;VALUE=DATE:20260907
+DTEND;VALUE=DATE:20260908
+RRULE:FREQ=DAILY;COUNT=3
+END:VEVENT
+END:VCALENDAR`;
+
+  const timezones = ['UTC', 'Europe/Berlin', 'America/Los_Angeles', 'Asia/Tokyo', 'America/New_York'];
+  for (const tz of timezones) {
+    // 2026-09-07 at midday in target timezone
+    const nowTarget = new Date('2026-09-07T12:00:00Z');
+    const data = await resolveIcalData({ raw_data: ALL_DAY_ICS, timezone: tz, locale: 'en' }, nowTarget);
+
+    assert.equal(data.events_today_count, 1, `events_today_count must be 1 in ${tz}`);
+    assert.equal(data.is_busy, false, `all-day event should not make room busy in ${tz}`);
+    assert.equal(data.status_detail, 'Free all day', `status_detail in ${tz}`);
+    assert.match(data.event_0_date, /Today/i, `event_0_date should be Today in ${tz}`);
+  }
+});
+
+test('parseSafeUrl trims whitespace, normalizes webcal, and rejects blocked targets', () => {
+  const { parseSafeUrl } = require('../lib/ssrf-guard');
+
+  const p1 = parseSafeUrl('  webcal://example.com/feed.ics  ');
+  assert.equal(p1.url.protocol, 'https:');
+  assert.equal(p1.url.hostname, 'example.com');
+  assert.equal(p1.url.pathname, '/feed.ics');
+
+  const p2 = parseSafeUrl('https://example.org/calendar.ics');
+  assert.equal(p2.url.hostname, 'example.org');
+
+  assert.throws(() => parseSafeUrl('https://user:pass@example.com/cal.ics'), (err) => err.reason === 'userinfo');
+  assert.throws(() => parseSafeUrl('http://127.0.0.1/cal.ics'), (err) => err.reason.startsWith('blocked-ip'));
+  assert.throws(() => parseSafeUrl('ftp://example.com/cal.ics'), (err) => err.reason === 'bad-scheme');
+});
+
+test('lookahead_days boundary: lookahead_days=1 lists only today and tomorrow', async () => {
+  const THREE_DAY_ICS = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//ScreenTinker Test//EN
+BEGIN:VEVENT
+UID:evt-day0
+SUMMARY:Today Event
+DTSTART:20260907T100000Z
+DTEND:20260907T110000Z
+END:VEVENT
+BEGIN:VEVENT
+UID:evt-day1
+SUMMARY:Tomorrow Event
+DTSTART:20260908T100000Z
+DTEND:20260908T110000Z
+END:VEVENT
+BEGIN:VEVENT
+UID:evt-day2
+SUMMARY:Day After Tomorrow Event
+DTSTART:20260909T100000Z
+DTEND:20260909T110000Z
+END:VEVENT
+END:VCALENDAR`;
+
+  const now = new Date('2026-09-07T08:00:00Z');
+  const data = await resolveIcalData({ raw_data: THREE_DAY_ICS, lookahead_days: 1, timezone: 'UTC' }, now);
+
+  assert.equal(data.event_count, 2, 'lookahead_days=1 should only include today (Sep 7) and tomorrow (Sep 8)');
+  assert.equal(data.event_0_title, 'Today Event');
+  assert.equal(data.event_1_title, 'Tomorrow Event');
+});
+
+
 


### PR DESCRIPTION
Addresses all follow-up items from #332 tracked in #338.

### Summary of Changes

1. **SSRF Guard Unification (Maintainer Top Priority):**
   - Hoisted unified `guardedRequest(url, options)` into [`server/lib/ssrf-guard.js`](file:///Users/rene/Documents/github/screentinker/server/lib/ssrf-guard.js).
   - Refactored [`server/routes/media.js`](file:///Users/rene/Documents/github/screentinker/server/routes/media.js) and [`server/lib/data-sources/ical-resolver.js`](file:///Users/rene/Documents/github/screentinker/server/lib/data-sources/ical-resolver.js) to consume `guardedRequest`.

2. **All-Day Event Handling on Hosts West of UTC (Maintainer Top Priority):**
   - Replaced server-local Date getters with UTC calendar getters (`getUTCFullYear()`, `getUTCMonth()`, `getUTCDate()`) for all-day key/date formatting in [`server/lib/data-sources/ical-resolver.js`](file:///Users/rene/Documents/github/screentinker/server/lib/data-sources/ical-resolver.js).
   - Widened window bounds calculation back 24h to avoid UTC offset boundary clipping.
   - Fixed `statusDetail` to check `!nextEvent.isAllDay` before formatting time (preventing "Free until 02:00 AM" on all-day events).

3. **Object Values in Data Source Interpolation:**
   - In [`server/lib/slide-render.js`](file:///Users/rene/Documents/github/screentinker/server/lib/slide-render.js) and [`frontend/js/views/slides.js`](file:///Users/rene/Documents/github/screentinker/frontend/js/views/slides.js), safely stringify objects via `JSON.stringify` instead of falling back to `[object Object]`.

4. **Input Validation:**
   - In [`server/routes/data-sources.js`](file:///Users/rene/Documents/github/screentinker/server/routes/data-sources.js), added `validateDataSourceConfig` on `POST /`, `PUT /:id`, and `POST /test` to reject basic-auth calendar URLs (`https://user:pass@host/...`) and invalid IANA timezones with 400 Bad Request.
   - Enforced `req.workspaceId` check on `POST /`.

5. **Rate Limiting & Dead Code Cleanup:**
   - Mounted `rateLimit(60000, 10)` for `POST /api/data-sources/:id/refresh` in [`server/server.js`](file:///Users/rene/Documents/github/screentinker/server/server.js).
   - Removed unused `getWorkspaceDataMap` and `global.__deviceIo` fallback in [`server/lib/data-sources/service.js`](file:///Users/rene/Documents/github/screentinker/server/lib/data-sources/service.js).

6. **Tests:**
   - Added comprehensive tests in [`server/test/data-sources-ical.test.js`](file:///Users/rene/Documents/github/screentinker/server/test/data-sources-ical.test.js) for `guardedRequest`, America/New_York all-day events, object interpolation, and route validations.
   - Verified that all 3,198 tests pass cleanly.

Fixes #338