### PR TITLE
fix(android): restore transitions, fit the wipe off the rotated stage (#344)

### DIFF
--- a/android/app/src/main/java/com/remotedisplay/player/MainActivity.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/MainActivity.kt
@@ -327,12 +327,18 @@ class MainActivity : AppCompatActivity() {
         playlistController.setSlideAudioPlayer(slideAudioPlayer)
         playlistController.setServerBase { config.serverUrl }
 
-        // feat/transition-engine: full-screen GLES2 overlay that plays image/video wipes. Inserted just
-        // BELOW the status overlay (so the connecting/idle screen still covers it) and ABOVE the image/
-        // video layers, so a wipe composites over the outgoing content. Hidden except during a wipe.
+        // feat/transition-engine: full-screen GLES2 overlay that plays image/video wipes.
+        //
+        // #344: attach it to the WINDOW CONTENT ROOT (android.R.id.content), NOT the rotated stage,
+        // just below pipLayout — the same move #109 made for the PiP. A SurfaceView is not guaranteed
+        // to inherit a rotated ancestor's transform on every ROM, so keeping the overlay on the raw,
+        // unrotated screen and baking the stage's rotation into the fitted bitmaps (see
+        // fitTransitionBitmapRotated + setTransitionStage) makes the wipe match the mounted content
+        // regardless of the composer. It was previously on rootView, which is what made the wipe draw
+        // in the panel's native orientation on ROMs that do not rotate the surface.
         val transitionView = TransitionGLView(this)
-        (rootView as FrameLayout).let { root ->
-            val idx = root.indexOfChild(statusOverlay).coerceAtLeast(0)
+        (captureRoot as ViewGroup).let { root ->
+            val idx = root.indexOfChild(pipLayout).coerceAtLeast(0)
             root.addView(transitionView, idx,
                 FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT))
         }
@@ -351,6 +357,18 @@ class MainActivity : AppCompatActivity() {
             },
             transitionView = transitionView
         )
+
+        // #344: applyOrientation() may have already run before mediaPlayer existed (its isInitialized
+        // guard skipped the geometry push then), so seed the transition-stage geometry now from
+        // whatever orientation is currently applied. Later orientation changes push it themselves.
+        if (appliedStageW > 0f && appliedStageH > 0f) {
+            val (rot0, swap0) = orientationRotSwap(currentOrientation)
+            val screenW0 = appliedStageW.toInt(); val screenH0 = appliedStageH.toInt()
+            mediaPlayer.setTransitionStage(
+                if (swap0) screenH0 else screenW0, if (swap0) screenW0 else screenH0,
+                screenW0, screenH0, rot0
+            )
+        }
 
         // Video-wall controller. The emit lambdas read wsService lazily (it's bound after
         // onCreate), and they no-op until the socket is connected (guarded in the service).
@@ -524,6 +542,15 @@ class MainActivity : AppCompatActivity() {
         applyOrientation(currentOrientation ?: "landscape")
     }
 
+    // #344: (rotation, transpose?) for an orientation string. One source, shared by applyOrientation
+    // and the initial transition-stage push so the two can never disagree on what "portrait" means.
+    private fun orientationRotSwap(o: String?): Pair<Float, Boolean> = when (o) {
+        "portrait" -> 90f to true
+        "portrait-flipped" -> 270f to true
+        "landscape-flipped" -> 180f to false
+        else -> 0f to false   // landscape
+    }
+
     private fun applyOrientation(orientation: String) {
         val (w, h) = windowSize()
         // The guard compares the measured SIZE as well as the orientation. Comparing the string
@@ -532,12 +559,7 @@ class MainActivity : AppCompatActivity() {
         currentOrientation = orientation
         appliedStageW = w
         appliedStageH = h
-        val (rot, swap) = when (orientation) {
-            "portrait" -> 90f to true
-            "portrait-flipped" -> 270f to true
-            "landscape-flipped" -> 180f to false
-            else -> 0f to false   // landscape
-        }
+        val (rot, swap) = orientationRotSwap(orientation)
         val lp = rootView.layoutParams
         lp.width = (if (swap) h else w).toInt()
         lp.height = (if (swap) w else h).toInt()
@@ -547,6 +569,10 @@ class MainActivity : AppCompatActivity() {
         rootView.rotation = rot
         rootView.requestLayout()
         mirrorTransformToPip()
+        // #344: tell the wipe compositor the box it must fit into. The overlay lives on the unrotated
+        // content root, so it needs the stage box (lp.width/height), the screen box (w/h) and the
+        // rotation to bake in — NOT its own measured size, which is 0 while it is GONE between wipes.
+        if (::mediaPlayer.isInitialized) mediaPlayer.setTransitionStage(lp.width, lp.height, w.toInt(), h.toInt(), rot)
         Log.i("MainActivity", "Applied orientation: $orientation (rotation=$rot, swap=$swap)")
     }
 

--- a/android/app/src/main/java/com/remotedisplay/player/player/MediaPlayerManager.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/player/MediaPlayerManager.kt
@@ -299,6 +299,29 @@ class MediaPlayerManager(
     // loop sync (they own their own frame timing). ----
     private fun transitionsActive(): Boolean = transitionView != null && !wallMute && !videoLooping
 
+    /*
+     * #344 — the stage/screen geometry a wipe is fitted to, pushed from MainActivity.applyOrientation.
+     *
+     * The overlay draws onto an UNROTATED, screen-sized surface, so the fit must be done in stage
+     * space and rotated into screen space here (see fitTransitionBitmapRotated). We take these numbers
+     * from the orientation code rather than the overlay's own measured size, because the overlay is
+     * GONE until play() and a GONE view measures 0 — reading it was what hard-cut every wipe (#344).
+     * Zero until the first orientation is applied, so a wipe hard-cuts rather than fitting to nothing.
+     */
+    @Volatile private var stageW = 0
+    @Volatile private var stageH = 0
+    @Volatile private var screenW = 0
+    @Volatile private var screenH = 0
+    @Volatile private var stageRotation = 0f
+    private var geomWarned = false
+
+    fun setTransitionStage(stageW: Int, stageH: Int, screenW: Int, screenH: Int, rotationDeg: Float) {
+        this.stageW = stageW; this.stageH = stageH
+        this.screenW = screenW; this.screenH = screenH
+        this.stageRotation = rotationDeg
+        geomWarned = false   // a real geometry change resets the one-shot diagnostic
+    }
+
     // The frame on screen now, as a bitmap, for the wipe's `from`. Image -> the ImageView bitmap; video
     // -> the ExoPlayer TextureView's current frame. Null (youtube/widget/none/unavailable) -> hard cut.
     private fun captureCurrentFrame(): Bitmap? = try {
@@ -327,23 +350,36 @@ class MediaPlayerManager(
         val view = transitionView
         if (view == null || spec == null || from == null || !transitionsActive()) return false
         val picked = pickEffect(spec) ?: return false
-        // #326: THE STAGE'S OWN BOX, NOT THE DEVICE'S.
-        //
-        // MainActivity rotates rootView for a portrait screen and TRANSPOSES its layout params
-        // (lp.width = h, lp.height = w) before setting rotation. A View's rotation does not change
-        // its layout bounds, so on a portrait panel the stage is laid out 1080x1920 while
-        // displayMetrics still reports 1920x1080 — each the other's transpose. Fitting both bitmaps
-        // to displayMetrics therefore played every wipe at the wrong aspect and snapped back when
-        // the plain mount took over, which is the same fault #315 fixed in the web player.
-        //
-        // transitionView is added to that same rootView with MATCH_PARENT in both axes, so its own
-        // measured size IS the stage box. Zero means it has not been laid out yet, and the existing
-        // guard below turns that into a hard cut rather than a wipe fitted to nothing.
-        val w = view.width; val h = view.height
-        if (w <= 0 || h <= 0) return false
+        /*
+         * #344 — fit to the KNOWN stage/screen geometry, NOT the overlay's measured size.
+         *
+         * #326 changed this to read view.width/height, meaning to use "the stage's own box". But the
+         * overlay is GONE until play() and a GONE view measures 0, so the old `w<=0` guard fired on
+         * EVERY wipe and hard-cut before play() was ever reached — transitions silently stopped
+         * working in all orientations. And even once shown, its size went stale after a rotation
+         * because a GONE view is skipped by later layout passes. So we take the geometry from the
+         * orientation code (setTransitionStage) instead, and fit in stage space + rotate into the
+         * screen box, which the overlay (on the unrotated content root) then draws 1:1.
+         */
+        val sw = stageW; val sh = stageH; val cw = screenW; val ch = screenH; val rot = stageRotation
+        if (sw <= 0 || sh <= 0 || cw <= 0 || ch <= 0) return false   // geometry not applied yet -> hard cut
+        // The invariant #344 asked for: the rotated stage box MUST equal the screen box we draw onto.
+        // If it does not, we would fit to the wrong thing (the exact silent fault) -> hard-cut and log once.
+        if (!TransitionGeometry.rotatedStageMatchesScreen(sw, sh, cw, ch, rot.toInt())) {
+            if (!geomWarned) { geomWarned = true; Log.w("MediaPlayerManager", "wipe geometry mismatch: stage ${sw}x${sh} rot ${rot} vs screen ${cw}x${ch} — hard-cutting") }
+            return false
+        }
+        // Diagnostic cross-check against the overlay's own surface once it is laid out. Never blocks
+        // the wipe (the surface is 0 while GONE); just surfaces drift this whole class of bug hides.
+        val vw = view.width; val vh = view.height
+        if (vw > 0 && vh > 0 && (vw != cw || vh != ch) && !geomWarned) {
+            geomWarned = true; Log.w("MediaPlayerManager", "wipe surface ${vw}x${vh} != screen box ${cw}x${ch}")
+        }
         val fromFit: Bitmap; val toFit: Bitmap
-        try { fromFit = fitTransitionBitmap(from, w, h); toFit = fitTransitionBitmap(toBitmap, w, h) }
-        catch (e: Throwable) { Log.w("MediaPlayerManager", "wipe fit failed: ${e.message}"); return false }
+        try {
+            fromFit = fitTransitionBitmapRotated(from, sw, sh, cw, ch, rot)
+            toFit = fitTransitionBitmapRotated(toBitmap, sw, sh, cw, ch, rot)
+        } catch (e: Throwable) { Log.w("MediaPlayerManager", "wipe fit failed: ${e.message}"); return false }
         view.play(fromFit, toFit, picked.first, picked.second, spec.durationMs) { swap() }
         return true
     }

--- a/android/app/src/main/java/com/remotedisplay/player/player/TransitionCompositor.kt
+++ b/android/app/src/main/java/com/remotedisplay/player/player/TransitionCompositor.kt
@@ -64,22 +64,72 @@ object TransitionGlsl {
     }
 }
 
+/*
+ * #344 — the wipe's geometry, pure and testable.
+ *
+ * The overlay draws its textures 1:1 across an UNROTATED, screen-sized GL surface (see the #344 note
+ * in MainActivity: it lives on the window content root, not the rotated stage, because a SurfaceView
+ * is not guaranteed to inherit an ancestor's rotation on every ROM). So the rotation the stage gets
+ * for a portrait screen has to be baked into the bitmap instead of relied upon from the compositor.
+ *
+ * This object holds only the box arithmetic — no Android graphics — so it can be unit-tested on the
+ * JVM (which the Android graphics path cannot). See TransitionGeometryTest.
+ */
+object TransitionGeometry {
+    /** The box content is laid out in: the stage is transposed for a portrait (swap) screen. */
+    fun stageBox(screenW: Int, screenH: Int, swap: Boolean): Pair<Int, Int> =
+        if (swap) screenH to screenW else screenW to screenH
+
+    /** true for the orientations MainActivity transposes the stage for (90 / 270). */
+    fun swapForRotation(rotDeg: Int): Boolean = ((rotDeg % 360) + 360) % 360 == 90 || ((rotDeg % 360) + 360) % 360 == 270
+
+    /**
+     * The invariant the reporter asked for: the box the bitmaps were fitted to (once rotated) must
+     * equal the surface they are drawn on. Rotating the stage box by 90/270 must give the screen box;
+     * 0/180 leaves it. A mismatch means we fitted to the wrong thing and MUST hard-cut, not wipe.
+     */
+    fun rotatedStageMatchesScreen(stageW: Int, stageH: Int, screenW: Int, screenH: Int, rotDeg: Int): Boolean {
+        if (stageW <= 0 || stageH <= 0 || screenW <= 0 || screenH <= 0) return false
+        val (rw, rh) = if (swapForRotation(rotDeg)) stageH to stageW else stageW to stageH
+        return rw == screenW && rh == screenH
+    }
+}
+
 // Fit a source bitmap into a w×h frame with object-fit:contain letterboxing (matches the static
 // ImageView/PlayerView framing), AND flip it vertically — GLES2 has no UNPACK_FLIP_Y_WEBGL, so the flip
 // here replicates exactly what the web renderer's upload() does, keeping the shader uv convention (and
 // therefore the transition geometry) identical across platforms. Returns an ARGB_8888 bitmap.
-fun fitTransitionBitmap(src: Bitmap, w: Int, h: Int): Bitmap {
-    val out = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+//
+// Landscape (no rotation) keeps calling this directly; it is unchanged.
+fun fitTransitionBitmap(src: Bitmap, w: Int, h: Int): Bitmap =
+    fitTransitionBitmapRotated(src, w, h, w, h, 0f)
+
+/*
+ * #344 — fit into the STAGE box, then rotate the result into the SCREEN box, in one Matrix, onto a
+ * screen-sized bitmap. The overlay surface is the unrotated screen, so baking the stage's rotation
+ * into the texture here is what makes the wipe match the mounted (rotated) content on every ROM,
+ * whether or not the composer would have rotated the surface for us.
+ *
+ * Order (postX appends): contain-fit in stage space -> recentre on origin -> rotate -> recentre in
+ * the screen box -> vertical GL flip on the final texture. For rot=0 with stage==screen this reduces
+ * to exactly the old contain+flip, so landscape is byte-identical.
+ */
+fun fitTransitionBitmapRotated(src: Bitmap, stageW: Int, stageH: Int, screenW: Int, screenH: Int, rotDeg: Float): Bitmap {
+    val out = Bitmap.createBitmap(screenW, screenH, Bitmap.Config.ARGB_8888)
     val c = Canvas(out)
     c.drawColor(android.graphics.Color.BLACK)
     val iw = src.width.toFloat(); val ih = src.height.toFloat()
-    if (iw > 0f && ih > 0f) {
-        val s = minOf(w / iw, h / ih)         // contain
+    if (iw > 0f && ih > 0f && stageW > 0 && stageH > 0) {
+        val s = minOf(stageW / iw, stageH / ih)   // contain, in stage space
         val dw = iw * s; val dh = ih * s
         val m = Matrix()
         m.postScale(s, s)
-        m.postTranslate((w - dw) / 2f, (h - dh) / 2f)
-        m.postScale(1f, -1f, w / 2f, h / 2f)  // vertical flip == UNPACK_FLIP_Y_WEBGL
+        m.postTranslate((stageW - dw) / 2f, (stageH - dh) / 2f)   // placed in the stage box
+        // rotate the stage box about its centre and drop it, centred, into the screen box
+        m.postTranslate(-stageW / 2f, -stageH / 2f)
+        m.postRotate(rotDeg)
+        m.postTranslate(screenW / 2f, screenH / 2f)
+        m.postScale(1f, -1f, screenW / 2f, screenH / 2f)          // vertical flip == UNPACK_FLIP_Y_WEBGL
         c.drawBitmap(src, m, Paint(Paint.FILTER_BITMAP_FLAG))
     }
     return out

--- a/android/app/src/test/java/com/remotedisplay/player/player/TransitionGeometryTest.kt
+++ b/android/app/src/test/java/com/remotedisplay/player/player/TransitionGeometryTest.kt
@@ -1,0 +1,59 @@
+package com.remotedisplay.player.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #344 — the wipe's box arithmetic.
+ *
+ * This is the half of the transition that has no test today and where two silent regressions have
+ * now lived: #326 fitted the wipe to the wrong box, and its follow-up fitted to a GONE overlay's
+ * zero size. The Android graphics path (Canvas/Matrix) cannot run on the JVM, but the box decision
+ * can, so this pins the contract the compositor and MainActivity must agree on:
+ *
+ *   - the stage is transposed for a portrait (swap) screen, and
+ *   - rotating that stage box by the applied rotation must land back on the screen box we draw onto.
+ *
+ * A wipe that cannot satisfy the second point is the exact fault #344 asks us to hard-cut on instead
+ * of playing at the wrong aspect.
+ */
+class TransitionGeometryTest {
+
+    @Test fun `stage box is the screen box in landscape and its transpose in portrait`() {
+        assertEquals(1024 to 600, TransitionGeometry.stageBox(1024, 600, swap = false))
+        assertEquals(600 to 1024, TransitionGeometry.stageBox(1024, 600, swap = true))
+    }
+
+    @Test fun `only 90 and 270 transpose the stage`() {
+        assertFalse(TransitionGeometry.swapForRotation(0))
+        assertTrue(TransitionGeometry.swapForRotation(90))
+        assertFalse(TransitionGeometry.swapForRotation(180))
+        assertTrue(TransitionGeometry.swapForRotation(270))
+        // normalised, so 360 and negatives behave
+        assertFalse(TransitionGeometry.swapForRotation(360))
+        assertTrue(TransitionGeometry.swapForRotation(-90))   // == 270
+    }
+
+    @Test fun `the rotated stage box matches the screen box for every real orientation`() {
+        val screenW = 1024; val screenH = 600
+        // landscape: no transpose, no rotation
+        assertTrue(TransitionGeometry.rotatedStageMatchesScreen(1024, 600, screenW, screenH, 0))
+        // landscape-flipped: no transpose, 180
+        assertTrue(TransitionGeometry.rotatedStageMatchesScreen(1024, 600, screenW, screenH, 180))
+        // portrait: stage transposed to 600x1024, rotated 90 lands back on 1024x600
+        assertTrue(TransitionGeometry.rotatedStageMatchesScreen(600, 1024, screenW, screenH, 90))
+        // portrait-flipped: 270
+        assertTrue(TransitionGeometry.rotatedStageMatchesScreen(600, 1024, screenW, screenH, 270))
+    }
+
+    @Test fun `fitting to the wrong box is rejected - the shape of both regressions`() {
+        // #326: portrait screen, but the stage box was NOT transposed (device metrics). Rotating a
+        // 1024x600 box by 90 gives 600x1024, which is not the 1024x600 screen -> reject, hard-cut.
+        assertFalse(TransitionGeometry.rotatedStageMatchesScreen(1024, 600, 1024, 600, 90))
+        // the follow-up: a zero box (the GONE overlay's measured size) never matches.
+        assertFalse(TransitionGeometry.rotatedStageMatchesScreen(0, 0, 1024, 600, 0))
+        assertFalse(TransitionGeometry.rotatedStageMatchesScreen(600, 1024, 0, 0, 90))
+    }
+}


### PR DESCRIPTION
Fixes #344, a regression from #326 (`7b0b536`) reported today with hardware captures by @visimpres-glitch.

## The regression
#326 meant to fit a wipe to the stage's own box, but read that box from the overlay's measured size. `TransitionGLView` is `visibility = GONE` until `play()`, and a GONE view measures 0, so the `w <= 0` guard fired on every wipe and `play()` was never reached. Result: **Android transitions silently became a hard cut in all orientations** since `7b0b536` (shipped in 2.0.7 / 2.0.8). It is plain View semantics, not device-specific. The reporter also documented two portrait faults: the size went stale after a rotation, and a SurfaceView does not inherit a rotated ancestor's transform on every ROM, so even the correct stage box drew the wipe in the panel's native orientation.

## The fix (the reporter's approach)
- The overlay is attached to the window content root (`android.R.id.content`), not the rotated stage, the same move #109 made for the PiP. It always draws on the raw, unrotated screen, so it does not depend on the composer rotating a SurfaceView.
- `runWipe` fits in stage space and rotates into screen space in one Matrix (`fitTransitionBitmapRotated`), baking the rotation into the texture. Landscape (rot=0, stage == screen) reduces to exactly the old contain+flip, so it is byte-identical; only portrait changes.
- The geometry comes from `MainActivity.applyOrientation` via `setTransitionStage`, not the overlay's measured size, so a GONE overlay can no longer zero it and a rotation can no longer leave it stale.

## Safeguards the reporter asked for
- A hard-cut invariant: the rotated stage box must equal the screen box we draw onto (`TransitionGeometry.rotatedStageMatchesScreen`); a mismatch logs once and hard-cuts rather than playing at the wrong aspect. Plus a diagnostic cross-check against the overlay's own surface size.
- A unit test (`TransitionGeometryTest`) over the pure box arithmetic, the half with no coverage where both regressions lived.

## Testing
Android unit tests 275/275 (4 new). Compiles clean. Landscape is unchanged by construction (delegates through the rot=0 path). The portrait geometry is ROM-independent by design (rotation baked in, overlay unrotated) and unit-tested.

Not yet confirmed on a real portrait panel end to end. The reporter has the hardware that exhibits the SurfaceView-rotation fault and offered to test; a look on their panel (transitions play, and the picture during a wipe matches the mounted content) is the final check. See #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jd3iTv4aRSRZ6gmY8kvv5r
